### PR TITLE
Don't let bad spiders cause endless errors

### DIFF
--- a/openprescribing/frontend/tests/test_bookmark_views.py
+++ b/openprescribing/frontend/tests/test_bookmark_views.py
@@ -113,3 +113,9 @@ class TestBookmarkViews(TransactionTestCase):
         response = self.client.post(url, {'url': bookmark.url, 'name': 'foo'})
         self.assertContains(
             response, "your monthly update")
+
+    def test_preview_practice_bookmark_with_get_is_not_error(self):
+        url = reverse('preview-practice-bookmark',
+                      kwargs={'code': Practice.objects.first().pk})
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)

--- a/openprescribing/frontend/views/bookmark_views.py
+++ b/openprescribing/frontend/views/bookmark_views.py
@@ -120,6 +120,8 @@ def preview_bookmark(request, practice=None, pct=None, url=None, name=None):
         html = msg.alternatives[0][0]
         images = msg.attachments
         return HttpResponse(_convert_images_to_data_uris(html, images))
+    else:
+        return HttpResponse()
 
 
 def email_verification_sent(request):


### PR DESCRIPTION
...by requesting URLs in form posts against a view that only handles
POSTS.

Fixes #469