### PR TITLE
Refactor measures

### DIFF
--- a/openprescribing/frontend/management/commands/measure_definitions/bens.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/bens.json
@@ -55,13 +55,7 @@
             "as a percentage of total prescription items for all diabetes (060102)."
         ],
         "why_it_matters": [
-            "Rosiglitazone is an antidiabetic drug that turned out to ",
-            "increase the risk of heart problems, and was effectively ",
-            "withdrawn from the market. There is concern that the ",
-            "problems may have been a 'class effect', covering other ",
-            "related drugs, and so doctors have tended to also stop ",
-            "using pioglitazone. This shows how local practice ",
-            "reflects that national trend."
+            "Rosiglitazone is an antidiabetic drug that turned out to increase the risk of heart problems, and was effectively withdrawn from the market. There is concern that the problems may have been a 'class effect', covering other related drugs, and so doctors have tended to also stop using pioglitazone. This shows how local practice reflects that national trend. However, the latest NICE guidance on diabetes recommends it equally with other drugs, so it may become more popular again."
         ],
         "num": ["Number of prescription items for Pioglitazone Hydrochloride (0601023B0)"],
         "denom": ["Number of prescription items for all diabetes (060102)"],
@@ -150,10 +144,11 @@
         "name": "High-cost ACE inhibitors",
         "title": [
             "Prescribing of high-cost ACE inhibitors ",
-            "as a percentage of prescribing of TBA"
+            "as a percentage of prescribing of all ACE inhibitors"
         ],
         "description": [
-            "TBA"
+            "Prescribing of high-cost ACE inhibitors ",
+            "as a percentage of prescribing of all ACE inhibitors."
         ],
         "why_it_matters": [
             "TBA"
@@ -193,10 +188,11 @@
             "as a percentage of prescribing of all ARBs"
         ],
         "description": [
-            "TBA"
+            "Prescribing of high-cost ARBs ",
+            "as a percentage of prescribing of all ARBs."
         ],
         "why_it_matters": [
-            "TBA"
+            "Various angiotensin receptor blockers (ARBs) are available. A number of them are now available generically, and are of low cost. NICE guidance for treating high blood pressure recommends that the low-cost versions should be used."
         ],
         "num": ["Quantity for high-cost ARBs"],
         "denom": ["Quantity for all included ARBs"],
@@ -233,7 +229,8 @@
             "as a percentage of prescribing of all PPIs"
         ],
         "description": [
-            "TBA"
+            "Prescribing of high-cost PPIs ",
+            "as a percentage of prescribing of all PPIs."
         ],
         "why_it_matters": [
             "TBA"
@@ -273,10 +270,11 @@
             "as a percentage of prescribing of all statins"
         ],
         "description": [
-            "TBA"
+            "Prescribing of high-cost statins ",
+            "as a percentage of prescribing of all statins."
         ],
         "why_it_matters": [
-            "TBA"
+            "When treating high cholesterol, doctors are recommended to prescribe statins which are both low-cost, and reduce cholesterol by at least 40%. The low-cost statins (simvastatin and atorvastatin) are suitable for the majority of patients."
         ],
         "num": ["Quantity for high-cost statins"],
         "denom": ["Quantity for all included statins"],

--- a/openprescribing/frontend/management/commands/measure_definitions/ktts.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ktts.json
@@ -8,7 +8,7 @@
             "as a percentage of total prescription items for BNF 2.12."
         ],
         "why_it_matters": [
-            "TBA"
+            "The latest NICE guidance suggests that, for the vast majority of people who need treatment for high cholesterol, these drugs should not be used.  There is no evidence that omega 3 fatty acids reduces the chances of patients getting cardiovascular disease."
         ],
         "title": [
             "KTT3 (Lipid-modifying drugs): Number of prescription",
@@ -69,7 +69,7 @@
             "antidepressants (sub-set of BNF 4.3)."
         ],
         "why_it_matters": [
-            "TBA"
+            "Although non-drug methods are often used to treat depression, sometimes antidepressants are needed. Most antidepressants seem to be equally effective, and therefore doctors should decide which ones to give based on people’s previous experience and the likely side-effects. NICE guidance recommends that a generic type of antidepressant called an SSRI should normally be used first."
         ],
         "title": [
             "KTT8 (Antidepressants: First choice % items)"
@@ -126,7 +126,7 @@
             "(subset of BNF 4.3)."
         ],
         "why_it_matters": [
-            "TBA"
+            "Dosulepin is an older antidepressant. For the last ten years there has been a concern that overdose can easily be fatal, and it is recommended that patients should only be started on it by an expert in mental health. Numbers of patients who still get prescribed this drug are reducing."
         ],
         "title": [
             "KTT8 (Dosulepin): First choice antidepressant use in",
@@ -218,10 +218,10 @@
             "5.1.3; 5.1.5; 5.1.8; 5.1.11; 5.1.12; and 5.1.13."
         ],
         "why_it_matters": [
-            "(TBC) Cephalosporins are broad spectrum antibiotics which can ",
+            "Co-amoxiclav, cephalosporins and quinolones are broad spectrum antibiotics that can ",
             "be used when others have failed. It is important that ",
             "they are used sparingly, to avoid drug-resistant bacteria ",
-            "developing. This measure looks at the quantity of cephalosporins ",
+            "developing. This measure looks at the quantity of these ",
             "prescribed, versus the broad class of similar antibiotics."
         ],
         "num": [
@@ -266,7 +266,11 @@
     "ktt10_uti_antibiotics": {
         "name": "Antibiotics for uncomplicated UTIs (KTT10)",
         "title": [
-            "KTT10 (TBA)"
+            "KTT10 (Antibiotics for uncomplicated UTIs): ",
+            "Number of average daily quantities (ADQs) per",
+            "item for trimethoprim 200mg tablets,",
+            "nitrofurantoin 50mg tablets and capsules,",
+            "nitrofurantoin 100mg m/r capsules and pivmecillinam 200mg tablets."
         ],
         "description": [
             "Number of average daily quantities (ADQs) per",
@@ -275,7 +279,7 @@
             "nitrofurantoin 100mg m/r capsules and pivmecillinam 200mg tablets."
         ],
         "why_it_matters": [
-            "TBA"
+            "For most women (who are not pregnant), a three-day course of antibiotics for an uncomplicated urinary tract infection (UTI) will treat it effectively. This also reduces the amount of unnecessary antibiotics being prescribed."
         ],
         "num": [
             "Total average daily quantity (ADQ) usage for ",
@@ -338,7 +342,7 @@
             "for minocycline per 1000 patients."
         ],
         "why_it_matters": [
-            "TBA"
+            "Minocycline is an antibiotic used to treat patients with acne. However, there are concerns about its safety, and there are other treatments which appear to be safer and as effective.  The amount of minocycline prescribing has dropped nationally as a result."
         ],
         "num": [
             "Total average daily quantity (ADQ) usage ",
@@ -379,7 +383,7 @@
             "of prescription items for all Antidiabetic drugs (BNF 6.1.2)."
         ],
         "why_it_matters": [
-            "TBA"
+            "The previous NICE guidance on diabetes (2009) recommended that patients are prescribed metformin or a sulphonylurea first to treat their diabetes.  This guideline has now been changed, and so it is likely that the use of these drugs will reduce."
          ],
         "num": [
             "Number of prescription items for BNF section ",
@@ -482,7 +486,7 @@
             "for all NSAIDs."
         ],
         "why_it_matters": [
-            "TBA"
+            "There have been a number of concerns about the safety of a number of anti-inflammatory drugs, for their effects on the stomach, kidneys and the risk of blood clots.  The latest evidence shows that ibuprofen and naproxen are two of the drugs with a lower level of risk, and therefore doctors should prescribe these to patients before trying the others."
         ],
         "num": [
             "Number of prescription items for ibuprofen and naproxen ",

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -174,7 +174,7 @@ def measure_for_practices_in_ccg(request, ccg_code, measure):
     requested_ccg = get_object_or_404(PCT, code=ccg_code)
     measure = get_object_or_404(Measure, id=measure)
     practices = Practice.objects.filter(ccg=requested_ccg)\
-        .order_by('name')
+        .filter(setting=4).order_by('name')
     context = {
         'ccg': requested_ccg,
         'practices': practices,
@@ -186,7 +186,7 @@ def measure_for_practices_in_ccg(request, ccg_code, measure):
 
 def measures_for_one_ccg(request, ccg_code):
     requested_ccg = get_object_or_404(PCT, code=ccg_code)
-    practices = Practice.objects.filter(ccg=requested_ccg).order_by('name')
+    practices = Practice.objects.filter(ccg=requested_ccg).filter(setting=4).order_by('name')
     context = {
         'ccg': requested_ccg,
         'practices': practices,

--- a/openprescribing/media/js/measures.js
+++ b/openprescribing/media/js/measures.js
@@ -1,541 +1,168 @@
 (function() {
+  var _ = require('underscore');
+  var mu = require('./src/measure_utils');
+  var Highcharts = require('Highcharts');
+  var chartOptions = require('./src/highcharts-options');
+  var L = require('mapbox.js');
+  var Handlebars = require('handlebars');
+  Highcharts.setOptions({
+    global: {useUTC: false}
+  });
+  L.mapbox.accessToken = 'pk.eyJ1IjoiYW5uYXBvd2VsbHNta' +
+    'XRoIiwiYSI6ImNzY1VpYkkifQ.LC_IcHpHfOvWOQCuo5t7Hw';
 
-global.jQuery = require('jquery');
-global.$ = global.jQuery;
-require('bootstrap');
-require('Highcharts');
-require('mapbox.js');
-var _ = require('underscore');
-var Handlebars = require('handlebars');
-
-var utils = require('./src/chart_utils');
-var formatters = require('./src/chart_formatters');
-var chartOptions = require('./src/highcharts-options');
-
-Highcharts.setOptions({
-    global: { useUTC: false }
-});
-L.mapbox.accessToken = 'pk.eyJ1IjoiYW5uYXBvd2VsbHNtaXRoIiwiYSI6ImNzY1VpYkkifQ.LC_IcHpHfOvWOQCuo5t7Hw';
-
-var measures = {
+  var measures = {
     el: {
-        mapPanel: 'map-measure'
+      chart: '#charts .chart',
+      charts: '#charts',
+      mapPanel: 'map-measure',
+      perfSummary: '#perfsummary',
+      showAll: '#showall',
+      sortButtons: ".btn-group > .btn",
+      summaryTemplate: '#summary-panel',
+      panelTemplate: "#measure-panel"
     },
 
     setUp: function() {
-        this.setUpShowPractices();
-        var _this = this;
+      var _this = this;
+      var summaryTemplate =
+        Handlebars.compile($(_this.el.summaryTemplate).html());
+      var panelTemplate =
+        Handlebars.compile($(_this.el.panelTemplate).html());
+      var NUM_MONTHS_FOR_RANKING = 6;
+      var centiles = ['10', '20', '30', '40', '50', '60', '70', '80', '90'];
 
-        _this.NUM_MONTHS_FOR_RANKING = 6;
-        _this.centiles = ['10', '20', '30', '40', '50', '60', '70', '80', '90'];
-        _this.measure = measureData.measure;
-        _this.measureIsCostBased = (measureData.measureIsCostBased) ? (measureData.measureIsCostBased === 'True') : null;
-        _this.measureIsPercentage = (measureData.measureIsPercentage) ? (measureData.measureIsPercentage === 'True') : null;
-        _this.orgType = measureData.orgType;
-        _this.parentOrg = (measureData.parentOrg) ? measureData.parentOrg : null;
-        _this.orgId = measureData.orgId;
-        _this.orgName = measureData.orgName;
-        _this.rollUpBy = (_this.measure) ? 'org_id': 'measure_id';
+      _this.allGraphsRendered = false;
+      _this.graphsToRenderInitially = 24;
 
-        // On long pages, only render some graphs initially, to stop the page choking.
-        _this.allGraphsRendered = false;
-        _this.graphsToRenderInitially = 24;
+      var options = measureData;
+      options.rollUpBy = (options.measure) ? 'org_id' : 'measure_id';
 
-        if ($('#' + _this.el.mapPanel).length) {
-            _this.setUpMap(_this.orgId, _this.orgType);
-        }
+      _this.setUpShowPractices();
+      _this.setUpMap(options);
 
-        // All pages have a summary, and a series of panels.
-        var summary_template = Handlebars.compile($('#summary-panel').html()),
-            panel_template = Handlebars.compile($("#measure-panel").html());
+      var urls = mu.getDataUrls(options);
+      $.when(
+        $.ajax(urls.panelMeasuresUrl),
+        $.ajax(urls.globalMeasuresUrl)
+        ).done(function(panelMeasures, globalMeasures) {
+          var chartData = panelMeasures[0].measures;
+          var globalData = globalMeasures[0].measures;
 
-        // Get the appropriate URLs for the individual panel measures, and the global measures.
-        var urls = _this.getDataUrls(_this.orgId, _this.orgType, _this.measure);
-        $.when(
-            $.ajax(urls.panelMeasuresUrl),
-            $.ajax(urls.globalMeasuresUrl)
-            ).done(function(panelMeasures, globalMeasures) {
-                var panelData = panelMeasures[0].measures,
-                    globalData = globalMeasures[0].measures,
-                    globalSeries = {};
+          _.extend(options,
+            mu.getCentilesAndYAxisExtent(globalData, options, centiles));
 
-                // If we're just looking at one measure, calculate the Highcharts x and
-                // y values at this point, so we can re-use them.
-                if (_this.rollUpBy === 'org_id') {
-                    // We're only using one measure. Get the global series.
-                    var series = _.findWhere(globalData, { id: _this.measure});
-                    _.each(_this.centiles, function(i) {
-                        globalSeries[i.toString()] = _this.convertDataForHighcharts(series.data,
-                            true, _this.orgType.toLowerCase(), i);
-                    });
-                    _this.globalYMax = _.max(globalSeries['90'], _.property('y'));
-                    _this.globalYMin = _.min(globalSeries['10'], _.property('y'));
-                } else {
-                    _this.globalYMax = 0;
-                    _this.globalYMin = 0;
-                }
+          chartData = mu.annotateAndSortData(chartData, options,
+            NUM_MONTHS_FOR_RANKING);
+          chartData = mu.addChartAttributes(chartData, globalData,
+            options.globalCentiles, centiles, options,
+            NUM_MONTHS_FOR_RANKING);
 
-                panelData = _this.annotateAndSortPanelData(panelData);
+          var perf = mu.getPerformanceSummary(chartData, options,
+            NUM_MONTHS_FOR_RANKING);
+          $(_this.el.perfSummary).html(summaryTemplate(perf));
 
-                // Render performance summary measures.
-                var perf = _this.getPerformanceSummary(panelData, _this.rollUpBy,
-                    _this.measureIsCostBased, _this.orgId, _this.measure);
-                $('#perfsummary').html(summary_template(perf));
-
-                // Draw the panel for each item (whether measure or org).
-                var html = '';
-                var chartData = _this.addChartAttributes(panelData, _this.rollUpBy,
-                    _this.orgType, _this.orgId, _this.parentOrg, _this.measure, _this.measureIsCostBased);
-                _.each(chartData, function(d) {
-                    html += panel_template(d);
-                });
-                $('#charts').html(html);
-
-                // Render the chart to each panel.
-                _.each(chartData, function(d, i) {
-                    d.data = _this.convertDataForHighcharts(d.data, false);
-                    if (_this.rollUpBy === 'measure_id') {
-                        // For measures, get the global series for each measure.
-                        var series = _.findWhere(globalData, { id: d.id});
-                        d.globalSeries = {};
-                        _.each(_this.centiles, function(i) {
-                            d.globalSeries[i] = _this.convertDataForHighcharts(series.data, true,
-                                _this.orgType.toLowerCase(), i);
-                        });
-                    } else {
-                        d.globalSeries = globalSeries;
-                    }
-                    if (i < _this.graphsToRenderInitially) {
-                        _this.renderGraph(d, _this.orgType, _this.measureIsPercentage);
-                    }
-                });
-
-                // On long pages, render remaining graphs only after scroll,
-                // to stop the page choking on first load.
-                $(window).scroll(function() {
-                    if (_this.allGraphsRendered === false) {
-                        _.each(chartData, function(d, i) {
-                            if (i >= _this.graphsToRenderInitially) {
-                                _this.renderGraph(d, _this.orgType, _this.measureIsPercentage);
-                            }
-                        });
-                        _this.allGraphsRendered = true;
-                    }
-                });
-
-                // Set up 'sort by' options, for per-measure pages.
-                if (_this.rollUpBy === 'measure_id') {
-                    var chartsByPercentile = $('#charts .chart');
-                    var chartsBySaving = $(chartsByPercentile).filter(function(a) {
-                        return $(this).data('costsaving') !== 0;
-                    });
-                    chartsBySaving.sort(function(a, b) {
-                        return +a.costsaving - +b.costsaving;
-                        // TODO: Fix for <IE10?
-                        //return +a.getAttribute('data-costsaving') - +b.getAttribute('data-costsaving');
-                    });
-                    $(".btn-group > .btn").click(function(){
-                        $(this).addClass("active").siblings().removeClass("active");
-                        if ($(this).data('orderby') === 'savings') {
-                            $('#charts').fadeOut(function(){
-                                $('#charts').html(chartsBySaving).fadeIn();
-                            });
-                        } else {
-                            $('#charts').fadeOut(function(){
-                                $('#charts').html(chartsByPercentile).fadeIn();
-                            });
-                        }
-                    });
-                }
-            })
-            .fail(function(){
-                console.log('data failed');
-            });
-    },
-
-    getDataUrls: function(orgId, orgType, measure) {
-        var urls = {
-            panelMeasuresUrl: '/api/1.0/measure_by_' + orgType.toLowerCase() + '/?format=json',
-            globalMeasuresUrl: '/api/1.0/measure/?format=json'
-        };
-        if (orgId) {
-            urls.panelMeasuresUrl += '&org=' + orgId;
-        }
-        if (measure) {
-            urls.panelMeasuresUrl += '&measure=' + measure;
-            urls.globalMeasuresUrl += '&measure=' + measure;
-        }
-        return urls;
-    },
-
-    renderGraph: function(d, orgType, isPercentageMeasure) {
-        // console.log('renderGraph', d.globalSeries);
-        // Assemble the series for the graph, and any extra options.
-        var _this = this;
-        if (d.data.length) {
-            var hcOptions = _this.getChartOptions(d, isPercentageMeasure);
-            hcOptions.series = [{
-                'name': 'This ' + orgType,
-                'is_national_series': false,
-                'data': d.data,
-                'color': 'red',
-                'marker': {
-                   'radius': 2
-                }
-            }];
-            for (var k in d.globalSeries) {
-                var e = {
-                    'name': k + 'th percentile nationally',
-                    'is_national_series': true,
-                    'data': d.globalSeries[k],
-                    'dashStyle': 'dot',
-                    'color': 'blue',
-                    'lineWidth': 1,
-                    'marker': {
-                       'enabled': false
-                    }
-                };
-                // Highlight median line with dashes.
-                if (k === '50') {
-                    e.dashStyle = 'longdash';
-                }
-                hcOptions.series.push(e);
+          var html = '';
+          _.each(chartData, function(d) {
+            html += panelTemplate(d);
+          });
+          $(_this.el.charts).html(html);
+          _.each(chartData, function(d, i) {
+            if (i < _this.graphsToRenderInitially) {
+              var chOptions = mu.getGraphOptions(d,
+                options, d.is_percentage, chartOptions);
+              if (chOptions) {
+                new Highcharts.Chart(chOptions);
+              }
             }
-            var chart = new Highcharts.Chart(hcOptions);
-        } else {
-            $('#' + chartOptions.chartId).find(_this.el.status).html('No data found for this ' + _this.orgType).show();
-        }
-    },
+          });
 
-    annotateAndSortPanelData: function(panelData) {
-        // Create an array with an item for each chart, rolled up either
-        // by measure, OR by organisation ID, as appropriate.
-        // Annotate each chart with the saving, and percentile.
-        // Sort the array by percentile, put all nulls at the bottom.
-        var data, _this = this;
-        if (_this.rollUpBy !== 'measure_id') {
-            panelData = _this.rollUpByOrg(panelData[0], _this.orgType);
-        }
-        panelData = _this.getSavingAndPercentilePerItem(panelData, _this.NUM_MONTHS_FOR_RANKING);
-        data = _.sortBy(panelData, function(d) {
-            if (d.mean_percentile === null) return -1;
-            return d.mean_percentile;
-        }).reverse();
-        return data;
-    },
-
-    _parseDate: function(d) {
-        var dates = d.split('-');
-        return Date.UTC(dates[0], dates[1]-1, dates[2]);
-    },
-
-    convertDataForHighcharts: function(data, is_global, org, num) {
-        // Take a data series and an attribute, and convert it to
-        // a series of x/y dictionaries, ready for Highcharts.
-        var _this = this,
-            dataCopy = JSON.parse(JSON.stringify(data));
-        _.each(dataCopy, function(d, i) {
-            d.x = _this._parseDate(d.date);
-            p = d.percentiles;
-            if (is_global) {
-                d.y = (p && p[org] && p[org][num] !== null) ? parseFloat(p[org][num]) : null;
-            } else {
-                d.y = (d.calc_value !== null) ? parseFloat(d.calc_value) : null;
+          // On long pages, render remaining graphs only after scroll,
+          // to stop the page choking on first load.
+          $(window).scroll(function() {
+            if (_this.allGraphsRendered === false) {
+              _.each(chartData, function(d, i) {
+                if (i >= _this.graphsToRenderInitially) {
+                  var chOptions = mu.getGraphOptions(d,
+                    options, d.is_percentage, chartOptions);
+                  if (chOptions) {
+                    new Highcharts.Chart(chOptions);
+                  }
+                }
+              });
+              _this.allGraphsRendered = true;
             }
-            if (_this.measureIsPercentage) {
-                d.y = d.y * 100;
-            }
+          });
+
+          if (options.rollUpBy === 'measure_id') {
+            _this.setUpSortGraphs();
+          }
+        })
+        .fail(function(jqXHR, textStatus, error) {
+          console.log("Error " + error + " when making request " + jqXHR);
         });
-        return dataCopy;
-    },
-
-    rollUpByOrg: function(data, orgType) {
-        var rolled = {};
-        _.each(data.data, function(d) {
-            var id = (orgType === 'practice') ? d.practice_id : d.pct_id,
-                name = (orgType === 'practice') ? d.practice_name : d.pct_name;
-            if (id in rolled) {
-                rolled[id].data.push(d);
-            } else {
-                rolled[id] = {
-                    'id': id,
-                    'name': name,
-                    'numerator_short': data.numerator_short,
-                    'denominator_short': data.denominator_short,
-                    'data': [d],
-                    'description': ''
-                };
-            }
-        });
-        var rolledArr = [];
-        for (var org_id in rolled) {
-            rolledArr.push(rolled[org_id]);
-        }
-        return rolledArr;
-    },
-
-    getSavingAndPercentilePerItem: function(data, num_months) {
-        // For each measure, or org, in the data, get the mean percentile,
-        // and the mean cost saving at the 50th percentile,
-        // over the number of months specified.
-        // We'll use this to sort the panels.
-        // console.log('getSavingAndPercentilePerItem', data);
-        _.each(data, function(d) {
-            var latestData = d.data.slice(num_months * -1);
-            var sum = _.reduce(latestData, function(memo, num){
-                return (num.percentile === null) ? memo : memo + num.percentile;
-            }, null);
-            d.mean_percentile = (sum !== null) ? sum / latestData.length: null;
-            d.cost_saving_50th = _.reduce(latestData, function(memo, num) {
-                var saving = (num.cost_savings) ? num.cost_savings['50'] : null;
-                return memo + saving;
-            }, null);
-        });
-        return data;
-    },
-
-    addChartAttributes: function(data, rollUpBy, orgType, orgId, parentOrg, measure, measureIsCostBased) {
-        // For each item of the dataset, get the chart title, URL, and any description.
-        var _this = this;
-        _.each(data, function(d) {
-            //console.log('addChartAttributes', d, measure);
-            d.chart_id = d.id;
-            if (rollUpBy === 'measure_id') {
-                // We want CCG or practice pages to link to the
-                // measure-by-all-practices in CCG page.
-                d.chart_title = d.name;
-                d.chart_title_url = '/ccg/';
-                d.chart_title_url += (parentOrg) ? parentOrg : orgId;
-                d.chart_title_url += '/' + d.id;
-            } else {
-                // We want measure pages to link to the appropriate
-                // organisation page.
-                d.chart_title = d.id + ': ' + d.name;
-                d.chart_title_url = '/' + orgType.toLowerCase() + '/' + d.id + '/measures';
-            }
-            d.description_short = d.description.substring(0, 80) + ' ...';
-            if ((d.is_cost_based) || measureIsCostBased) {
-                d.cost_description = '';
-                if (d.cost_saving_50th < 0) {
-                    d.cost_description += '<strong>Cost savings:</strong> ';
-                    d.cost_description += 'By prescribing better than the median, ';
-                    d.cost_description += 'this ' + orgType + ' has saved the NHS £';
-                    d.cost_description += Highcharts.numberFormat((d.cost_saving_50th * -1), 2);
-                    d.cost_description += ' over the past six months.';
-                } else if (d.cost_saving_50th === 0) {
-                } else {
-                    d.cost_description += '<strong>Cost savings:</strong> ';
-                    d.cost_description += 'If it had prescribed in line with the median, ';
-                    d.cost_description += 'this ' + orgType + ' would have spent £';
-                    d.cost_description += Highcharts.numberFormat(d.cost_saving_50th, 2);
-                    d.cost_description += ' less over the past six months.';
-                }
-                d.chart_explanation = d.cost_description;
-            } else {
-                if (d.mean_percentile) {
-                    var p = Highcharts.numberFormat(d.mean_percentile, 0);
-                    d.chart_explanation = 'This organisation was at the ';
-                    d.chart_explanation += p + _this.getOrdinalSuffix(p);
-                    d.chart_explanation += ' percentile on average across the past six months.';
-                } else {
-                    d.chart_explanation = 'No data available.';
-                }
-            }
-        });
-        return data;
-    },
-
-    getChartOptions: function(d, isPercentageMeasure) {
-        // console.log('getChartOptions', d);
-        // Highcharts options for these panel charts.
-        // Y-axis minimum, maximum, and label, and tooltip.
-        var _this = this,
-            options = $.extend(true, {}, chartOptions.dashOptions),
-            localMax = _.max(d.data, _.property('y')),
-            localMin = _.min(d.data, _.property('y')),
-            ymax, ymin;
-        isPercentageMeasure = (d.is_percentage || isPercentageMeasure);
-        options.chart.renderTo = d.chart_id;
-        options.chart.height = 200;
-        options.legend.enabled = false;
-        if (_this.rollUpBy === 'org_id') {
-            ymax = _.max([localMax.y, _this.globalYMax.y]);
-            ymin = _.min([localMin.y, _this.globalYMin.y]);
-        } else {
-            var local90thMax = _.max(d.globalSeries['90'], _.property('y'));
-            ymax = _.max([localMax.y, local90thMax.y]);
-            var local90thMin = _.min(d.globalSeries['10'], _.property('y'));
-            ymin = _.min([localMin.y, local90thMin.y]);
-        }
-        var yAxisLabel = (isPercentageMeasure) ? '%' : 'Measure';
-        options.yAxis = {
-            title: {
-                text: yAxisLabel
-            },
-            max: ymax,
-            // If ymin is zero, Highcharts will sometimes pick a negative value
-            // for formatting reasons. Force zero as the lowest value.
-            min: _.max([0, ymin])
-        };
-        options.tooltip = {
-            formatter: function() {
-                // console.log('tooltip', this.point);
-                var num = Highcharts.numberFormat(this.point.numerator, 0),
-                    denom = Highcharts.numberFormat(this.point.denominator, 0),
-                    percentile = Highcharts.numberFormat(this.point.percentile, 0),
-                    str = '';
-                str += '<b>' + this.series.name;
-                str += ' in ' + Highcharts.dateFormat('%b \'%y',
-                                      new Date(this.x));
-                str += '</b><br/>';
-                if (!this.series.options.is_national_series) {
-                    str += d.numerator_short + ': ' + num;
-                    str += '<br/>';
-                    str += d.denominator_short + ': ' + denom;
-                    str += '<br/>';
-                }
-                str += 'Measure: ' +  Highcharts.numberFormat(this.point.y, 3);
-                str += (isPercentageMeasure) ? '%' : '';
-                if (!this.series.options.is_national_series) {
-                    //str += ' (' + num + '/' + denom + ')';
-                    str += ' (' + percentile + _this.getOrdinalSuffix(percentile) + ' percentile)';
-                }
-                return str;
-            }
-        };
-        return options;
-    },
-
-    getOrdinalSuffix: function(percentile) {
-        var lastChar = percentile.toString().slice(-1), suffix;
-        switch (lastChar) {
-            case '1':
-                suffix = (percentile == '11') ? 'th' : 'st';
-                break;
-            case '2':
-                suffix = (percentile == '12') ? 'th' : 'nd';
-                break;
-            case '3':
-                suffix = (percentile == '13') ? 'th' : 'rd';
-                break;
-            default:
-                suffix = 'th';
-        }
-        return suffix;
-    },
-
-    getPerformanceSummary: function(orderedData, rollUpBy, isCostBased, orgId, measure) {
-        //console.log('getPerformanceSummary', orderedData[0], rollUpBy);
-        var perf = {
-            total: 0,
-            above_median: 0,
-            potential_savings_50th: 0,
-            potential_savings_10th: 0,
-            org_id: orgId,
-            measure_id: measure
-        };
-        if (orderedData.length) {
-            _.each(orderedData, function(d) {
-                if (d.mean_percentile !== null) {
-                    perf.total += 1;
-                    if (d.mean_percentile > 50) {
-                        perf.above_median += 1;
-                        perf.potential_savings_50th += (isCostBased) ? d.cost_saving_50th : 0;
-                    }
-                    if (d.mean_percentile > 10) {
-                        perf.potential_savings_10th += (isCostBased) ? d.cost_saving_10th : 0;
-                    }
-                }
-            });
-            perf.performance_description = "Over the past six months, this organisation ";
-            perf.performance_description += "has prescribed above the median on ";
-            perf.performance_description += perf.above_median + " of " + perf.total + " measures.";
-            perf.proportion_above_median = perf.above_median / perf.total;
-            if (perf.proportion_above_median >= 0.75) {
-                perf.rank = 'poor';
-            } else if (perf.proportion_above_median >= 0.5) {
-                perf.rank = 'acceptable';
-            } else if (perf.proportion_above_median >= 0.25) {
-                perf.rank = 'good';
-            } else if (perf.proportion_above_median >= 0) {
-                perf.rank = 'very good';
-            }
-            if (perf.performance_description) {
-                perf.performance_description += ' We think this is ' + perf.rank;
-                perf.performance_description += ' performance overall.';
-            }
-
-            var p = Highcharts.numberFormat(orderedData[0].mean_percentile, 0);
-            perf.top_opportunity = 'The measure with the biggest potential for improvement was ';
-            perf.top_opportunity += orderedData[0].name + ', where this ' + this.orgType;
-            perf.top_opportunity += ' was at the ' + p + this.getOrdinalSuffix(p);
-            perf.top_opportunity += ' percentile on average across the past six months.';
-
-            perf.proportion_above_median = Highcharts.numberFormat(perf.proportion_above_median * 100, 1);
-
-            if (isCostBased) {
-                if (rollUpBy === 'measure_id') {
-                    perf.cost_savings = 'Over the past six months, if this ';
-                    perf.cost_savings += (this.orgType === 'practice') ? "practice " : "CCG ";
-                    perf.cost_savings += ' had prescribed ';
-                    perf.cost_savings += 'at the median ratio or better on all cost-saving measures below, then it would ';
-                    perf.cost_savings += 'have spent £' + Highcharts.numberFormat(perf.potential_savings_50th, 2);
-                    perf.cost_savings += ' less. (We use the national median as a suggested ';
-                    perf.cost_savings += 'target because by definition, 50% of practices were already prescribing ';
-                    perf.cost_savings += 'at this level or better, so we think it ought to be achievable.)';
-                } else {
-                    perf.cost_savings = 'Over the past six months, if all ' ;
-                    perf.cost_savings += (this.orgType === 'practice') ? "practices " : "CCGs ";
-                    perf.cost_savings += 'had prescribed at the median ratio or better, then ';
-                    perf.cost_savings += (this.orgType === 'practice') ? "this CCG " : "NHS England ";
-                    perf.cost_savings += 'would have spent £' + Highcharts.numberFormat(perf.potential_savings_50th, 2);
-                    perf.cost_savings += ' less. (We use the national median as a suggested ';
-                    perf.cost_savings += 'target because by definition, 50% of ';
-                    perf.cost_savings += (this.orgType === 'practice') ? "practices " : "CCGs ";
-                    perf.cost_savings += ' were already prescribing ';
-                    perf.cost_savings += 'at this level or better, so we think it ought to be achievable.)';
-                }
-            }
-        } else {
-            perf.performance_description = "This organisation hasn't prescribed on any of these measures.";
-        }
-        //console.log('perf', perf);
-        return perf;
     },
 
     setUpShowPractices: function() {
-        $('#showall').on('click', function(e) {
-            e.preventDefault();
-            $('#practices li.hidden').each(function (i, item) {
-                $(item).removeClass('hidden');
-            });
-            $(this).hide();
+      $(this.el.showAll).on('click', function(e) {
+        e.preventDefault();
+        $('#practices li.hidden').each(function(i, item) {
+          $(item).removeClass('hidden');
         });
+        $(this).hide();
+      });
     },
 
-    setUpMap: function(orgId, orgType) {
-        var _this = this;
-        var map = L.mapbox.map(_this.el.mapPanel, 'mapbox.streets').setView([52.905, -1.79], 6);
+    setUpMap: function(options) {
+      var _this = this;
+      if ($('#' + _this.el.mapPanel).length) {
+        var map = L.mapbox.map(_this.el.mapPanel,
+          'mapbox.streets').setView([52.905, -1.79], 6);
         map.scrollWheelZoom.disable();
-        var url = '/api/1.0/org_location/?org_type=' + orgType.toLowerCase();
-        url += '&q=' + orgId;
+        var url = '/api/1.0/org_location/?org_type=' +
+          options.orgType.toLowerCase();
+        url += '&q=' + options.orgId;
         var layer = L.mapbox.featureLayer()
-            .loadURL(url)
-            .on('ready', function() {
-                if (layer.getBounds().isValid()) {
-                    map.fitBounds(layer.getBounds(), {maxZoom: 12});
-                    layer.setStyle({fillColor: '#ff00ff',
-                                    fillOpacity: 0.2,
-                                    weight: 0.5,
-                                    color: "#333",
-                                    radius: 10});
-                } else {
-                    $('#map-container').html('');
-                }
-            })
-            .addTo(map);
-    }
-};
+        .loadURL(url)
+        .on('ready', function() {
+          if (layer.getBounds().isValid()) {
+            map.fitBounds(layer.getBounds(), {maxZoom: 12});
+            layer.setStyle({fillColor: '#ff00ff',
+              fillOpacity: 0.2,
+              weight: 0.5,
+              color: "#333",
+              radius: 10});
+          } else {
+            $('#map-container').html('');
+          }
+        })
+        .addTo(map);
+      }
+    },
 
-measures.setUp();
+    setUpSortGraphs: function() {
+      var _this = this;
+      var chartsByPercentile = $(_this.el.chart);
+      var chartsBySaving = $(chartsByPercentile).filter(function(a) {
+        return $(this).data('costsaving') !== 0;
+      });
+      chartsBySaving.sort(function(a, b) {
+        return Number(a.costsaving) - Number(b.costsaving);
+      });
+      $(_this.el.sortButtons).click(function() {
+        $(this).addClass("active").siblings().removeClass("active");
+        if ($(this).data('orderby') === 'savings') {
+          $(_this.el.charts).fadeOut(function() {
+            $(_this.el.charts).html(chartsBySaving).fadeIn();
+          });
+        } else {
+          $(_this.el.charts).fadeOut(function() {
+            $(_this.el.charts).html(chartsByPercentile).fadeIn();
+          });
+        }
+      });
+    }
+  };
+
+  measures.setUp();
 })();

--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -51,6 +51,7 @@
     "bootstrap": "^3.3.4",
     "compute-quantile": "^1.0.1",
     "handlebars": "4.0.5",
+    "humanize": "^0.0.9",
     "jquery": "^1.11.3",
     "localforage": "^1.2.2",
     "mapbox.js": "^2.2.1",

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -1,0 +1,437 @@
+global.jQuery = require('jquery');
+global.$ = global.jQuery;
+var _ = require('underscore');
+var humanize = require('humanize');
+
+var utils = {
+
+  getDataUrls: function(options) {
+    var panelUrl = '/api/1.0/measure_by_';
+    panelUrl += options.orgType.toLowerCase() + '/?format=json';
+    var urls = {
+      panelMeasuresUrl: panelUrl,
+      globalMeasuresUrl: '/api/1.0/measure/?format=json'
+    };
+    if (options.orgId) {
+      urls.panelMeasuresUrl += '&org=' + options.orgId;
+    }
+    if (options.measure) {
+      urls.panelMeasuresUrl += '&measure=' + options.measure;
+      urls.globalMeasuresUrl += '&measure=' + options.measure;
+    }
+    return urls;
+  },
+
+  getCentilesAndYAxisExtent: function(globalData, options, centiles) {
+    /*
+    If there is a single global set of centiles, calculate the global
+    y-axis min and max. We will use this to set the y-axis extent of
+    all the charts consistently. This is because visual comparisons
+    are much easier if the y-axes are consistent.
+    */
+    var _this = this;
+    var globalCentiles = {};
+    var globalYMax = 0;
+    var globalYMin = 0;
+    if (options.rollUpBy !== 'measure_id') {
+      var series = _.findWhere(globalData, {id: options.measure});
+      if (series) {
+        _.each(centiles, function(i) {
+          globalCentiles[i.toString()] =
+          _this._addHighchartsXAndY(series.data,
+            true, series.is_percentage, options, i);
+        });
+        globalYMax = _.max(globalCentiles['90'], _.property('y'));
+        globalYMin = _.min(globalCentiles['10'], _.property('y'));
+      }
+    }
+    return {
+      globalCentiles: globalCentiles,
+      globalYMax: globalYMax,
+      globalYMin: globalYMin
+    };
+  },
+
+  annotateAndSortData: function(panelData, options, numMonths) {
+    /*
+    Create a new array with an item for each chart, each chart being
+    either a measure or an organisation, as appropriate.
+    Annotate each chart with the mean percentile over the past
+    N months, and cost saving if appropriate.
+    Sort the array by percentile, pushing nulls to the bottom.
+    */
+    var data = [];
+    var _this = this;
+    if (panelData.length) {
+      if (options.rollUpBy !== 'measure_id') {
+        panelData = _this._rollUpByOrg(panelData[0], options.orgType);
+      }
+      panelData = _this._getSavingAndPercentilePerItem(panelData,
+        numMonths);
+      data = _.sortBy(panelData, function(d) {
+        if (d.meanPercentile === null) return -1;
+        return d.meanPercentile;
+      }).reverse();
+    }
+    return data;
+  },
+
+  _rollUpByOrg: function(data, orgType) {
+    var rolled = {};
+    _.each(data.data, function(d) {
+      var id = (orgType === 'practice') ? d.practice_id : d.pct_id;
+      var name = (orgType === 'practice') ? d.practice_name : d.pct_name;
+      if (id in rolled) {
+        rolled[id].data.push(d);
+      } else {
+        rolled[id] = {
+          id: id,
+          name: name,
+          numeratorShort: data.numerator_short,
+          denominatorShort: data.denominator_short,
+          data: [d],
+          isCostBased: data.is_cost_based,
+          isPercentage: data.is_percentage
+        };
+      }
+    });
+    var rolledArr = [];
+    for (var orgId in rolled) {
+      if (rolled[orgId]) {
+        rolledArr.push(rolled[orgId]);
+      }
+    }
+    return rolledArr;
+  },
+
+  _getSavingAndPercentilePerItem: function(data, numMonths) {
+    /*
+    For each measure, or org, in the data, get the mean percentile,
+    and the mean cost saving at the 50th percentile,
+    over the number of months specified.
+    We'll use this to sort the charts by percentile or saving.
+    */
+    _.each(data, function(d) {
+      var latestData = d.data.slice(numMonths * -1);
+      var sum = _.reduce(latestData, function(memo, num) {
+        return (num.percentile === null) ? memo : memo + num.percentile;
+      }, null);
+      var validMonths = _.filter(latestData, function(d) {
+        return (d.percentile !== null);
+      }).length;
+      d.meanPercentile = (sum === null) ? null : sum / validMonths;
+      d.costSaving50th = _.reduce(latestData, function(memo, num) {
+        var saving = (num.cost_savings) ? num.cost_savings['50'] : null;
+        return memo + saving;
+      }, null);
+      if (!('numeratorShort' in d)) {
+        d.numeratorShort = d.numerator_short;
+        d.denominatorShort = d.denominator_short;
+      }
+    });
+    return data;
+  },
+
+  getPerformanceSummary: function(orderedData, options, numMonths) {
+    /*
+    Get the introductory paragraph for the page, talking about
+    (if applicable) the number of practices above the
+    median, or (if applicable) the cost savings available.
+    */
+    var perf = {
+      total: 0,
+      aboveMedian: 0,
+      potentialSavings50th: 0,
+      potentialSavings10th: 0,
+      orgId: options.orgId,
+      measureId: options.measure
+    };
+    if (orderedData.length) {
+      _.each(orderedData, function(d) {
+        if (d.meanPercentile !== null) {
+          perf.total += 1;
+          if (d.meanPercentile > 50) {
+            perf.aboveMedian += 1;
+            perf.potentialSavings50th +=
+              (options.isCostBasedMeasure) ? d.costSaving50th : 0;
+          }
+          if (d.meanPercentile > 10) {
+            perf.potentialSavings10th +=
+              (options.isCostBasedMeasure) ? d.costSaving50th : 0;
+          }
+        }
+      });
+      if (options.rollUpBy === 'measure_id') {
+        perf.performanceDescription = "Over the past " + numMonths +
+          " months, this organisation has prescribed above the median on " +
+          perf.aboveMedian + " of " + perf.total + " measures. ";
+      } else {
+        perf.performanceDescription = "Over the past " + numMonths +
+          " months, " + perf.aboveMedian + " of " + perf.total + ' ';
+        perf.performanceDescription += (options.orgType === 'practice') ?
+          "practices " : "CCGs ";
+        perf.performanceDescription += "have prescribed above the " +
+          "national median. ";
+      }
+      perf.proportionAboveMedian = perf.aboveMedian / perf.total;
+      if (perf.proportionAboveMedian >= 0.7) {
+        perf.rank = 'poor';
+      } else if (perf.proportionAboveMedian >= 0.45) {
+        perf.rank = 'acceptable';
+      } else if (perf.proportionAboveMedian >= 0.25) {
+        perf.rank = 'good';
+      } else if (perf.proportionAboveMedian >= 0) {
+        perf.rank = 'very good';
+      }
+      if (perf.performanceDescription) {
+        perf.performanceDescription += 'We think this is ' + perf.rank +
+          ' performance overall.';
+      }
+      if (options.rollUpBy === 'measure_id') {
+        var p = humanize.numberFormat(orderedData[0].meanPercentile, 0);
+        perf.topOpportunity = 'The measure with the biggest potential for ' +
+          ' improvement was ' + orderedData[0].name + ', where this ' +
+          options.orgType + ' was at the ' + humanize.ordinal(p) +
+          ' percentile on average across the past ' + numMonths + ' months.';
+      }
+      perf.proportionAboveMedian =
+        humanize.numberFormat(perf.proportionAboveMedian * 100, 1);
+      if (options.isCostBasedMeasure) {
+        if (options.rollUpBy === 'measure_id') {
+          perf.costSavings = 'Over the past ' + numMonths + ' months, if this ';
+          perf.costSavings += (options.orgType === 'practice') ?
+            "practice " : "CCG ";
+          perf.costSavings += ' had prescribed at the median ratio or better ' +
+            'on all cost-saving measures below, then it would have spent £' +
+            humanize.numberFormat(perf.potentialSavings50th, 2) +
+            ' less. (We use the national median as a suggested ' +
+            'target because by definition, 50% of practices were already ' +
+            'prescribing at this level or better, so we think it ought ' +
+            'to be achievable.)';
+        } else {
+          perf.costSavings = 'Over the past ' + numMonths + ' months, if all ';
+          perf.costSavings += (options.orgType === 'practice') ?
+            "practices " : "CCGs ";
+          perf.costSavings += 'had prescribed at the median ratio ' +
+            'or better, then ';
+          perf.costSavings += (options.orgType === 'practice') ?
+            "this CCG " : "NHS England ";
+          perf.costSavings += 'would have spent £' +
+            humanize.numberFormat(perf.potentialSavings50th, 2) +
+            ' less. (We use the national median as a suggested ' +
+            'target because by definition, 50% of ';
+          perf.costSavings += (options.orgType === 'practice') ?
+            "practices " : "CCGs ";
+          perf.costSavings += 'were already prescribing ' +
+            'at this level or better, so we think it ought to be achievable.)';
+        }
+      }
+    } else {
+      perf.performanceDescription = "This organisation hasn't " +
+        "prescribed on any of these measures.";
+    }
+    return perf;
+  },
+
+  addChartAttributes: function(data, globalData, globalCentiles,
+    centiles, options, numMonths) {
+    /*
+    Expects an array that represents a series of charts. For
+    each chart, add Highcharts attributes to the data,
+    merge in centiles from the global data, and
+    add chart title, URL, description etc.
+    */
+    var _this = this;
+    var newData = [];
+    _.each(data, function(d) {
+      d.data = _this._addHighchartsXAndY(d.data, false,
+        d.isPercentage, options, null);
+      if (options.rollUpBy === 'measure_id') {
+        // If each chart is a different measure, get the
+        // centiles for that measure.
+        var series = _.findWhere(globalData, {id: d.id});
+        d.globalCentiles = {};
+        _.each(centiles, function(i) {
+          d.globalCentiles[i] = _this._addHighchartsXAndY(series.data,
+            true, series.is_percentage, options, i);
+        });
+      } else {
+        d.globalCentiles = globalCentiles;
+      }
+      d.chartId = d.id;
+      _.extend(d, _this._getChartTitleEtc(d, options, numMonths));
+      newData.push(d);
+    });
+    return newData;
+  },
+
+  _addHighchartsXAndY: function(data, isGlobal, isPercentage,
+      options, centile) {
+    // Add X and Y attributes in the format that Highcharts expects.
+    var dataCopy = JSON.parse(JSON.stringify(data));
+    _.each(dataCopy, function(d, i) {
+      var dates = d.date.split('-');
+      d.x = Date.UTC(dates[0], dates[1] - 1, dates[2]);
+      if (isGlobal) {
+        var p = d.percentiles;
+        var org = options.orgType.toLowerCase();
+        d.y = (p && p[org] && p[org][centile] !== null) ?
+          parseFloat(p[org][centile]) : null;
+      } else {
+        d.y = (d.calc_value === null) ? null : parseFloat(d.calc_value);
+      }
+      if (isPercentage) {
+        d.y = (isPercentage && d.y) ? d.y * 100 : d.y;
+      }
+    });
+    return dataCopy;
+  },
+
+  _getChartTitleEtc: function(d, options, numMonths) {
+    var chartTitle;
+    var chartTitleUrl;
+    var chartExplanation;
+    if (options.rollUpBy === 'measure_id') {
+      // We want measure charts to link to the
+      // measure-by-all-practices-in-CCG page.
+      chartTitle = d.name;
+      chartTitleUrl = '/ccg/';
+      chartTitleUrl += (options.parentOrg) ? options.parentOrg : options.orgId;
+      chartTitleUrl += '/' + d.id;
+    } else {
+      // We want organisation charts to link to the appropriate
+      // organisation page.
+      chartTitle = d.id + ': ' + d.name;
+      chartTitleUrl = '/' + options.orgType.toLowerCase() +
+        '/' + d.id + '/measures';
+    }
+    if (d.meanPercentile === null) {
+      chartExplanation = 'No data available.';
+    } else if (d.isCostBased) {
+      chartExplanation = '<strong>Cost savings:</strong> ';
+      if (d.costSaving50th < 0) {
+        chartExplanation += 'By prescribing better than the median, ' +
+          'this ' + options.orgType + ' has saved the NHS £' +
+          humanize.numberFormat((d.costSaving50th * -1), 2) +
+          ' over the past ' + numMonths + ' months.';
+      } else {
+        chartExplanation += 'If it had prescribed in line with the ' +
+          'median, this ' + options.orgType + ' would have spent £' +
+          humanize.numberFormat(d.costSaving50th, 2) +
+          ' less over the past ' + numMonths + ' months.';
+      }
+    } else {
+      var p = humanize.numberFormat(d.meanPercentile, 0);
+      chartExplanation = 'This organisation was at the ' +
+        humanize.ordinal(p) +
+        ' percentile on average across the ' +
+        'past ' + numMonths + ' months.';
+    }
+    return {
+      chartTitle: chartTitle,
+      chartTitleUrl: chartTitleUrl,
+      chartExplanation: chartExplanation
+    };
+  },
+
+  getGraphOptions: function(d, options, isPercentageMeasure, chartOptions) {
+    // Assemble the series for the chart, and add chart config options.
+    if (d.data.length) {
+      var hcOptions = this._getChartOptions(d, isPercentageMeasure,
+        options, chartOptions);
+      hcOptions.series = [{
+        name: 'This ' + options.orgType,
+        isNationalSeries: false,
+        data: d.data,
+        color: 'red',
+        marker: {
+          radius: 2
+        }
+      }];
+      _.each(_.keys(d.globalCentiles), function(k) {
+        var e = {
+          name: k + 'th percentile nationally',
+          isNationalSeries: true,
+          data: d.globalCentiles[k],
+          dashStyle: 'dot',
+          color: 'blue',
+          lineWidth: 1,
+          marker: {
+            enabled: false
+          }
+        };
+        // Distinguish the median visually.
+        if (k === '50') {
+          e.dashStyle = 'longdash';
+        }
+        hcOptions.series.push(e);
+      });
+      return hcOptions;
+    }
+    return null;
+  },
+
+  _getChartOptions: function(d, isPercentageMeasure,
+        options, chartOptions) {
+    /*
+    Get Highcharts config for each chart: set
+    Y-axis minimum, maximum, and label, and tooltip.
+    */
+    var chOptions = $.extend(true, {}, chartOptions.dashOptions);
+    var localMax = _.max(d.data, _.property('y'));
+    var localMin = _.min(d.data, _.property('y'));
+    var ymax;
+    var ymin;
+    isPercentageMeasure = (d.isPercentage || isPercentageMeasure);
+    chOptions.chart.renderTo = d.chartId;
+    chOptions.chart.height = 200;
+    chOptions.legend.enabled = false;
+    if (options.rollUpBy === 'org_id') {
+      ymax = _.max([localMax.y, options.globalYMax.y]);
+      ymin = _.min([localMin.y, options.globalYMin.y]);
+    } else {
+      var local90thMax = _.max(d.globalCentiles['90'], _.property('y'));
+      ymax = _.max([localMax.y, local90thMax.y]);
+      var local90thMin = _.min(d.globalCentiles['10'], _.property('y'));
+      ymin = _.min([localMin.y, local90thMin.y]);
+    }
+    var yAxisLabel = (isPercentageMeasure) ? '%' : 'Measure';
+    chOptions.yAxis = {
+      title: {
+        text: yAxisLabel
+      },
+      max: ymax,
+        // If ymin is zero, Highcharts will sometimes pick a negative value
+        // because it prefers that formatting. Force zero as the lowest value.
+      min: _.max([0, ymin])
+    };
+    chOptions.tooltip = {
+      formatter: function() {
+        var num = humanize.numberFormat(this.point.numerator, 0);
+        var denom = humanize.numberFormat(this.point.denominator, 0);
+        var percentile = humanize.numberFormat(this.point.percentile, 0);
+        var str = '';
+        str += '<b>' + this.series.name;
+        str += ' in ' + humanize.date('M Y', new Date(this.x));
+        str += '</b><br/>';
+        if (!this.series.options.isNationalSeries) {
+          str += d.numeratorShort + ': ' + num;
+          str += '<br/>';
+          str += d.denominatorShort + ': ' + denom;
+          str += '<br/>';
+        }
+        str += 'Measure: ' + humanize.numberFormat(this.point.y, 3);
+        str += (isPercentageMeasure) ? '%' : '';
+        if (!this.series.options.isNationalSeries) {
+          str += ' (' + humanize.ordinal(percentile);
+          str += ' percentile)';
+        }
+        return str;
+      }
+    };
+    return chOptions;
+  }
+
+};
+
+module.exports = utils;

--- a/openprescribing/media/js/test/test_measures.js
+++ b/openprescribing/media/js/test/test_measures.js
@@ -1,0 +1,766 @@
+var expect = require('chai').expect;
+var mu = require('../src/measure_utils');
+
+describe('Measures', function() {
+  describe('#getDataUrls', function() {
+    it('should get the URL for all CCGs', function() {
+      var options = {
+        orgId: null,
+        orgType: 'CCG',
+        measure: null
+      };
+      var urls = mu.getDataUrls(options);
+      expect(urls.panelMeasuresUrl).to.equal('/api/1.0/measure_by_ccg/?format=json');
+      expect(urls.globalMeasuresUrl).to.equal('/api/1.0/measure/?format=json');
+    });
+
+    it('should get the URL for an organisation', function() {
+      var options = {
+        orgId: 'A81001',
+        orgType: 'practice',
+        measure: null
+      };
+      var urls = mu.getDataUrls(options);
+      expect(urls.panelMeasuresUrl).to.equal('/api/1.0/measure_by_practice/?format=json&org=A81001');
+      expect(urls.globalMeasuresUrl).to.equal('/api/1.0/measure/?format=json');
+    });
+
+    it('should get the URL for an measure', function() {
+      var options = {
+        orgId: null,
+        orgType: 'CCG',
+        measure: 'ace'
+      };
+      var urls = mu.getDataUrls(options);
+      expect(urls.panelMeasuresUrl).to.equal('/api/1.0/measure_by_ccg/?format=json&measure=ace');
+      expect(urls.globalMeasuresUrl).to.equal('/api/1.0/measure/?format=json&measure=ace');
+    });
+  });
+
+  describe('#getCentilesAndYAxisExtent', function() {
+    it('should calculate global series and y-extent correctly', function() {
+      var globalData = [{
+        data: [
+        {
+          date: '2015-01-01',
+          percentiles: {
+            practice: {10: 46, 90: 97}
+          }
+        },
+        {
+          date: '2015-02-01',
+          percentiles: {
+            practice: {10: 25, 90: 82}
+          }
+        }
+        ],
+        id: 'ace'
+      }
+      ],
+      options = {
+        rollUpBy: 'org_id',
+        measure: 'ace',
+        orgType: 'practice'
+      },
+      centiles = ["10", "20", "30", "40", "50", "60", "70", "80", "90"];
+      var result = mu.getCentilesAndYAxisExtent(globalData, options, centiles);
+      expect(result.globalYMax.y).to.equal(97);
+      expect(result.globalYMin.y).to.equal(25);
+      expect(result.globalCentiles['10'][0].x).to.equal(1420070400000);
+      expect(result.globalCentiles['10'][0].y).to.equal(46);
+      expect(result.globalCentiles['90'][0].x).to.equal(1420070400000);
+      expect(result.globalCentiles['90'][0].y).to.equal(97);
+    });
+
+    it('should do nothing when the charts are multiple measures', function() {
+      var globalData = [],
+      options = {
+        rollUpBy: 'measure_id'
+      },
+      centiles = ["10", "20", "30", "40", "50", "60", "70", "80", "90"];
+      var result = mu.getCentilesAndYAxisExtent(globalData, options, centiles);
+      expect(result.globalYMax).to.equal(0);
+      expect(result.globalYMin).to.equal(0);
+    });
+  });
+
+  describe('#annotateAndSortData', function() {
+    it('sorts organisations correctly', function() {
+      var data = [{
+        data: [
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-01-01',
+          calc_value: 8,
+          percentile: 20
+        },
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-02-01',
+          calc_value: 9,
+          percentile: 21
+        },
+        {
+          pct_id: '03V',
+          pct_name: 'NHS CORBY CCG',
+          date: '2015-01-01',
+          calc_value: 10,
+          percentile: 40
+        },
+        {
+          pct_id: '03V',
+          pct_name: 'NHS CORBY CCG',
+          date: '2015-02-01',
+          calc_value: 12,
+          percentile: 37
+        },
+        {
+          pct_id: '99P',
+          pct_name: 'NHS NORTH, EAST AND WEST DEVON CCG',
+          date: '2015-01-01',
+          calc_value: null,
+          percentile: null
+        },
+        {
+          pct_id: '99P',
+          pct_name: 'NHS NORTH, EAST AND WEST DEVON CCG',
+          date: '2015-02-01',
+          calc_value: null,
+          percentile: null
+        }
+        ],
+        id:"ace",
+        is_cost_based: true,
+        is_percentage: true,
+        name: "High-cost ACE inhibitors",
+        numerator_short: "High-cost ACEs quantity",
+        title: "TBA"
+      }];
+      var result = mu.annotateAndSortData(data,
+        {rollUpBy: 'org_id', orgType: 'CCG'}, 6);
+      expect(result.length).to.equal(3);
+      expect(result[0].name).to.equal('NHS CORBY CCG');
+      expect(result[0].meanPercentile).to.equal(38.5);
+      expect(result[0].data.length).to.equal(2);
+      expect(result[2].name).to.equal('NHS NORTH, EAST AND WEST DEVON CCG');
+      expect(result[2].meanPercentile).to.equal(null);
+      expect(result[2].data.length).to.equal(2);
+    });
+
+    it('sorts measures correctly', function() {
+      var data = [
+      {
+        id: 'ace',
+        data: [{
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-01-01',
+          calc_value: 8,
+          percentile: 20
+        },
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-02-01',
+          calc_value: 9,
+          percentile: 21
+        }]
+      },
+      {
+        id: 'arb',
+        data: [{
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-01-01',
+          calc_value: 3.48,
+          percentile: 58
+        },
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-02-01',
+          calc_value: 7.42,
+          percentile: 62
+        }]
+      },
+      {
+        id: 'statins',
+        data: [{
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-01-01',
+          calc_value: 1200,
+          percentile: 1
+        },
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-02-01',
+          calc_value: 1400,
+          percentile: 3
+        }]
+      }
+      ];
+      var result = mu.annotateAndSortData(data,
+        { rollUpBy: 'measure_id', orgType: null}, 6);
+      expect(result.length).to.equal(3);
+      expect(result[0].id).to.equal('arb');
+      expect(result[0].meanPercentile).to.equal(60);
+      expect(result[0].data.length).to.equal(2);
+    });
+  });
+
+  describe('#_rollUpByOrg', function() {
+    it('rolls up by CCG', function() {
+      var data = {
+        data: [
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-01-01',
+          calc_value: 8
+        },
+        {
+          pct_id: '04N',
+          pct_name: 'NHS RUSHCLIFFE CCG',
+          date: '2015-02-01',
+          calc_value: 9
+        },
+        {
+          pct_id: '03V',
+          pct_name: 'NHS CORBY CCG',
+          date: '2015-01-01',
+          calc_value: 10
+        },
+        {
+          pct_id: '03V',
+          pct_name: 'NHS CORBY CCG',
+          date: '2015-02-01',
+          calc_value: 12
+        }
+        ],
+        id:"ace",
+        is_cost_based: true,
+        is_percentage: true,
+        name: "High-cost ACE inhibitors",
+        numerator_short: "High-cost ACEs quantity",
+        title: "TBA"
+      };
+      var result = mu._rollUpByOrg(data, 'CCG');
+      expect(result.length).to.equal(2);
+      expect(result[0].data[0].date).to.equal('2015-01-01');
+    });
+
+    it('rolls up by practice', function() {
+      var data = {
+        data: [
+        {
+          practice_id: 'A81001',
+          practice_name: 'foo',
+          date: '2015-01-01',
+          calc_value: 8
+        },
+        {
+          practice_id: 'A81001',
+          practice_name: 'foo',
+          date: '2015-02-01',
+          calc_value: 9
+        },
+        {
+          practice_id: 'A81002',
+          practice_name: 'bar',
+          date: '2015-01-01',
+          calc_value: 10
+        },
+        {
+          practice_id: 'A81002',
+          practice_name: 'bar',
+          date: '2015-02-01',
+          calc_value: 12
+        }
+        ],
+        id:"ace",
+        is_cost_based: true,
+        is_percentage: true,
+        name: "High-cost ACE inhibitors",
+        numerator_short: "High-cost ACEs quantity",
+        title: "TBA"
+      };
+      var result = mu._rollUpByOrg(data, 'practice');
+      expect(result.length).to.equal(2);
+      expect(result[0].data[0].date).to.equal('2015-01-01');
+    });
+  });
+
+  describe('#_getSavingAndPercentilePerItem', function() {
+
+    it('should get mean cost saving and percentile across last N months', function() {
+      var data = [{
+        data: [
+        {date: '2015-01-01', percentile: 21, cost_savings: { 50: 7 }},
+        {date: '2015-02-01', percentile: 22, cost_savings: { 50: 7 }},
+        {date: '2015-03-01', percentile: 19, cost_savings: { 50: 7 }},
+        {date: '2015-04-01', percentile: 16, cost_savings: { 50: 7 }},
+        {date: '2015-05-01', percentile: 15, cost_savings: { 50: 7 }},
+        {date: '2015-06-01', percentile: 19, cost_savings: { 50: 12 }},
+        {date: '2015-07-01', percentile: 18, cost_savings: { 50: 81 }},
+        {date: '2015-08-01', percentile: 16, cost_savings: { 50: 12.8 }},
+        {date: '2015-09-01', percentile: 13, cost_savings: { 50: 12.4 }},
+        {date: '2015-10-01', percentile: 12, cost_savings: { 50: 10 }},
+        {date: '2015-11-01', percentile: 12, cost_savings: { 50: 8 }},
+        {date: '2015-12-01', percentile: 7, cost_savings: { 50: 7 }},
+        ]
+      }];
+      var result = mu._getSavingAndPercentilePerItem(data, 6);
+      expect(result[0].meanPercentile).to.equal(13);
+      expect(result[0].costSaving50th).to.equal(131.2);
+    });
+
+    it('should handle intermittent null elements correctly', function() {
+      var data = [{
+        data: [
+        {date: '2015-07-01', percentile: 2, cost_savings: { 50: -20 }},
+        {date: '2015-08-01', percentile: null, cost_savings: null},
+        {date: '2015-09-01', percentile: 3, cost_savings: { 50: -10 }},
+        {date: '2015-10-01', percentile: 2, cost_savings: { 50: -10 }},
+        {date: '2015-11-01', percentile: 0, cost_savings: { 50: -10 }},
+        {date: '2015-12-01', percentile: 4, cost_savings: { 50: -10 }},
+        ]
+      }];
+      var result = mu._getSavingAndPercentilePerItem(data, 6);
+      expect(result[0].meanPercentile).to.equal(11/5);
+      expect(result[0].costSaving50th).to.equal(-60);
+    });
+
+    it('should handle entirely null data correctly', function() {
+      var data = [{
+        data: [
+        {date: '2015-07-01', percentile: null, cost_savings: null},
+        {date: '2015-08-01', percentile: null, cost_savings: null},
+        {date: '2015-09-01', percentile: null, cost_savings: null},
+        {date: '2015-10-01', percentile: null, cost_savings: null},
+        {date: '2015-11-01', percentile: null, cost_savings: null},
+        {date: '2015-12-01', percentile: null, cost_savings: null},
+        ]
+      }];
+      var result = mu._getSavingAndPercentilePerItem(data, 6);
+      expect(result[0].meanPercentile).to.equal(null);
+      expect(result[0].costSaving50th).to.equal(0);
+    });
+
+    it('should handle a short data array', function() {
+      var data = [{
+        data: [
+        {date: '2015-10-01', percentile: 12, cost_savings: { 50: 10 }},
+        {date: '2015-11-01', percentile: 12, cost_savings: { 50: 8 }},
+        {date: '2015-12-01', percentile: 6, cost_savings: { 50: 7 }},
+        ]
+      }];
+      var result = mu._getSavingAndPercentilePerItem(data, 6);
+      expect(result[0].meanPercentile).to.equal(10);
+      expect(result[0].costSaving50th).to.equal(25);
+    });
+
+    it('should handle an empty data array', function() {
+      var data = [{
+        data: []
+      }];
+      var result = mu._getSavingAndPercentilePerItem(data, 6);
+      expect(result[0].data.length).to.equal(0);
+    });
+  });
+
+  describe('#getPerformanceSummary', function() {
+
+    it('gets summaries for a single measure across organisations', function() {
+      var data = [
+      { meanPercentile: 100, costSaving50th: 100 },
+      { meanPercentile: 77, costSaving50th: 100 },
+      { meanPercentile: 60, costSaving50th: 100 },
+      { meanPercentile: 50, costSaving50th: 0 },
+      { meanPercentile: 30, costSaving50th: -100 },
+      { meanPercentile: 21, costSaving50th: -100 },
+      { meanPercentile: 11, costSaving50th: -100 }
+      ];
+      var options = {
+        rollUpBy: 'org_id',
+        isCostBasedMeasure: true,
+        orgId: null,
+        orgType: 'CCG',
+        measure: 'statins'
+      };
+      var result = mu.getPerformanceSummary(data, options, 6);
+      expect(result.total).to.equal(7);
+      expect(result.aboveMedian).to.equal(3);
+      expect(result.proportionAboveMedian).to.equal('42.9');
+      expect(result.potentialSavings50th).to.equal(300);
+      expect(result.rank).to.equal('good');
+      var str = "Over the past 6 months, 3 of 7 CCGs have prescribed ";
+      str += 'above the national median. We think this is good ';
+      str += 'performance overall.';
+      expect(result.performanceDescription).to.equal(str);
+      str = 'Over the past 6 months, if all CCGs had prescribed at ';
+      str += 'the median ratio or better, then NHS England would have ';
+      str += 'spent £300.00 less. (We use the national median as a ';
+      str += 'suggested target because by definition, 50% of CCGs ';
+      str += 'were already prescribing at this level or better, so ';
+      str += 'we think it ought to be achievable.)';
+      expect(result.costSavings).to.equal(str);
+    });
+
+    it('gets summaries for all measures across one organisation', function() {
+      var data = [
+      { meanPercentile: 14 },
+      { meanPercentile: 33 },
+      { meanPercentile: 82, costSaving50th: 12000 },
+      { meanPercentile: 50 },
+      { meanPercentile: 30 },
+      { meanPercentile: 21, costSaving50th: -200 }
+      ];
+      var options = {
+        rollUpBy: 'measure_id',
+        isCostBasedMeasure: true,
+        orgId: 'A81001',
+        orgType: 'practice',
+        measure: null
+      };
+      var result = mu.getPerformanceSummary(data, options, 6);
+      expect(result.total).to.equal(6);
+      expect(result.aboveMedian).to.equal(1);
+      expect(result.proportionAboveMedian).to.equal('16.7');
+      expect(result.potentialSavings50th).to.equal(12000);
+      expect(result.rank).to.equal('very good');
+      var str = "Over the past 6 months, this organisation has ";
+      str += "prescribed above the median on 1 of 6 measures. We ";
+      str += "think this is very good performance overall.";
+      expect(result.performanceDescription).to.equal(str);
+      str = "Over the past 6 months, if this practice  had prescribed ";
+      str += "at the median ratio or better on all cost-saving measures ";
+      str += "below, then it would have spent £12,000.00 less. (We use ";
+      str += "the national median as a suggested target because by ";
+      str += "definition, 50% of practices were already prescribing ";
+      str += "at this level or better, so we think it ought to be ";
+      str += "achievable.)";
+      expect(result.costSavings).to.equal(str);
+    });
+
+    it('handles empty data', function() {
+      var options = {
+        rollUpBy: 'org_id',
+        isCostBasedMeasure: true,
+        orgId: null,
+        orgType: 'CCG',
+        measure: 'ace'
+      };
+      var result = mu.getPerformanceSummary([], options, null);
+      var str = "This organisation hasn't prescribed on any of these measures.";
+      expect(result.performanceDescription).to.equal(str);
+    });
+
+  });
+
+  describe('#addChartAttributes', function() {
+
+    it('sets the expected title, URL, and descriptions for all-CCG charts', function() {
+      var data = [
+      {
+        id: '10W',
+        name: 'NHS SOUTH READING CCG',
+        meanPercentile: 80,
+        costSaving50th: 10,
+        isCostBased: true,
+        data: []
+      }
+      ],
+      globalData = [],
+      globalCentiles = [],
+      centiles = ['10'],
+      options = {
+        rollUpBy: 'org_id',
+        orgType: 'CCG',
+        orgId: null,
+        parentOrg: null
+      };
+      var result = mu.addChartAttributes(data, globalData, globalCentiles,
+        centiles, options, 6);
+      expect(result[0].chartTitle).to.equal('10W: NHS SOUTH READING CCG');
+      expect(result[0].chartTitleUrl).to.equal('/ccg/10W/measures');
+      str = '<strong>Cost savings:</strong> If it had prescribed in line ';
+      str += 'with the median, this CCG would have spent £10.00 less ';
+      str += 'over the past 6 months.';
+      expect(result[0].chartExplanation).to.equal(str);
+    });
+
+    it('sets the expected title, URL, and descriptions for non-cost-based all-CCG charts', function() {
+      var data = [
+      {
+        id: '10W',
+        name: 'NHS SOUTH READING CCG',
+        meanPercentile: 80,
+        isCostBased: false,
+        data: []
+      }
+      ],
+      globalData = [],
+      globalCentiles = [],
+      centiles = ['10'],
+      options = {
+        rollUpBy: 'org_id',
+        orgType: 'CCG',
+        orgId: null,
+        parentOrg: null
+      };
+      var result = mu.addChartAttributes(data, globalData, globalCentiles,
+        centiles, options, 6);
+      expect(result[0].chartTitle).to.equal('10W: NHS SOUTH READING CCG');
+      expect(result[0].chartTitleUrl).to.equal('/ccg/10W/measures');
+      var str = 'This organisation was at the 80th percentile ';
+      str += 'on average across the past 6 months.';
+      expect(result[0].chartExplanation).to.equal(str);
+    });
+
+    it('sets the expected title, URL, and descriptions for one-CCG measure charts', function() {
+      var data = [
+      {
+        id: 'ace',
+        name: 'ACE',
+        meanPercentile: 80,
+        costSaving50th: 10,
+        isCostBased: true,
+        data: []
+      }
+      ],
+      globalData = [{ id: 'ace', data: []}],
+      globalCentiles = [],
+      centiles = ['10'],
+      options = {
+        rollUpBy: 'measure_id',
+        orgType: 'CCG',
+        orgId: '03V',
+        parentOrg: null
+      };
+      var result = mu.addChartAttributes(data, globalData, globalCentiles,
+        centiles, options, 6);
+      expect(result[0].chartTitle).to.equal('ACE');
+      expect(result[0].chartTitleUrl).to.equal('/ccg/03V/ace');
+      str = '<strong>Cost savings:</strong> If it had prescribed in line ';
+      str += 'with the median, this CCG would have spent £10.00 less ';
+      str += 'over the past 6 months.';
+      expect(result[0].chartExplanation).to.equal(str);
+    });
+
+    it('sets the expected title, URL, and descriptions for measure practice charts', function() {
+      var data = [
+      {
+        id: 'ace',
+        name: 'ACE',
+        meanPercentile: 80,
+        costSaving50th: 10,
+        isCostBased: true,
+        data: []
+      }
+      ],
+      globalData = [{ id: 'ace', data: []}],
+      globalCentiles = [],
+      centiles = ['10'],
+      options = {
+        rollUpBy: 'measure_id',
+        orgType: 'practice',
+        orgId: 'A81001',
+        parentOrg: '03V'
+      };
+      var result = mu.addChartAttributes(data, globalData, globalCentiles,
+        centiles, options, 6);
+      expect(result[0].chartTitle).to.equal('ACE');
+      expect(result[0].chartTitleUrl).to.equal('/ccg/03V/ace');
+      str = '<strong>Cost savings:</strong> If it had prescribed in line ';
+      str += 'with the median, this practice would have spent £10.00 less ';
+      str += 'over the past 6 months.';
+      expect(result[0].chartExplanation).to.equal(str);
+    });
+  });
+
+  describe('#_addHighchartsXAndY', function() {
+    it('should convert global data correctly', function() {
+      var data = [
+      { date: '2015-01-01', percentiles: { 'ccg': { '10': 2.1} }},
+      { date: '2015-02-01', percentiles: { 'ccg': { '10': 2.4} }},
+      { date: '2015-03-01', percentiles: { 'ccg': { '10': 2.2} }}
+      ];
+      var options = {'orgType': 'ccg'};
+      var result = mu._addHighchartsXAndY(data, true, false, options, '10');
+      expect(result.length).to.equal(3);
+      expect(result[0].x).to.equal(1420070400000);
+      expect(result[0].y).to.equal(2.1);
+    });
+
+    it('should multiply percentages by 100 for display purposes', function() {
+      var data = [
+      { date: '2015-01-01', calc_value: '0.08'},
+      { date: '2015-02-01', calc_value: '0.04'},
+      { date: '2015-03-01', calc_value: '0.05'}
+      ];
+      var options = {};
+      var result = mu._addHighchartsXAndY(data, false, true, options, null);
+      expect(result.length).to.equal(3);
+      expect(result[0].x).to.equal(1420070400000);
+      expect(result[0].y).to.equal(8);
+    });
+  });
+
+  describe('#_getChartTitleEtc', function() {
+    it('should get explanation for cost-based measures', function() {
+      var d = {
+        id: 'ace',
+        name: 'ACE',
+        meanPercentile: 80,
+        costSaving50th: 10,
+        isCostBased: true,
+        data: []
+      },
+      options = {
+        rollUpBy: 'measure_id',
+        orgType: 'practice',
+        orgId: 'A81001',
+        parentOrg: '03V'
+      };
+      var result = mu._getChartTitleEtc(d, options, 6);
+      expect(result.chartTitle).to.equal('ACE');
+      expect(result.chartTitleUrl).to.equal('/ccg/03V/ace');
+      str = '<strong>Cost savings:</strong> If it had prescribed in line ';
+      str += 'with the median, this practice would have spent £10.00 less ';
+      str += 'over the past 6 months.';
+      expect(result.chartExplanation).to.equal(str);
+    });
+
+    it('should get explanation for non-cost-based measures', function() {
+      var d = {
+        id: 'ace',
+        name: 'ACE',
+        meanPercentile: 80,
+        costSaving50th: null,
+        isCostBased: false,
+        data: []
+      },
+      options = {
+        rollUpBy: 'measure_id',
+        orgType: 'practice',
+        orgId: 'A81001',
+        parentOrg: '03V'
+      };
+      var result = mu._getChartTitleEtc(d, options, 6);
+      expect(result.chartTitle).to.equal('ACE');
+      expect(result.chartTitleUrl).to.equal('/ccg/03V/ace');
+      str = 'This organisation was at the 80th percentile ';
+      str += 'on average across the past 6 months.';
+      expect(result.chartExplanation).to.equal(str);
+    });
+  });
+
+  describe('#_getChartOptions', function() {
+
+    it('sets correct Highcharts options for % measures', function() {
+      var d = {
+        data: [{x: 0, y: 60}, {x: 10, y: 0}]
+      },
+      options = {
+        rollUpBy: 'org_id',
+        globalYMax: {y: 100},
+        globalYMin: {y: 10}
+      },
+      chartOptions = {dashOptions: { chart: {}, legend: {}}};
+      var result = mu._getChartOptions(d, true,
+        options, chartOptions);
+      expect(result.yAxis.title.text).to.equal('%');
+      expect(result.yAxis.min).to.equal(0);
+      expect(result.yAxis.max).to.equal(100);
+      var point = {
+        x: '2015-01-01',
+        point: {
+          numerator: 10,
+          denominator: 30,
+          percentile: 60,
+          y: 0.3333333
+        },
+        series: {
+          name: 'Foo',
+          options: {
+            isNationalSeries: true
+          }
+        }
+      };
+      var tooltip = result.tooltip.formatter.call(point);
+      var str = '<b>Foo in Jan 2015</b><br/>Measure: 0.333%';
+      expect(tooltip).to.equal(str);
+    });
+
+    it('sets correct Highcharts options for non-% measures', function() {
+      var d = {
+        data: [{x: 0, y: 90}, {x: 10, y: 10}],
+        numeratorShort: 'foo',
+        denominatorShort: 'bar'
+      },
+      options = {
+        rollUpBy: 'org_id',
+        globalYMax: { y: 50},
+        globalYMin: { y: 0}
+      },
+      chartOptions = { dashOptions: { chart: {}, legend: {}}};
+      var result = mu._getChartOptions(d, false,
+        options, chartOptions);
+      expect(result.yAxis.title.text).to.equal('Measure');
+      expect(result.yAxis.min).to.equal(0);
+      expect(result.yAxis.max).to.equal(90);
+      var point = {
+        x: '2015-01-01',
+        point: {
+          numerator: 10,
+          denominator: 30,
+          percentile: 60,
+          y: 0.3333333
+        },
+        series: {
+          name: 'Bar',
+          options: {
+            isNationalSeries: false
+          }
+        }
+      };
+      var tooltip = result.tooltip.formatter.call(point);
+      var str = '<b>Bar in Jan 2015</b><br/>foo: 10<br/>';
+      str += 'bar: 30<br/>Measure: 0.333 (60th percentile)';
+      expect(tooltip).to.equal(str);
+    });
+  });
+
+  describe('#getGraphOptions', function() {
+    it('should amalgamate the series correctly', function() {
+      var d = {
+        data: [{x: 0, y: 12}, {x: 10, y: 10}],
+        numeratorShort: 'foo',
+        denominatorShort: 'bar',
+        globalCentiles: {
+          10: [{ x: 0, y: 2}, { x: 10, y: 3}],
+          50: [{ x: 0, y: 45}, { x: 10, y: 46}],
+          90: [{ x: 0, y: 88}, { x: 10, y: 92}],
+        }
+      },
+      options = {
+        orgType: 'CCG',
+        rollUpBy: 'org_id',
+        globalYMax: { y: 50},
+        globalYMin: { y: 0}
+      },
+      chartOptions = { dashOptions: { chart: {}, legend: {}}};
+      var result = mu.getGraphOptions(d, options, true, chartOptions);
+      expect(result.series.length).to.equal(4);
+      expect(result.series[0].name).to.equal('This CCG');
+      expect(result.series[2].name).to.equal('50th percentile nationally');
+      expect(result.series[2].isNationalSeries).to.equal(true);
+      expect(result.series[2].dashStyle).to.equal('longdash');
+
+    });
+  });
+});

--- a/openprescribing/templates/measure_for_all_ccgs.html
+++ b/openprescribing/templates/measure_for_all_ccgs.html
@@ -41,21 +41,21 @@
 
 {% verbatim %}
 <script id="summary-panel" type="text/x-handlebars-template">
-{{ cost_savings }}
+{{ costSavings }}
 </script>
 
 <script id="measure-panel" type="text/x-handlebars-template">
 <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
     <div class="panel panel-info">
         <div class="panel-heading">
-            <a href="{{ chart_title_url }}">{{ chart_title }}</a>
+            <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
         </div>
-        <div class="panel-body" id="{{ chart_id }}" data-costsaving="{{ cost_saving }}">
+        <div class="panel-body" id="{{ chartId }}" data-costsaving="{{ cost_saving }}">
             <div class="chart">
                 <div class="status"></div>
             </div>
         </div>
-        <div class="explanation">{{{ chart_explanation }}}</div>
+        <div class="explanation">{{{ chartExplanation }}}</div>
     </div>
 </div>
 </script>
@@ -65,8 +65,7 @@
 var measureData = {
     'orgType': 'CCG',
     'measure': '{{ measure.id }}',
-    'measureIsCostBased': '{{ measure.is_cost_based }}',
-    'measureIsPercentage': '{{ measure.is_percentage }}',
+    'isCostBasedMeasure': '{{ measure.is_cost_based }}',
     'numerator': '{{ measure.numerator_short }}',
     'denominator': '{{ measure.denominator_short }}'
 };

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+f{% extends "base.html" %}
 {% load humanize %}
 {% load template_extras %}
 
@@ -40,23 +40,23 @@
 </div>
 
 {% verbatim %}
-<script id="summary-panel" type="text/x-handlebars-template">{{ performance_description }}
-
-{{ cost_savings }}
+<script id="summary-panel" type="text/x-handlebars-template">
+{{ performanceDescription }}
+{{ costSavings }}
 </script>
 
 <script id="measure-panel" type="text/x-handlebars-template">
 <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
     <div class="panel panel-info">
         <div class="panel-heading">
-            <a href="{{ chart_title_url }}">{{ chart_title }}</a>
+            <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
         </div>
-        <div class="panel-body" id="{{ chart_id }}" data-costsaving="{{ cost_saving }}">
+        <div class="panel-body" id="{{ chartId }}" data-costsaving="{{ cost_saving }}">
             <div class="chart">
                 <div class="status"></div>
             </div>
         </div>
-        <div class="explanation">{{{ chart_explanation }}}</div>
+        <div class="explanation">{{{ chartExplanation }}}</div>
     </div>
 </div>
 </script>
@@ -68,8 +68,7 @@ var measureData = {
     'orgName': '{{ ccg.name }}',
     'orgType': 'practice',
     'measure': '{{ measure.id }}',
-    'measure_is_cost_based': '{{ measure.is_cost_based }}',
-    'measureIsPercentage': '{{ measure.is_percentage }}',
+    'isCostBasedMeasure': '{{ measure.is_cost_based }}',
     'numerator': '{{ measure.numerator_short }}',
     'denominator': '{{ measure.denominator_short }}'
 };

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -11,9 +11,9 @@
 
 {% block content %}
 
-<h1>{{measure.name}} prescribing by practices in {{ ccg.name }}</h1>
+<h1>{{measure.name}} prescribing by GP practices in {{ ccg.name }}</h1>
 
-<p>How GP practices in {{ ccg.name }} prescribed {{ measure.title }}.</p>
+<p>How standard GP practices in {{ ccg.name }} prescribed {{ measure.title }}.</p>
 
 {% if measure.url %}
 <p>Read <a href="{{ measure.url }}">more about this measure</a>.</p>

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -24,7 +24,7 @@
 class='hidden'
 {% endif %}
 >
-<a href="{% url 'practice' p.code %}/measures">{{ p }}</a>
+<a href="{% url 'practice' p.code %}measures">{{ p }}</a>
 ({{ p.get_setting_display }})
 </li>
 {% endfor %}

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -44,7 +44,7 @@ class='hidden'
 
 <div id="intro">
 
-<p>Blah blah blah brief intro to measures, explaining what these measures are, what the ordering means and why they matter. <a href='{% url 'caution' %}#metrics'>Read more about measures</a>.</p>
+<p>We have brought together various prescribing measures to show how this organisation compares with its peers across NHS England. These are indicative only, and should be approached with caution. <a href='{% url 'caution' %}#metrics'>Read more about measures</a>.</p>
 
 <p id="perfsummary">Loading...</p>
 

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -92,7 +92,7 @@ class='hidden'
                 <p><strong>Why it matters:</strong> {{ why_it_matters }}</p>
                 <p><strong>Description:</strong> {{ description }}</p>
                 <p>{{{ cost_description }}}</p>
-                <p><strong>Explore:</strong> see <a href="/ccg/99P/{{ chart_id }}">how all practices in this CCG</a> contribute to this CCG's performance.</p>
+                <p><strong>Explore:</strong> see <a href="{{ chart_title_url }}">how all practices in this CCG</a> contribute to this CCG's performance.</p>
             </div>
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="{{ chart_id }}">
                 <div class="status"></div>

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -16,7 +16,7 @@
 <div class="row" id="intro">
 
 <div class="col-md-6">
-<p>Practices currently in this CCG:</p>
+<p>Standard practices currently in this CCG:</p>
 <ul class="list-unstyled" id="practices">
 {% for p in practices %}
 <li

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -73,28 +73,28 @@ class='hidden'
 
 {% verbatim %}
 <script id="summary-panel" type="text/x-handlebars-template">
-<p>{{ performance_description }}</p>
+<p>{{ performanceDescription }}</p>
 
-{{ top_opportunity }}
+{{ topOpportunity }}
 
-{{{ cost_savings }}}
+{{{ costSavings }}}
 
 </script>
 
 <script id="measure-panel" type="text/x-handlebars-template">
-<div id="measure_{{ chart_id }}" class="col-xs-12 col-sm-12 col-md-12 col-lg-12 chart" data-id="{{ chart_id }}" data-costsaving="{{ cost_saving_50th }}">
+<div id="measure_{{ chartId }}" class="col-xs-12 col-sm-12 col-md-12 col-lg-12 chart" data-id="{{ chartId }}" data-costsaving="{{ costSaving50th }}">
     <div class="panel panel-info">
         <div class="panel-heading">
-            <a href="{{ chart_title_url }}">{{ chart_title }}</a>
+            <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
         </div>
         <div class="panel-body" class="row">
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
                 <p><strong>Why it matters:</strong> {{ why_it_matters }}</p>
                 <p><strong>Description:</strong> {{ description }}</p>
-                <p>{{{ cost_description }}}</p>
-                <p><strong>Explore:</strong> see <a href="{{ chart_title_url }}">how all practices in this CCG</a> contribute to this CCG's performance.</p>
+                <p>{{{ costDescription }}}</p>
+                <p><strong>Explore:</strong> see <a href="{{ chartTitleUrl }}">how all practices in this CCG</a> contribute to this CCG's performance.</p>
             </div>
-            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="{{ chart_id }}">
+            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="{{ chartId }}">
                 <div class="status"></div>
             </div>
         </div>

--- a/openprescribing/templates/measures_for_one_practice.html
+++ b/openprescribing/templates/measures_for_one_practice.html
@@ -69,28 +69,28 @@
 
 {% verbatim %}
 <script id="summary-panel" type="text/x-handlebars-template">
-<p>{{ performance_description }}</p>
+<p>{{ performanceDescription }}</p>
 
-{{ top_opportunity }}
+{{ topOpportunity }}
 
-{{ cost_savings }}
+{{ costSavings }}
 
 </script>
 
 <script id="measure-panel" type="text/x-handlebars-template">
-<div id="measure_{{ chart_id }}" class="col-xs-12 col-sm-12 col-md-12 col-lg-12 chart" data-id="{{ chart_id }}" data-costsaving="{{ cost_saving_50th }}">
+<div id="measure_{{ chartId }}" class="col-xs-12 col-sm-12 col-md-12 col-lg-12 chart" data-id="{{ chartId }}" data-costsaving="{{ costSaving50th }}">
     <div class="panel panel-info">
         <div class="panel-heading">
-            <a href="{{ chart_title_url }}">{{ chart_title }}</a>
+            <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
         </div>
         <div class="panel-body" class="row">
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
                 <p><strong>Why it matters:</strong> {{ why_it_matters }}</p>
                 <p><strong>Description:</strong> {{ description }}</p>
-                <p>{{{ cost_description }}}</p>
-                <p><strong>Explore:</strong> prescribing of this measure by <a href="{{ chart_title_url }}">other practices in the same CCG</a>.</p>
+                <p>{{{ costDescription }}}</p>
+                <p><strong>Explore:</strong> prescribing of this measure by <a href="{{ chartTitleUrl }}">other practices in the same CCG</a>.</p>
             </div>
-            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="{{ chart_id }}">
+            <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6" id="{{ chartId }}">
                 <div class="status"></div>
             </div>
         </div>

--- a/openprescribing/templates/measures_for_one_practice.html
+++ b/openprescribing/templates/measures_for_one_practice.html
@@ -18,7 +18,7 @@
 <div class="col-md-6">
 <p class="lead">Address: {{ practice.address_pretty }}</p>
 {% if practice.ccg %}
-<p class="lead">Part of CCG: <a href="{% url 'ccg' practice.ccg.code %}/measures">{{ practice.ccg.name }}</a></p>
+<p class="lead">Part of CCG: <a href="{% url 'ccg' practice.ccg.code %}measures">{{ practice.ccg.name }}</a></p>
 {% endif %}
 {% if practice.list_size_13 %}
 <p class="lead">Registered patients in 2013/14: {{ practice.list_size_13|intcomma }}</p>

--- a/openprescribing/templates/measures_for_one_practice.html
+++ b/openprescribing/templates/measures_for_one_practice.html
@@ -40,7 +40,7 @@
 </div>
 {% endif %}
 
-<p>Blah blah blah brief intro to measures, explaining what these measures are, what the ordering means and why they matter. <a href="{% url 'caution' %}#metrics">Read more about measures</a>.</p>
+<p>>We have brought together various prescribing measures to show how this organisation compares with its peers across NHS England. These are indicative only, and should be approached with caution. <a href="{% url 'caution' %}#metrics">Read more about measures</a>.</p>
 
 <p id="perfsummary">Loading...</p>
 


### PR DESCRIPTION
A couple of typo fixes, plus more significant improvements:

1. Show only standard practices on measures pages. We only use standard practices to calculate our CCG-level measures, and therefore we should only show these practices on CCG pages.

2. Make this code less of a giant hairball of doom. Create a separate file for data logic. Add tests for this file. Keep only presentation logic in the original file. This changes nothing visible on the front-end, but makes the code much more maintainable, and will be a good basis for using a framework in the future.

Fixes #66 among other things.  