### PR TITLE
Partition prescribing table

### DIFF
--- a/openprescribing/frontend/management/commands/generate_ccg_statistics_sql.py
+++ b/openprescribing/frontend/management/commands/generate_ccg_statistics_sql.py
@@ -61,6 +61,7 @@ FROM
   ebmdatalab.hscic.practice_statistics AS statistics
 JOIN ebmdatalab.hscic.ccgs ccgs
 ON (statistics.pct_id = ccgs.code AND ccgs.org_type = 'CCG')
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   month,
   pct_id,

--- a/openprescribing/frontend/management/commands/import_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/import_hscic_prescribing.py
@@ -1,16 +1,13 @@
 import csv
+import datetime
 import glob
 import logging
 import re
-import psycopg2
-import os
-import sys
-import time
-from pprint import pprint
-from os import environ
-from django.core.management.base import BaseCommand, CommandError
-from frontend.models import SHA, PCT, Prescription, ImportLog
-from common import utils
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from frontend.models import SHA, PCT, ImportLog
 
 
 class Command(BaseCommand):
@@ -19,10 +16,13 @@ class Command(BaseCommand):
     help += 'Set DEBUG to False in your settings before running this.'
 
     def add_arguments(self, parser):
-        parser.add_argument('--db_name')
-        parser.add_argument('--db_user')
-        parser.add_argument('--db_pass')
         parser.add_argument('--filename')
+        parser.add_argument(
+            '--date', help="Specify date rather than infer it from filename")
+        parser.add_argument(
+            '--skip-orgs',
+            action='store_true',
+            help="Don't parse orgs from the file")
         parser.add_argument('--truncate')
 
     def handle(self, *args, **options):
@@ -33,40 +33,27 @@ class Command(BaseCommand):
             self.truncate = True
         else:
             self.truncate = False
-        if options['db_name']:
-            db_name = options['db_name']
-        else:
-            db_name = utils.get_env_setting('DB_NAME')
-        if options['db_user']:
-            db_user = options['db_user']
-        else:
-            db_user = utils.get_env_setting('DB_USER')
-        if options['db_pass']:
-            db_pass = options['db_pass']
-        else:
-            db_pass = utils.get_env_setting('DB_PASS')
-        db_host = utils.get_env_setting('DB_HOST', '127.0.0.1')
-        self.conn = psycopg2.connect(database=db_name, user=db_user,
-                                     password=db_pass, host=db_host)
-        cursor = self.conn.cursor()
 
         if options['filename']:
             files_to_import = [options['filename']]
         else:
             filepath = './data/raw_data/T*PDPI+BNFT_formatted*'
             files_to_import = glob.glob(filepath)
-
         for f in files_to_import:
-            self.import_shas_and_pcts(f)
-            self.delete_existing_prescriptions(f)
-            self.import_prescriptions(f, cursor)
+            if options['date']:
+                date = datetime.datetime.strptime(
+                    options['date'], '%Y-%m-%d').date()
+            else:
+                date = self._date_from_filename(f)
+            if not options['skip_orgs']:
+                self.import_shas_and_pcts(f, date)
+            self.drop_partition(date)
+            self.create_partition(date)
+            self.import_prescriptions(f, date)
+            self.create_partition_indexes(date)
+            self.add_parent_trigger()
 
-        self.vacuum_db(cursor)
-        self.analyze_db(cursor)
-
-        self.conn.close()
-
-    def import_shas_and_pcts(self, filename):
+    def import_shas_and_pcts(self, filename, date):
         if self.IS_VERBOSE:
             print 'Importing SHAs and PCTs from %s' % filename
         rows = csv.reader(open(filename, 'rU'))
@@ -90,15 +77,121 @@ class Command(BaseCommand):
             print shas_created, 'SHAs created'
             print pcts_created, 'PCTs created'
 
-    def import_prescriptions(self, filename, cursor):
+    def create_partition(self, date):
+        sql = ("CREATE TABLE %s ("
+               "  CHECK ( "
+               "    processing_date >= DATE '%s' "
+               "      AND processing_date < DATE '%s'"
+               "  )"
+               ") INHERITS (frontend_prescription);")
+        constraint_from = "%s-%s-%s" % (date.year, date.month, "01")
+        next_month = (date.month + 1) % 12
+        if next_month == 0:
+            next_year = date.year + 1
+            next_month = 1
+        else:
+            next_year = date.year
+        constraint_to = "%s-%s-%s" % (next_year, next_month, "01")
+        sql = sql % (
+            self._partition_name(date),
+            constraint_from,
+            constraint_to
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+
+    def _partition_name(self, date):
+        return "frontend_prescription_%s%s" % (date.year, date.month)
+
+    def add_parent_trigger(self):
+        """A trigger to prevent accidental adding of data to the parent table
+
+        """
+        function = ("CREATE OR REPLACE FUNCTION prescription_prevent_action() "
+                    "  RETURNS trigger AS $prevent_action$ "
+                    "BEGIN "
+                    "  RAISE EXCEPTION "
+                    "  '% on % not allowed. Perform on descendant tables',"
+                    "  TG_OP, TG_TABLE_NAME;"
+                    "END; "
+                    "$prevent_action$ LANGUAGE plpgsql; ")
+        trigger = ("DROP TRIGGER IF EXISTS prevent_action "
+                   "  ON frontend_prescription; "
+                   "CREATE TRIGGER prevent_action "
+                   "BEFORE INSERT OR UPDATE OR DELETE ON frontend_prescription"
+                   "  FOR EACH STATEMENT "
+                   "  EXECUTE PROCEDURE prescription_prevent_action();")
+        with connection.cursor() as cursor:
+            cursor.execute(function)
+            cursor.execute(trigger)
+
+    def create_partition_indexes(self, date):
+        indexes = [
+            ("CREATE INDEX %s_6ea07fe3 "
+             "ON %s "
+             "USING btree (practice_id)"),
+            ("CREATE INDEX %s_by_pct "
+             "ON %s "
+             "USING btree (presentation_code, pct_id)"),
+            ("CREATE INDEX %s_by_pct_and_presentation "
+             "ON %s "
+             "USING btree (pct_id, presentation_code varchar_pattern_ops)"),
+            ("CREATE INDEX %s_by_prac_date_code "
+             "ON %s "
+             "USING btree (practice_id, processing_date, presentation_code)"),
+            ("CREATE INDEX %s_by_practice "
+             "ON %s "
+             "USING btree (presentation_code, practice_id)"),
+            ("CREATE INDEX %s_by_practice_and_code "
+             "ON %s "
+             "USING btree (practice_id, presentation_code varchar_pattern_ops)"),
+            ("CREATE INDEX %s_idx_date_and_code "
+             "ON %s "
+             "USING btree (processing_date, presentation_code)")]
+        constraints = [
+            ("ALTER TABLE %s ADD CONSTRAINT "
+             "cnstrt_%s_pkey "
+             "PRIMARY KEY (id)"),
+            ("ALTER TABLE %s ADD CONSTRAINT "
+             "cnstrt_%s_chemical_bnf_code "
+             "FOREIGN KEY (chemical_id) REFERENCES frontend_chemical(bnf_code)"
+             " DEFERRABLE INITIALLY DEFERRED"),
+            ("ALTER TABLE %s ADD CONSTRAINT "
+             "cnstrt_%s__practice_code "
+             "FOREIGN KEY (practice_id) REFERENCES frontend_practice(code) "
+             "DEFERRABLE INITIALLY DEFERRED"),
+            ("ALTER TABLE %s ADD CONSTRAINT "
+             "cnstrt_%s__pct_code "
+             "FOREIGN KEY (pct_id) REFERENCES frontend_pct(code) "
+             "DEFERRABLE INITIALLY DEFERRED"),
+            ("ALTER TABLE %s ADD CONSTRAINT "
+             "cnstrt_%s__sha_code "
+             "FOREIGN KEY (sha_id) REFERENCES frontend_sha(code) "
+             "DEFERRABLE INITIALLY DEFERRED")
+            ]
+        partition_name = self._partition_name(date)
+        with connection.cursor() as cursor:
+            for index_sql in indexes:
+                cursor.execute(index_sql % (
+                    partition_name, partition_name))
+            for constraint_sql in constraints:
+                cursor.execute(constraint_sql % (
+                    partition_name, partition_name))
+
+    def drop_partition(self, date):
+        sql = "DROP TABLE IF EXISTS %s" % self._partition_name(date)
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+
+    def import_prescriptions(self, filename, date):
         if self.IS_VERBOSE:
             print 'Importing Prescriptions from %s' % filename
         # start = time.clock()
-        copy_str = "COPY frontend_prescription(sha_id,pct_id,"
+        copy_str = "COPY %s(sha_id,pct_id,"
         copy_str += "practice_id,chemical_id,presentation_code,"
         copy_str += "presentation_name,total_items,actual_cost,"
         copy_str += "quantity,processing_date) FROM STDIN "
-        copy_str += "WITH DELIMITER AS ','"
+        copy_str += "WITH (FORMAT CSV)"
         i = 0
         if self.truncate:
             with open("/tmp/sample", "wb") as outfile:
@@ -111,36 +204,15 @@ class Command(BaseCommand):
             file_obj = open("/tmp/sample")
         else:
             file_obj = open(filename)
-        cursor.copy_expert(copy_str, file_obj)
-        self.conn.commit()
-        date = self._date_from_filename(filename)
-        ImportLog.objects.create(
-            current_at=date,
-            filename=filename,
-            category='prescribing'
-        )
+        with connection.cursor() as cursor:
+            cursor.copy_expert(copy_str % self._partition_name(date), file_obj)
+            ImportLog.objects.create(
+                current_at=date,
+                filename=filename,
+                category='prescribing'
+            )
 
     def _date_from_filename(self, filename):
         file_str = filename.split('/')[-1].split('.')[0]
         file_str = re.sub(r'PDPI.BNFT_formatted', '', file_str)
-        return file_str[1:5] + '-' + file_str[5:] + '-01'
-
-    def delete_existing_prescriptions(self, filename):
-        if self.IS_VERBOSE:
-            print 'Deleting existing Prescriptions for month'
-        p = Prescription.objects.filter(
-            processing_date=self._date_from_filename(filename))
-        p.delete()
-
-    def vacuum_db(self, cursor):
-        if self.IS_VERBOSE:
-            print 'Vacuuming database...'
-        old_isolation_level = self.conn.isolation_level
-        self.conn.set_isolation_level(0)
-        cursor.execute("VACUUM frontend_prescription")
-        self.conn.set_isolation_level(old_isolation_level)
-
-    def analyze_db(self, cursor):
-        if self.IS_VERBOSE:
-            print 'Analyzing database...'
-        cursor.execute('ANALYZE VERBOSE frontend_prescription')
+        return datetime.date(int(file_str[1:5]), int(file_str[5:]), 1)

--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -140,6 +140,8 @@ class Command(BaseCommand):
                 month.strftime('%Y-%m-01')
         else:
             l = ImportLog.objects.latest_in_category('prescribing')
+            options['start_date'] = "%s-%s-%s" % (
+                l.current_at.year - 5, l.current_at.month, l.current_at.day)
             options['end_date'] = l.current_at.strftime('%Y-%m-%d')
         # validate the date format
         datetime.datetime.strptime(options['start_date'], "%Y-%m-%d")

--- a/openprescribing/frontend/management/commands/migrate_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/migrate_hscic_prescribing.py
@@ -1,0 +1,81 @@
+import datetime
+import calendar
+import tempfile
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    args = ''
+    help = 'Import all data from any data files that have been downloaded. '
+    help += 'Set DEBUG to False in your settings before running this.'
+
+    def handle(self, *args, **options):
+        self.migrate_data()
+
+    def migrate_data(self):
+        # rename the main table
+        with connection.cursor() as cursor:
+            cursor.execute("ALTER TABLE frontend_prescription "
+                           "RENAME TO frontend_prescription_old")
+            # create a new parent table with the same name
+            sql = """
+            CREATE TABLE frontend_prescription (
+                id integer NOT NULL,
+                presentation_code character varying(15) NOT NULL,
+                presentation_name character varying(1000) NOT NULL,
+                total_items integer NOT NULL,
+                actual_cost double precision NOT NULL,
+                quantity double precision NOT NULL,
+                processing_date date NOT NULL,
+                chemical_id character varying(9) NOT NULL,
+                pct_id character varying(3) NOT NULL,
+                practice_id character varying(6) NOT NULL,
+                sha_id character varying(3) NOT NULL
+            );
+            DROP SEQUENCE IF EXISTS frontend_prescription_parent_id_seq;
+            CREATE SEQUENCE frontend_prescription_id_seq
+                START WITH 1
+                INCREMENT BY 1
+                NO MINVALUE
+                NO MAXVALUE
+                CACHE 1;
+
+            ALTER TABLE ONLY frontend_prescription ALTER COLUMN id
+              SET DEFAULT
+                nextval('frontend_prescription_parent_id_seq'::regclass);
+            """
+            cursor.execute(sql)
+        # month, by month, dump data to a CSV; then reimport
+        start_date = datetime.date(2011, 8, 1)
+        end_date = datetime.date(2016, 8, 1)
+        for date in self.each_date(start_date, end_date):
+            start = datetime.datetime.now()
+            print "Copying", date
+            query = ("COPY (select * from frontend_prescription) "
+                     "TO STDOUT WITH CSV HEADER")
+            with tempfile.NamedTemporaryFile(mode='rb+') as f:
+                with connection.cursor() as cursor:
+                    cursor.copy_expert(query, f)
+                    print "  importing", date
+                    call_command(
+                        'import_hscic_prescribing',
+                        filename=f.name,
+                        skip_orgs=True,
+                        date=date.strftime("%Y-%m-%d"))
+            print "  %s seconds elapsed" % (
+                datetime.datetime.now() - start).seconds
+        print "Done. Now check the data in frontend_prescription."
+        print "If you're happy, drop frontend_prescription_old"
+
+    def each_date(self, start_date, end_date):
+        date = start_date
+        while date <= end_date:
+            yield date
+            month = date.month
+            year = int(date.year + month / 12)
+            month = month % 12 + 1
+            day = min(date.day, calendar.monthrange(year, month)[1])
+            date = datetime.date(year, month, day)

--- a/openprescribing/frontend/management/commands/migrate_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/migrate_hscic_prescribing.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
             query = ("COPY (select * from frontend_prescription) "
                      "TO STDOUT WITH CSV HEADER")
             with tempfile.NamedTemporaryFile(mode='rb+') as f:
-                with connection.cursor() as cursor:
+                with connection['old'].cursor() as cursor:
                     cursor.copy_expert(query, f)
                     print "  importing", date
                     call_command(

--- a/openprescribing/frontend/management/commands/views_sql/ccgstatistics.sql
+++ b/openprescribing/frontend/management/commands/views_sql/ccgstatistics.sql
@@ -17,9 +17,10 @@ SELECT
   SUM(astro_pu_cost) AS astro_pu_cost,
   jsonify_starpu(SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.analgesics_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.antidepressants_adq') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.antidepressants_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.antiepileptic_drugs_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.antiplatelet_drugs_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.benzodiazepine_caps_and_tabs_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.bisphosphonates_and_other_drugs_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.bronchodilators_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.calcium-channel_blockers_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.cox-2_inhibitors_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.drugs_acting_on_benzodiazepine_receptors_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.drugs_affecting_the_renin_angiotensin_system_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.drugs_for_dementia_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.drugs_used_in_parkinsonism_and_related_disorders_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.hypnotics_adq') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.inhaled_corticosteroids_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.laxatives_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.lipid-regulating_drugs_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.omega-3_fatty_acid_compounds_adq') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.oral_antibacterials_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.oral_antibacterials_item') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.oral_nsaids_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.proton_pump_inhibitors_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.statins_cost') AS FLOAT64)),SUM(CAST(JSON_EXTRACT_SCALAR(star_pu,'$.ulcer_healing_drugs_cost') AS FLOAT64))) AS star_pu
 FROM
-  ebmdatalab.%s.practice_statistics AS statistics
-JOIN ebmdatalab.%s.ccgs ccgs
+  ebmdatalab.{{dataset}}.practice_statistics AS statistics
+JOIN ebmdatalab.{{dataset}}.ccgs ccgs
 ON (statistics.pct_id = ccgs.code AND ccgs.org_type = 'CCG')
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   month,
   pct_id,

--- a/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_ccg.sql
+++ b/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_ccg.sql
@@ -6,7 +6,8 @@ SELECT
   SUM(actual_cost) AS cost,
   CAST(SUM(quantity) AS INT64) AS quantity
 FROM
-  ebmdatalab.%s.prescribing
+  ebmdatalab.{{dataset}}.prescribing
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   pct_id,

--- a/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_practice.sql
+++ b/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_practice.sql
@@ -6,7 +6,8 @@ SELECT
   SUM(actual_cost) AS cost,
   CAST(SUM(quantity) AS INT64) AS quantity
 FROM
-  ebmdatalab.%s.prescribing
+  ebmdatalab.{{dataset}}.prescribing
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   practice_id,

--- a/openprescribing/frontend/management/commands/views_sql/practice_summary.sql
+++ b/openprescribing/frontend/management/commands/views_sql/practice_summary.sql
@@ -5,7 +5,8 @@ SELECT
   SUM(actual_cost) AS cost,
   CAST(SUM(quantity) AS INT64) AS quantity
 FROM
-  ebmdatalab.%s.prescribing
+  ebmdatalab.{{dataset}}.prescribing
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   practice_id

--- a/openprescribing/frontend/management/commands/views_sql/presentation_summary.sql
+++ b/openprescribing/frontend/management/commands/views_sql/presentation_summary.sql
@@ -6,7 +6,8 @@ SELECT
   SUM(actual_cost) AS cost,
   CAST(SUM(quantity) AS INT64) AS quantity
 FROM
-  ebmdatalab.%s.prescribing
+  ebmdatalab.{{dataset}}.prescribing
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   presentation_code

--- a/openprescribing/frontend/management/commands/views_sql/presentation_summary_by_ccg.sql
+++ b/openprescribing/frontend/management/commands/views_sql/presentation_summary_by_ccg.sql
@@ -7,7 +7,8 @@ SELECT
   SUM(actual_cost) AS cost,
   CAST(SUM(quantity) AS INT64) AS quantity
 FROM
-  ebmdatalab.%s.prescribing
+  ebmdatalab.{{dataset}}.prescribing
+WHERE month >= TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   pct_id,

--- a/openprescribing/frontend/tests/commands/test_create_views.py
+++ b/openprescribing/frontend/tests/commands/test_create_views.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 
 from common import utils
 from ebmdatalab import bigquery
+from frontend.models import ImportLog
 
 
 def setUpModule():
@@ -39,6 +40,7 @@ def setUpModule():
             bigquery.load_ccgs_from_pg('test_hscic')
             bigquery.load_statistics_from_pg('test_hscic')
     # Create view tables and indexes
+    ImportLog.objects.create(category='prescribing', current_at='2015-10-01')
     with open('frontend/management/commands/replace_matviews.sql', 'r') as f:
         with connection.cursor() as c:
             c.execute(f.read())

--- a/openprescribing/frontend/tests/commands/test_import_hscic_prescribing.py
+++ b/openprescribing/frontend/tests/commands/test_import_hscic_prescribing.py
@@ -1,49 +1,50 @@
 import datetime
 from django.core.management import call_command
+from django.db import InternalError
 from django.test import TestCase
 from frontend.models import Chemical, PCT, Practice
 from frontend.models import Prescription, SHA, ImportLog
 from common import utils
-
-
-def setUpModule():
-    chemical = Chemical.objects.create(bnf_code='0401020K0', chem_name='test')
-    Chemical.objects.create(bnf_code='0410030C0', chem_name='test')
-    Practice.objects.create(code='Y00135', name='test')
-    Practice.objects.create(code='Y01957', name='test')
-    practice = Practice.objects.create(code='Y03375', name='test')
-    pct = PCT.objects.create(code='5D7', name='test')
-    sha = SHA.objects.create(code='Q30', name='test')
-    Prescription.objects.create(sha=sha, pct=pct, practice=practice,
-                                chemical=chemical,
-                                presentation_code='0410030C0BBAABA',
-                                presentation_name='Methadose_Oral Conc',
-                                total_items=4,
-                                actual_cost=44.12, quantity=588,
-                                processing_date='2013-04-01')
-
-
-def tearDownModule():
-    call_command('flush', verbosity=0, interactive=False)
+from mock import patch
 
 
 class CommandsTestCase(TestCase):
+    def setUp(self):
+        self.chemical = Chemical.objects.create(
+            bnf_code='0401020K0', chem_name='test')
+        self.practice = Practice.objects.create(code='Y03375', name='test')
+        self.pct = PCT.objects.create(code='5D7', name='test')
+        self.sha = SHA.objects.create(code='Q30', name='test')
+        Chemical.objects.create(bnf_code='0410030C0', chem_name='test')
+        Practice.objects.create(code='Y00135', name='test')
+        Practice.objects.create(code='Y01957', name='test')
 
-    def test_import_hscic_prescribing(self):
-        args = []
-        db_name = 'test_' + utils.get_env_setting('DB_NAME')
-        db_user = utils.get_env_setting('DB_USER')
-        db_pass = utils.get_env_setting('DB_PASS')
         test_file = 'frontend/tests/fixtures/commands/'
         test_file += 'T201304PDPI+BNFT_formatted.CSV'
-        new_opts = {
-            'db_name': db_name,
-            'db_user': db_user,
-            'db_pass': db_pass,
+        self.new_opts = {
             'filename': test_file
         }
-        call_command('import_hscic_prescribing', *args, **new_opts)
+        db_name = 'test_' + utils.get_env_setting('DB_NAME')
+        self.env = patch.dict(
+            'os.environ', {'DB_NAME': db_name})
+        with self.env:
+            call_command('import_hscic_prescribing', **self.new_opts)
 
+    def test_import_drops_existing(self):
+        with self.env:
+            call_command('import_hscic_prescribing', **self.new_opts)
+        self.assertEqual(Prescription.objects.count(), 15)
+
+    def test_inserts_fail(self):
+        with self.assertRaises(InternalError):
+            Prescription.objects.create(
+                sha=self.sha, pct=self.pct, practice=self.practice,
+                chemical=self.chemical, presentation_code='0000',
+                presentation_name='asd', total_items=4,
+                actual_cost=4, quantity=4,
+                processing_date='2013-04-01')
+
+    def test_import_creates_prescriptions(self):
         shas = SHA.objects.all()
         self.assertEqual(shas.count(), 1)
         pcts = PCT.objects.all()

--- a/openprescribing/openprescribing/settings/production.py
+++ b/openprescribing/openprescribing/settings/production.py
@@ -49,7 +49,15 @@ DATABASES = {
         'USER': utils.get_env_setting('DB_USER'),
         'PASSWORD': utils.get_env_setting('DB_PASS'),
         'HOST': utils.get_env_setting('DB_HOST', '127.0.0.1')
+    },
+    'old': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        'NAME': utils.get_env_setting('DB_NAME'),
+        'USER': utils.get_env_setting('DB_USER'),
+        'PASSWORD': utils.get_env_setting('DB_PASS'),
+        'HOST': utils.get_env_setting('DB_HOST', '138.68.140.164')
     }
+
 }
 # END DATABASE CONFIGURATION
 


### PR DESCRIPTION
Fixes #246 

When deployed:

* The one-off migration `migrate_hscic_prescribing` needs to be run. The commit that introduced it could then be reverted.
* MeasureValues before 5 years ago should be deleted manually