### PR TITLE
Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ travis.
     docker push ebmdatalab/openprescribing-base
     docker push ebmdatalab/openprescribing-test
 
+
+### Running the application from within Docker
+To be able to access the django instance running inside Docker from outside the container, docker must be told to publish the port on which Django will listen:
+
+    docker-compose run -p 8000:8000 dev
+
+This will give a shell, at which you can start Django, specifying the ``0.0.0.0`` interface so that it will accept connections from all IP addesses (not just localhost):
+
+     python manage.py runserver_plus 0.0.0.0:8000 --settings=openprescribing.settings.local
+
+The application should then be accessible at ``http://localhost:8000/`` from a web-browser on the host computer.
+
 ## On bare metal
 
 This should be enough to get a dev sandbox running; some brief notes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     env_file: .env-dev
   dev:
     image: ebmdatalab/openprescribing-test:latest
-    command: /bin/bash -c './scripts/docker_setup.sh && /bin/bash -l'
+    command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'
     env_file: .env-dev
     volumes:
       - .:/code


### PR DESCRIPTION
This pull request makes three changes related to Docker:

- it causes the dev service  to specify a requirements file by providing the argument ``local`` when calling ``docker_setup.sh``. Currently, this is not done, resulting in the error ``Could not open requirements file: [Errno 2] No such file or directory: 'requirements/.txt'``

- it causes the dev service to also change directory into code/openprescribing, so django can be started directly

- it adds an explanation of how to make the application accessible from outside the Docker container to the README 

