### PR TITLE
Fix description of KTT9, all antibiotics

### DIFF
--- a/openprescribing/frontend/management/commands/measure_definitions/ktts.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ktts.json
@@ -149,10 +149,10 @@
     "ktt9_antibiotics": {
         "name": "Broad-spectrum antibiotics (KTT9)",
         "title": [
-            "KTT9 (Antibiotic prescribing - especially broad spectrum antibiotics)"
+            "KTT9 (Antibiotic prescribing)"
         ],
         "description": [
-            "Number of prescription items for antibacterial drugs (BNF 5.1)",
+            "Number of prescription items for all antibacterial drugs (BNF 5.1)",
             "per oral antibacterials (BNF 5.1 sub-set) item-based STAR-PU."
         ],
         "why_it_matters": [


### PR DESCRIPTION
Due to confusing wording in the KTT definitions document, this
had been recorded as broad spectrum antibiotics when in fact it's
all antibiotics. Fixes #205.