### PR TITLE
Use gunzip instead of zcat

### DIFF
--- a/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
@@ -276,7 +276,7 @@ def download_from_gcs(gcs_uri, target_path):
     bucket = client.get_bucket(bucket)
     prefix = blob_name.split('*')[0]
     unzipped = open(target_path, 'w')
-    cmd = "zcat -f %s >> %s"
+    cmd = "gunzip -c -f %s >> %s"
     for blob in bucket.list_blobs(prefix=prefix):
         with tempfile.NamedTemporaryFile(mode='rb+') as f:
             logger.info("Downloading %s to %s" % (blob.path, f.name))

--- a/openprescribing/frontend/management/commands/create_views.py
+++ b/openprescribing/frontend/management/commands/create_views.py
@@ -149,12 +149,12 @@ def download_and_unzip(gcs_uri):
     for i, f in enumerate(download_from_gcs(gcs_uri)):
         # Unzip
         if i == 0:
-            cmd = "zcat -f %s >> %s"
+            cmd = "gunzip -c -f %s >> %s"
         else:
             # When the file is split into several shards in GCS, it
             # puts a header on every file, so we have to skip that
             # header on all except the first shard.
-            cmd = "zcat -f %s | tail -n +2 >> %s"
+            cmd = "gunzip -c -f %s | tail -n +2 >> %s"
         subprocess.check_call(
             cmd % (f.name, unzipped.name), shell=True)
     return unzipped


### PR DESCRIPTION
zcat behaves oddly on OSX, always appending a .Z to filenames passed as
arguments.

See https://github.com/dalibo/pgbadger/issues/70 for a related
discussion.