### PR TITLE
Cloud storage in parts

### DIFF
--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -70,8 +70,6 @@ class Command(BaseCommand):
         pool.close()
         pool.join()  # wait for all worker processes to exit
         for result in pool_results:
-            if not result.successful():
-                raise RuntimeError("Error running job: %s" % result.__dict__)
             tablename, gcs_uri = result.get()
             f = download_and_unzip(self.dataset, gcs_uri)
             copy_str = "COPY %s(%s) FROM STDIN "

--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -215,12 +215,14 @@ def wait_for_job(job_id, project_id):
         counter += 1
         if response['status']['state'] == 'DONE':
             if 'errors' in response['status']:
-                query = str(response['configuration']['query']['query'])
-                for i, l in enumerate(query.split("\n")):
-                    # print SQL query with line numbers for debugging
-                    print "{:>3}: {}".format(i + 1, l)
-                raise StandardError(
-                    json.dumps(response['status']['errors'], indent=2))
+                error = json.dumps(response['status']['errors'], indent=2)
+                if 'query' in response['configuration']:
+                    query = str(response['configuration']['query']['query'])
+                    for i, l in enumerate(query.split("\n")):
+                        # print SQL query with line numbers for debugging
+                        logging.error(
+                            error + ":\n" + "{:>3}: {}".format(i + 1, l))
+                raise StandardError(error)
             else:
                 break
     elapsed = (datetime.datetime.now() - start).total_seconds()

--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
 
     def fill_views(self):
         paths = [x for x in self.view_paths
-                 if not self.view or (self.view and self.view == x)]
+                 if not self.view or (self.view and self.view in x)]
         pool = Pool(processes=len(paths))
         pool_results = []
         for view in paths:

--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -99,7 +99,8 @@ def query_and_export(dataset, view):
     try:
         project_id = 'ebmdatalab'
         tablename = "vw__%s" % os.path.basename(view).replace('.sql', '')
-        gzip_destination = "gs://ebmdatalab/views/%s-*.csv.gz" % tablename
+        gzip_destination = "gs://ebmdatalab/%s/views/%s-*.csv.gz" % (
+            dataset, tablename)
         # We do a string replacement here as we don't know how
         # many times a dataset substitution token (i.e. `%s`) will
         # appear in each SQL template. And we can't use new-style
@@ -154,12 +155,11 @@ def export_to_gzip(project_id, dataset_id, table_id, destination):
     }
     return insert_job(project_id, payload)
 
-
+"".split
 def download_from_gcs(gcs_uri):
-    bucket, folder, blob = gcs_uri.replace('gs://', '').split('/')
+    bucket, blob_name = gcs_uri.replace('gs://', '').split('/', 1)
     client = storage.Client(project='embdatalab')
     bucket = client.get_bucket(bucket)
-    blob_name = "%s/%s" % (folder, blob)
     prefix = blob_name.split('*')[0]
     for blob in bucket.list_blobs(prefix=prefix):
         with tempfile.NamedTemporaryFile(mode='rb+') as f:

--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -57,8 +57,14 @@ class Command(BaseCommand):
             self.fill_views()
 
     def fill_views(self):
-        paths = [x for x in self.view_paths
-                 if not self.view or (self.view and self.view in x)]
+        paths = []
+        if self.view:
+            for path in self.view_paths:
+                if self.view in path:
+                    paths.append(path)
+                    break
+        else:
+            paths = self.view_paths
         pool = Pool(processes=len(paths))
         pool_results = []
         for view in paths:


### PR DESCRIPTION
We use Google Cloud Storage as an interim storage area to stash compressed CSV data for importing into our views. When a file is greater than 1GB, GCS fails; to address this, we need to export using a wildcard which causes the file to be sharded.