### PR TITLE
Add missing measure description and links. 

### DIFF
--- a/openprescribing/frontend/management/commands/measure_definitions/bens.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/bens.json
@@ -148,10 +148,11 @@
         ],
         "description": [
             "Prescribing of high-cost ACE inhibitors ",
-            "as a percentage of prescribing of all ACE inhibitors."
+            "as a percentage of prescribing of all ACE inhibitors.",
+            "See the <a href='https://docs.google.com/spreadsheets/d/1VEvnh3iBUk4vjn6iHO5ax0e3YMJyXaWGZpWl0DD8VS4/edit#gid=1417276769'>full list of BNF codes used in this measure</a>."
         ],
         "why_it_matters": [
-            "TBA"
+            "All commonly-used ACE inhibitors are now available generically and are low-cost. There is no difference between these generic versions and the more expensive brands, and so it’s important that practices prescribe the most cost-effective version possible."
         ],
         "num": ["Quantity for high-cost ACEs"],
         "denom": ["Quantity for all included ACEs"],
@@ -189,7 +190,9 @@
         ],
         "description": [
             "Prescribing of high-cost ARBs ",
-            "as a percentage of prescribing of all ARBs."
+            "as a percentage of prescribing of all ARBs.",
+            "See the <a href='https://docs.google.com/spreadsheets/d/1VEvnh3iBUk4vjn6iHO5ax0e3YMJyXaWGZpWl0DD8VS4/edit#gid=1417276769'>full list of BNF codes used in this measure</a>."
+
         ],
         "why_it_matters": [
             "Various angiotensin receptor blockers (ARBs) are available. A number of them are now available generically, and are of low cost. NICE guidance for treating high blood pressure recommends that the low-cost versions should be used."
@@ -230,7 +233,9 @@
         ],
         "description": [
             "Prescribing of high-cost PPIs ",
-            "as a percentage of prescribing of all PPIs."
+            "as a percentage of prescribing of all PPIs.",
+            "See the <a href='https://docs.google.com/spreadsheets/d/1VEvnh3iBUk4vjn6iHO5ax0e3YMJyXaWGZpWl0DD8VS4/edit#gid=1417276769'>full list of BNF codes used in this measure</a>."
+
         ],
         "why_it_matters": [
             "TBA"
@@ -271,7 +276,9 @@
         ],
         "description": [
             "Prescribing of high-cost statins ",
-            "as a percentage of prescribing of all statins."
+            "as a percentage of prescribing of all statins.",
+            "See the <a href='https://docs.google.com/spreadsheets/d/1VEvnh3iBUk4vjn6iHO5ax0e3YMJyXaWGZpWl0DD8VS4/edit#gid=1417276769'>full list of BNF codes used in this measure</a>."
+
         ],
         "why_it_matters": [
             "When treating high cholesterol, doctors are recommended to prescribe statins which are both low-cost, and reduce cholesterol by at least 40%. The low-cost statins (simvastatin and atorvastatin) are suitable for the majority of patients."

--- a/openprescribing/templates/measure_for_all_ccgs.html
+++ b/openprescribing/templates/measure_for_all_ccgs.html
@@ -17,7 +17,7 @@
 
 <p><strong>Why it matters</strong>: {{ measure.why_it_matters }}</p>
 
-<p><strong>Definition</strong>: {{ measure.description }}</p>
+<p><strong>Definition</strong>: {% autoescape off %} {{ measure.description }} {% endautoescape %}</p>
 
 {% if measure.is_cost_based %}
 

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -21,7 +21,7 @@ f{% extends "base.html" %}
 
 <p><strong>Why it matters</strong>: {{ measure.why_it_matters }}</p>
 
-<p><strong>Definition</strong>: {{ measure.description }}</p>
+<p><strong>Definition</strong>: {% autoescape off %} {{ measure.description }} {% endautoescape %}</p>
 
 <p><strong>How this CCG is doing:</strong> <span id="perfsummary">Loading...</span> See <a href="/ccg/{{ ccg.code }}/measures">how this CCG is doing on other measures</a>.</p>
 

--- a/openprescribing/templates/measures_for_one_ccg.html
+++ b/openprescribing/templates/measures_for_one_ccg.html
@@ -90,7 +90,7 @@ class='hidden'
         <div class="panel-body" class="row">
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
                 <p><strong>Why it matters:</strong> {{ why_it_matters }}</p>
-                <p><strong>Description:</strong> {{ description }}</p>
+                <p><strong>Description:</strong> {{{ description }}}</p>
                 <p>{{{ costDescription }}}</p>
                 <p><strong>Explore:</strong> see <a href="{{ chartTitleUrl }}">how all practices in this CCG</a> contribute to this CCG's performance.</p>
             </div>

--- a/openprescribing/templates/measures_for_one_practice.html
+++ b/openprescribing/templates/measures_for_one_practice.html
@@ -86,7 +86,7 @@
         <div class="panel-body" class="row">
             <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
                 <p><strong>Why it matters:</strong> {{ why_it_matters }}</p>
-                <p><strong>Description:</strong> {{ description }}</p>
+                <p><strong>Description:</strong> {{{ description }}}</p>
                 <p>{{{ costDescription }}}</p>
                 <p><strong>Explore:</strong> prescribing of this measure by <a href="{{ chartTitleUrl }}">other practices in the same CCG</a>.</p>
             </div>


### PR DESCRIPTION
Richard gave us a description for the ACE inhibitors measure which I forgot to add. Also, Ben requested that the descriptions link to the full codelist for our ACE/ARB/PPI/statins measures, which we store as a Google doc.

For the link to render correctly, we need to turn off auto-escaping in the relevant part of the Django/Handlebars templates.

NB I haven't made an issue for this - but happy to add one if you think that would be best - just let me know. 