### PR TITLE
Correctly parse month-from-filename option

### DIFF
--- a/openprescribing/common/utils.py
+++ b/openprescribing/common/utils.py
@@ -1,5 +1,6 @@
 from os import environ
 from django.core.exceptions import ImproperlyConfigured
+from django import db
 
 
 def get_env_setting(setting, default=None):
@@ -15,3 +16,7 @@ def get_env_setting(setting, default=None):
         else:
             error_msg = "Set the %s env variable" % setting
             raise ImproperlyConfigured(error_msg)
+
+
+def under_test():
+    return db.connections.databases['default']['NAME'].startswith("test_")


### PR DESCRIPTION
This is the option used by the `openprescribing-data` repo, and the
failure to parse correctly was leading to measures not being updated.

Closes #122