### PR TITLE
Only allow query params to select API data format

### DIFF
--- a/openprescribing/frontend/negotiation.py
+++ b/openprescribing/frontend/negotiation.py
@@ -1,0 +1,28 @@
+from rest_framework.negotiation import DefaultContentNegotiation
+
+
+class IgnoreAcceptsContentNegotiation(DefaultContentNegotiation):
+    def select_parser(self, request, parsers):
+        """
+        Select the first parser in the `.parser_classes` list.
+        """
+        return parsers[0]
+
+    def select_renderer(self, request, renderers, format_suffix=None):
+        """
+        Given a request and a list of renderers, return a two-tuple of:
+        (renderer, media type).
+        """
+        # Allow URL style format override.  eg. "?format=json
+        requested_format = format_suffix or request.query_params.get('format')
+        found_html = False
+        if requested_format:
+            renderers = self.filter_renderers(renderers, requested_format)
+        else:
+            for renderer in renderers:
+                if 'html' in renderer.media_type.lower():
+                    found_html = True
+                    break
+        if not found_html:
+            renderer = renderers[0]
+        return renderer, renderer.media_type

--- a/openprescribing/frontend/tests/functional/test_general.py
+++ b/openprescribing/frontend/tests/functional/test_general.py
@@ -61,6 +61,15 @@ class GeneralFrontendTest(SeleniumTestCase):
                 "get in touch functionality broken at %s" % url
             )
 
+    def test_drug_name_typeahead(self):
+        self.browser.get(self.live_server_url + '/analyse/')
+        el = self.find_by_xpath(
+            '//div[@id="denomIds-wrapper"]'
+            '//input[@class="select2-search__field"]')
+        el.send_keys("chl")
+        # This should succeed; if not, the JSON dropdown-filling has not:
+        self.find_by_xpath('//ul[@id="select2-denomIds-results"]//li')
+
     def test_ccg_measures_sorting(self):
         # add CCGs and one measure
         setUpMeasures()

--- a/openprescribing/frontend/tests/test_api_bnf_codes.py
+++ b/openprescribing/frontend/tests/test_api_bnf_codes.py
@@ -49,6 +49,39 @@ class TestAPIBNFCodeViews(TestCase):
 
     api_prefix = '/api/1.0'
 
+    def assertNotJson(self, content):
+        try:
+            json.loads(content)
+            raise AssertionError(
+                "Expected %s... to be non-JSON" % content[:10])
+        except ValueError:
+            pass
+
+    def assertJson(self, content):
+        try:
+            json.loads(content)
+        except ValueError:
+            raise AssertionError("Expected %s... to be JSON" % content[:10])
+
+    def test_header_and_query_string_json_negotiation(self):
+        url = '%s/bnf_code?q=lor&format=json' % self.api_prefix
+        response = self.client.get(url, follow=True)
+        self.assertJson(response.content)
+
+        url = '%s/bnf_code?q=lor&format=json' % self.api_prefix
+        response = self.client.get(
+            url, {}, follow=True, HTTP_ACCEPT='text/html')
+        self.assertJson(response.content)
+
+        url = '%s/bnf_code?q=lor' % self.api_prefix
+        response = self.client.get(url, follow=True)
+        self.assertNotJson(response.content)
+
+        url = '%s/bnf_code?q=lor' % self.api_prefix
+        response = self.client.get(
+            url, {}, follow=True, HTTP_ACCEPT='application/json')
+        self.assertNotJson(response.content)
+
     def test_api_view_bnf_chemical(self):
         url = '%s/bnf_code?q=lor&format=json' % self.api_prefix
         response = self.client.get(url, follow=True)

--- a/openprescribing/media/js/src/form.js
+++ b/openprescribing/media/js/src/form.js
@@ -339,8 +339,7 @@ var queryForm = {
         return str;
       },
       ajax: {
-        url: config.apiHost + "/api/1.0/bnf_code/",
-        dataType: 'json',
+        url: config.apiHost + "/api/1.0/bnf_code/?format=json",
         delay: 50,
         data: function(params) {
           return {

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -235,6 +235,8 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
         'rest_framework_csv.renderers.CSVRenderer',
     ),
+    'DEFAULT_CONTENT_NEGOTIATION_CLASS':
+    'frontend.negotiation.IgnoreAcceptsContentNegotiation',
 }
 
 CORS_URLS_REGEX = r'^/api/.*$'


### PR DESCRIPTION
Inconsistent use of `?format=json` as opposed to the `Accepts:
application/json` HTTP header meant that sometimes data expected to be
JSON was being served from the cache as HTML.

Fixes #168