### PR TITLE
Remove 'prescribing' from title

### DIFF
--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 {% load template_extras %}
 
-{% block title %}{{measure.name}} prescribing by practices in {{ ccg.name }}{% endblock %}
+{% block title %}{{measure.name}} by practices in {{ ccg.name }}{% endblock %}
 {% block active_class %}ccg{% endblock %}
 
 {% block extra_css %}
@@ -11,7 +11,7 @@
 
 {% block content %}
 
-<h1>{{measure.name}} prescribing by GP practices in {{ ccg.name }}</h1>
+<h1>{{measure.name}} by GP practices in {{ ccg.name }}</h1>
 
 <p>How standard GP practices in {{ ccg.name }} prescribed {{ measure.title }}.</p>
 

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -13,8 +13,6 @@
 
 <h1>{{measure.name}} by GP practices in {{ ccg.name }}</h1>
 
-<p>How standard GP practices in {{ ccg.name }} prescribed {{ measure.title }}.</p>
-
 {% if measure.url %}
 <p>Read <a href="{{ measure.url }}">more about this measure</a>.</p>
 {% endif %}

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -23,7 +23,7 @@
 
 <p><strong>How this CCG is doing:</strong> <span id="perfsummary">Loading...</span> See <a href="/ccg/{{ ccg.code }}/measures">how this CCG is doing on other measures</a>.</p>
 
-<p>Practices are ordered by mean percentile over the past six months, with the worst-performing at the top. Each chart shows the results for the individual practice, plus deciles across all practices in NHS England.</p>
+<p>Practices are ordered by mean percentile over the past six months. Each chart shows the results for the individual practice, plus deciles across all practices in NHS England.</p>
 
 <div id="measures">
 <div id="charts" class="row">


### PR DESCRIPTION
Some of the measures already have 'prescribing' in their title, so having text for each measure saying 'prescribing by practices' often makes no sense

e.g. 
Prescribing of pregabalin prescribing by GP practice
Antibiotic stewardship: volume of antibiotic prescribing (KTT9) prescribing by all CCGs

Have removed 'prescribing' from the text - it still makes sense for measures without prescribing in the title e.g. Silver Dressings by all CCGs