### PR TITLE
Update measure_for_all_ccgs.html

### DIFF
--- a/openprescribing/templates/measure_for_all_ccgs.html
+++ b/openprescribing/templates/measure_for_all_ccgs.html
@@ -2,14 +2,12 @@
 {% load humanize %}
 {% load template_extras %}
 
-{% block title %}Prescribing of {{ measure }} by all CCGs{% endblock %}
+{% block title %} {{ measure }} by all CCGs{% endblock %}
 {% block active_class %}ccg{% endblock %}
 
 {% block content %}
 
-<h1>{{measure.name}} prescribing by all CCGs</h1>
-
-<p>How all CCGs prescribed {{ measure.title }}.</p>
+<h1>{{measure.name}} by all CCGs</h1>
 
 {% if measure.url %}
 <p>Read <a href="{{ measure.url }}">more about this measure</a>.</p>
@@ -25,7 +23,7 @@
 
 {% endif %}
 
-<p>CCGs are ordered by mean percentile over the past six months, with the worst-performing at the top. Each chart shows the results for the individual CCG, plus deciles across all CCGs in NHS England.</p>
+<p>CCGs are ordered by mean percentile over the past six months. Each chart shows the results for the individual CCG, plus deciles across all CCGs in NHS England.</p>
 
 <div id="measures">
 <div id="charts" class="row">


### PR DESCRIPTION
Some of the measures already have 'prescribing' in their title, so having text for each measure saying 'prescribing by practices' often makes no sense

e.g.
Prescribing of pregabalin prescribing by GP practice
Antibiotic stewardship: volume of antibiotic prescribing (KTT9) prescribing by all CCG

- Have removed 'prescribing' from the text - it still makes sense for measures without prescribing in the title e.g. Silver Dressings by all CCGs

- Removed first line of text under title, as had same problem & doesn't add anything to page.

- Have also removed 'worst performing practices' as per #400 but @sebbacon might disagree!