### PR TITLE
In spine chart, always show ticks for active orgs

### DIFF
--- a/openprescribing/media/js/src/bar-chart.js
+++ b/openprescribing/media/js/src/bar-chart.js
@@ -34,11 +34,27 @@ var barChart = {
     };
     var activeOrgs = _.pluck(globalOptions.orgIds, 'id');
     this.barData = this._indexDataByMonthAndRatio(globalOptions.data.combinedData,
-                                                      activeOrgs);
+                                                  activeOrgs);
+    // Ensure we always show ticks for any active (selected) orgs:
+    barOptions.xAxis.tickPositioner = function() {
+      var calculated = this.tickPositions;
+      var activeOrgsIndex = [];
+      _.each(this.series[0].options.data, function(d, i) {
+        if (d.active) {
+          activeOrgsIndex.push(i);
+        }
+      });
+      console.log(this.chart.series[0].data)
+      _.each(activeOrgsIndex, function(d) {
+        var j = _.sortedIndex(calculated, d);
+        calculated.splice(j, 0, d);
+      });
+      return calculated;
+    };
     var activeMonth = globalOptions.activeMonth;
     var ratio = globalOptions.chartValues.ratio;
     var dataForMonth = this.barData[activeMonth][ratio];
-        // barOptions.xAxis.labels.step = (barData.length > 120) ? 3 : 1;
+    // barOptions.xAxis.labels.step = (barData.length > 120) ? 3 : 1;
     barOptions.series = utils.createChartSeries(dataForMonth);
     return new Highcharts.Chart(barOptions);
   },
@@ -70,8 +86,13 @@ var barChart = {
     var newData = {};
     _.each(combinedData, function(d) {
       d.name = d.row_name;
-      d.color = (_.contains(activeOrgs, d.id)) ? 'rgba(255, 64, 129, .8)' :
-                        'rgba(119, 152, 191, .5)';
+      if (_.contains(activeOrgs, d.id)) {
+        d.color = 'rgba(255, 64, 129, .8)';
+        d.active = true;
+      } else {
+        d.color = 'rgba(119, 152, 191, .5)';
+        d.active = false;
+      }
       var copy1 = $.extend(true, {}, d);
       var copy2 = $.extend(true, {}, d);
       if (d.date in newData) {

--- a/openprescribing/media/js/src/bar-chart.js
+++ b/openprescribing/media/js/src/bar-chart.js
@@ -44,7 +44,6 @@ var barChart = {
           activeOrgsIndex.push(i);
         }
       });
-      console.log(this.chart.series[0].data)
       _.each(activeOrgsIndex, function(d) {
         var j = _.sortedIndex(calculated, d);
         calculated.splice(j, 0, d);


### PR DESCRIPTION
This PR adds ticks on the x-Axis for any selected orgs.

This ensures that a practice someone is interested in always has a label, so can be identified on the graph.

However, it does make the layout look a bit jarring sometimes, because the default tick algorithm ensures ticks are evenly-spaced. Adding extra ticks between evenly-spaced ticks therefore crowds the labels sometimes.

It may be worth investing a bit more time into refining the tick-insertion algorithm to remove non-active orgs which are adjacent to active ones; on the other hand, if someone has selected two adjacent orgs, then the crowding will be unavoidable, so the current solution may be acceptable. See screen grabs for illustration.

![2](https://cloud.githubusercontent.com/assets/211271/16910181/2985c050-4ccf-11e6-9a13-e5b27472add6.png)

![1](https://cloud.githubusercontent.com/assets/211271/16910185/2e0fc7d8-4ccf-11e6-86dd-a06cef27b3a7.png)

Closes #117 
