### PR TITLE
Documentation for training courses

### DIFF
--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -1,7 +1,9 @@
 from pyquery import PyQuery as pq
 from django.core import management
 from django.test import TestCase
+from django.conf import settings
 from frontend.models import Measure, MeasureValue, MeasureGlobal
+
 
 def setUpModule():
     fix_dir = 'frontend/tests/fixtures/'
@@ -204,3 +206,8 @@ class TestFrontendViews(TestCase):
     def test_call_view_ccg_redirect(self):
         response = self.client.get('/ccg/03V/measures/')
         self.assertEqual(response.status_code, 301)
+
+    def test_gdoc_inclusion(self):
+        for doc_id in settings.GDOC_DOCS.keys():
+            response = self.client.get("/docs/%s/" % doc_id)
+            self.assertEqual(response.status_code, 200)

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -249,3 +249,9 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_METHODS = (
     'GET'
 )
+GDOC_DOCS = {
+    'zooming': '1lz1uRfNOy2fQ-xSy_6BiLV_7Mgr-Z2V0-VWzo6HlCO0',
+    'analyse': '1HqlJlUA86cnlyJpUxiQdGsM46Gsv9xyZkmhkTqjbwH0',
+    'analyse-by-practice': '1idnk9yczLLBLbYUbp06dMglfivobTNoKY7pA2zCDPI8',
+    'analyse-by-ccg': '1izun1jIGW7Wica-eMkUOU1x7RWqCZ9BJrbWNvsCzWm0'
+}

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -63,6 +63,11 @@ urlpatterns = [
 
     url(r'^api/1.0/', include('api.urls')),
 
+    url(r'^docs/(?P<doc_id>[A-Za-z\d_-]+)/$',
+        frontend_views.gdoc_view,
+        name='docs'),
+
+
     # Other files.
     url(r'^robots\.txt/$', TemplateView.as_view(template_name='robots.txt',
                                                 content_type='text/plain')),

--- a/openprescribing/templates/gdoc.html
+++ b/openprescribing/templates/gdoc.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load template_extras %}
+
+{% block title %}Document{% endblock %}
+
+{% block content %}
+
+{{ content|safe }}
+
+{% endblock %}


### PR DESCRIPTION
Currently imports Google Docs HTML in case the content gets tweaked -
means we can use Google as a kind of CMS.

Longer term this content should probably be included as part of the
source code.

Connected to https://github.com/ebmdatalab/private/issues/12 