### PR TITLE
Consistently normalise `isPercentage` variable

### DIFF
--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -124,6 +124,10 @@ var utils = {
         var saving = (num.cost_savings) ? num.cost_savings['50'] : null;
         return memo + saving;
       }, null);
+      // normalise to camelcase convention
+      if (!('isPercentage' in d)) {
+        d.isPercentage = d.is_percentage;
+      }
       if (!('numeratorShort' in d)) {
         d.numeratorShort = d.numerator_short;
         d.denominatorShort = d.denominator_short;
@@ -245,7 +249,7 @@ var utils = {
     var newData = [];
     _.each(data, function(d) {
       d.data = _this._addHighchartsXAndY(d.data, false,
-        d.is_percentage, options, null);
+        d.isPercentage, options, null);
       if (options.rollUpBy === 'measure_id') {
         // If each chart is a different measure, get the
         // centiles for that measure.

--- a/openprescribing/media/js/test/test_measures.js
+++ b/openprescribing/media/js/test/test_measures.js
@@ -143,6 +143,7 @@ describe('Measures', function() {
       expect(result.length).to.equal(3);
       expect(result[0].name).to.equal('NHS CORBY CCG');
       expect(result[0].meanPercentile).to.equal(38.5);
+      expect(result[0].isPercentage).to.be.true
       expect(result[0].data.length).to.equal(2);
       expect(result[2].name).to.equal('NHS NORTH, EAST AND WEST DEVON CCG');
       expect(result[2].meanPercentile).to.equal(null);
@@ -153,6 +154,7 @@ describe('Measures', function() {
       var data = [
       {
         id: 'ace',
+        is_percentage: true,
         data: [{
           pct_id: '04N',
           pct_name: 'NHS RUSHCLIFFE CCG',
@@ -170,6 +172,7 @@ describe('Measures', function() {
       },
       {
         id: 'arb',
+        is_percentage: true,
         data: [{
           pct_id: '04N',
           pct_name: 'NHS RUSHCLIFFE CCG',
@@ -187,6 +190,7 @@ describe('Measures', function() {
       },
       {
         id: 'statins',
+        is_percentage: true,
         data: [{
           pct_id: '04N',
           pct_name: 'NHS RUSHCLIFFE CCG',
@@ -208,6 +212,7 @@ describe('Measures', function() {
       expect(result.length).to.equal(3);
       expect(result[0].id).to.equal('arb');
       expect(result[0].meanPercentile).to.equal(60);
+      expect(result[0].isPercentage).to.be.true
       expect(result[0].data.length).to.equal(2);
     });
   });


### PR DESCRIPTION
`is_percentage` is the variable name on the Measures model in Django,
and the REST representation in the API.

`isPercentage` is supposed to be the variable name in javascript per our
house style.

Fixes #99 