### PR TITLE
Add switch to compute measures based on file path

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -107,8 +107,8 @@ class Command(BaseCommand):
         if not options['month'] and not options['end_date'] \
            and not options['month_from_prescribing_filename']:
             err = 'You must supply either --month or --end_date '
-            err += 'in the format YYYY-MM-DD, supply a path to a file which '
-            err += 'includes the timetamp in the path. You can also '
+            err += 'in the format YYYY-MM-DD, or supply a path to a file which '
+            err += 'includes the timestamp in the path. You can also '
             err += 'optionally supply a start date.'
             print err
             sys.exit()

--- a/openprescribing/media/js/test/test_utils.js
+++ b/openprescribing/media/js/test/test_utils.js
@@ -40,7 +40,7 @@ describe('Utils', function () {
             };
             var urls = utils.constructQueryURLs(options);
             expect(urls.numeratorUrl).to.equal('/api/1.0/spending_by_practice/?format=json&code=1234,5678&org=Y020405,J04052');
-            expect(urls.denominatorUrl).to.equal('/api/1.0/org_details/?format=json&org_type=practice&keys=row_id,row_name,date,astro_pu_cost&org=Y020405,J04052');
+            expect(urls.denominatorUrl).to.equal('/api/1.0/org_details/?format=json&org_type=practice&keys=astro_pu_cost&org=Y020405,J04052');
         });
         it('should correctly construct urls for list size', function () {
             var options = {
@@ -53,7 +53,7 @@ describe('Utils', function () {
             };
             var urls = utils.constructQueryURLs(options);
             expect(urls.numeratorUrl).to.equal('/api/1.0/spending_by_ccg/?format=json&code=1234,5678');
-            expect(urls.denominatorUrl).to.equal('/api/1.0/org_details/?format=json&org_type=ccg&keys=row_id,row_name,date,total_list_size');
+            expect(urls.denominatorUrl).to.equal('/api/1.0/org_details/?format=json&org_type=ccg&keys=total_list_size');
         });
     });
 


### PR DESCRIPTION
This is required to support automated monthly updates. It allows us to
pass the path of the last-imported prescribing data as use that as the
key for knowing which date measures need updating for