### PR TITLE
Test the app can be loaded in production pip env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
   - docker
 script:
   - export SAUCE_HOST=$(ip -4 addr show scope global dev docker0 | grep inet | awk '{print $2}' | cut -d / -f 1)
-  - docker-compose run --service-ports test
+  - docker-compose run --service-ports test && docker-compose run --service-ports test-production
 notifications:
   email:
     - tech@ebmdatalab.net

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements /tmp/requirements/
-RUN pip install -r /tmp/requirements/test.txt && rm -rf /tmp/requirements
+RUN pip install -r /tmp/requirements/production.txt && rm -rf /tmp/requirements
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install -y  nodejs binutils libproj-dev gdal-bin libgeoip1 libgeos-c1 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /npm

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,4 @@
+FROM ebmdatalab/openprescribing-base:latest
+
+ADD requirements /tmp/requirements/
+RUN pip install -r /tmp/requirements/test.txt && rm -rf /tmp/requirements

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ In the project root, run
 
     docker-compose run test
 
-This will pull down the relevant images, and run the tests.
+This will pull down the relevant images, and run the tests.  In our CI
+system, we also run checks against the production environment, which
+you can reproduce with
+
+    docker-compose run test-production
 
 To open a shell (from where you can run migrations, start a server,
 etc), run
@@ -40,11 +44,17 @@ database configuration, you'll need to blow away the volume with:
     docker-compose rm -f all
 
 Any time you change the npm or pip dependencies, you should rebuild
-the docker image used by the tests:
+the docker image used by the tests to improve runtime performance of
+travis.
 
+    # Base docker image, for production
     docker build -t ebmdatalab/openprescribing-base .
+    # Same as base, but with local-only pip dependencies
+    docker build -t ebmdatalab/openprescribing-test -f Dockerfile-test .
     docker login  # details in `pass`; only have to do this once on your machin
-    docker push  # pushes the image to hub.docker.io
+    # push the images to hub.docker.io
+    docker push ebmdatalab/openprescribing-base
+    docker push ebmdatalab/openprescribing-test
 
 ## On bare metal
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,27 @@ services:
     image: mdillon/postgis:latest
     env_file: .env-test
   test:
+    image: ebmdatalab/openprescribing-test:latest
+    command: /bin/bash -c './scripts/docker_setup.sh test && cd openprescribing && make test'
+    env_file: .env-test
+    environment:
+      - TRAVIS=${TRAVIS}
+      - TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
+      - TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
+      - SAUCE_USERNAME=${SAUCE_USERNAME}
+      - SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY}
+    extra_hosts:
+      - "saucehost:${SAUCE_HOST}"
+    ports:
+      - "6080:6080"
+    volumes:
+      - .:/code
+    depends_on:
+      - db-test
+
+  test-production:
     image: ebmdatalab/openprescribing-base:latest
-    command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && make test'
+    command: /bin/bash -c './scripts/docker_setup.sh production && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
     env_file: .env-test
     environment:
       - TRAVIS=${TRAVIS}
@@ -26,7 +45,7 @@ services:
     image: mdillon/postgis:latest
     env_file: .env-dev
   dev:
-    image: ebmdatalab/openprescribing-base:latest
+    image: ebmdatalab/openprescribing-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh && /bin/bash -l'
     env_file: .env-dev
     volumes:

--- a/openprescribing/frontend/tests/custom_runner.py
+++ b/openprescribing/frontend/tests/custom_runner.py
@@ -10,7 +10,6 @@ class AssetBuildingTestRunner(DiscoverRunner):
     os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = "0.0.0.0:6080"
 
     def setup_test_environment(self):
-        settings.DJANGO_SETTINGS_MODULE = 'frontend.settings.test'
         # Before we load any func tests, ensure we've got assets built
         npm_cmd = "mkdir -p ../../static/js && npm run build"
         subprocess.check_call(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,4 @@ openpyxl==2.3.3
 numpy==1.10.4
 pandas==0.17.1
 scipy==0.17.0
+lxml==3.6.4

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -4,7 +4,7 @@
 # application session via docker-compose
 
 python ./scripts/wait_for_postgres.py
-pip install -q -r requirements/test.txt
+pip install -q -r requirements/$1.txt
 if ! [ -r openprescribing/media/js/node_modules ]; then
     ln -s /npm/node_modules openprescribing/media/js/
 else


### PR DESCRIPTION
The intention is catch when you accidentally forget to add stuff to
requirements, because it happens to be in the local test/dev
environments).

I expect this to fail until I add a further commit to include the missing requirement.