### PR TITLE
Steps towards removing all flake8 warnings

### DIFF
--- a/openprescribing/.flake8
+++ b/openprescribing/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude = *migrations*,*settings*
+ignore = E501
+statistics = true

--- a/openprescribing/api/urls.py
+++ b/openprescribing/api/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url, include
-from rest_framework import routers
 from rest_framework.urlpatterns import format_suffix_patterns
 import views_bnf_codes
 import views_spending

--- a/openprescribing/api/views_org_location.py
+++ b/openprescribing/api/views_org_location.py
@@ -1,5 +1,4 @@
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 from frontend.models import PCT, Practice
 import view_utils as utils
 from django.http import HttpResponse

--- a/openprescribing/common/utils.py
+++ b/openprescribing/common/utils.py
@@ -11,7 +11,6 @@ import re
 import uuid
 
 from django.core.exceptions import ImproperlyConfigured
-from django.forms.models import model_to_dict
 from django import db
 
 logger = logging.getLogger(__name__)

--- a/openprescribing/dmd/admin.py
+++ b/openprescribing/dmd/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/openprescribing/dmd/management/commands/fetch_dmd.py
+++ b/openprescribing/dmd/management/commands/fetch_dmd.py
@@ -1,12 +1,10 @@
 from argparse import RawTextHelpFormatter
 import datetime
 import os
-import re
 import zipfile
 
 from lxml import html
 import requests
-from tqdm import tqdm
 
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError

--- a/openprescribing/dmd/views.py
+++ b/openprescribing/dmd/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
@@ -99,7 +99,7 @@ class Command(BaseCommand):
         FROM [ebmdatalab:hscic.prescribing]
         WHERE month = TIMESTAMP('%s')""" % date.replace('_', '-')
         results = client.query(sql)
-        assert query.rows[0][0] == 0
+        assert results.rows[0][0] == 0
 
     def append_aggregated_data_to_prescribing_table(
             self, raw_data_table_name, date):

--- a/openprescribing/frontend/management/commands/create_foreign_keys.py
+++ b/openprescribing/frontend/management/commands/create_foreign_keys.py
@@ -1,7 +1,5 @@
-import csv
 import psycopg2
-from django.core.management.base import BaseCommand, CommandError
-from frontend.models import Section
+from django.core.management.base import BaseCommand
 from common import utils
 
 

--- a/openprescribing/frontend/management/commands/create_indexes.py
+++ b/openprescribing/frontend/management/commands/create_indexes.py
@@ -1,7 +1,5 @@
-import csv
 import psycopg2
-from django.core.management.base import BaseCommand, CommandError
-from frontend.models import Section
+from django.core.management.base import BaseCommand
 from common import utils
 
 

--- a/openprescribing/frontend/management/commands/generate_presentation_replacements.py
+++ b/openprescribing/frontend/management/commands/generate_presentation_replacements.py
@@ -184,7 +184,7 @@ def create_bigquery_table():
             writer.writerow([p.bnf_code, p.current_version.bnf_code])
         csv_file.seek(0)
         client = Client('hscic')
-        table = Client.get_or_create_table('bnf_map', BNF_MAP_SCHEMA)
+        table = client.get_or_create_table('bnf_map', BNF_MAP_SCHEMA)
         table.insert_rows_from_csv(csv_file.name)
 
 

--- a/openprescribing/frontend/management/commands/generate_presentation_replacements.py
+++ b/openprescribing/frontend/management/commands/generate_presentation_replacements.py
@@ -101,7 +101,6 @@ from django.core.management.base import CommandError
 from django.db import connection
 from django.db import transaction
 
-from google.cloud.bigquery import SchemaField
 from google.cloud.exceptions import Conflict
 
 from frontend.models import Chemical

--- a/openprescribing/frontend/management/commands/geocode_practices.py
+++ b/openprescribing/frontend/management/commands/geocode_practices.py
@@ -1,10 +1,8 @@
 import csv
-import requests
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.contrib.gis.gdal import SpatialReference, CoordTransform
 from django.contrib.gis.geos import Point
 from frontend.models import Practice
-from common import utils
 
 
 class Command(BaseCommand):

--- a/openprescribing/frontend/management/commands/import_adqs.py
+++ b/openprescribing/frontend/management/commands/import_adqs.py
@@ -2,7 +2,7 @@ import csv
 import re
 import sys
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from frontend.models import Presentation
 
 

--- a/openprescribing/frontend/management/commands/import_hscic_chemicals.py
+++ b/openprescribing/frontend/management/commands/import_hscic_chemicals.py
@@ -1,7 +1,7 @@
 import csv
 import glob
 import sys
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from frontend.models import Chemical
 
 

--- a/openprescribing/frontend/management/commands/import_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/import_hscic_prescribing.py
@@ -2,11 +2,9 @@ import csv
 import datetime
 import logging
 import re
-import subprocess
 import tempfile
 
 from dateutil.relativedelta import relativedelta
-from google.cloud.bigquery.dataset import Dataset
 
 from django.core.management.base import BaseCommand
 from django.db import connection

--- a/openprescribing/frontend/management/commands/import_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/import_hscic_prescribing.py
@@ -19,7 +19,7 @@ from frontend.models import Prescription
 from frontend.models import Product
 from frontend.models import Section
 
-from gcutils.bigquery import Client
+from gcutils.bigquery import Client, TableExporter
 
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,6 @@ class Command(BaseCommand):
         rows = csv.reader(open(filename, 'rU'))
         pct_codes = set()
         practices = set()
-        i = 0
         for row in rows:
             pct_codes.add(row[0])
             practices.add(row[1])

--- a/openprescribing/frontend/management/commands/import_org_names.py
+++ b/openprescribing/frontend/management/commands/import_org_names.py
@@ -1,6 +1,6 @@
 import csv
 import sys
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from frontend.models import PCT
 
 

--- a/openprescribing/frontend/management/commands/import_practice_dispensing_status.py
+++ b/openprescribing/frontend/management/commands/import_practice_dispensing_status.py
@@ -1,4 +1,3 @@
-import sys
 import xlrd
 from django.core.management.base import BaseCommand
 from frontend.models import Practice, PracticeIsDispensing as PID

--- a/openprescribing/frontend/management/commands/import_practice_dispensing_status.py
+++ b/openprescribing/frontend/management/commands/import_practice_dispensing_status.py
@@ -1,5 +1,5 @@
 import xlrd
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from frontend.models import Practice, PracticeIsDispensing as PID
 
 

--- a/openprescribing/frontend/management/commands/import_practices.py
+++ b/openprescribing/frontend/management/commands/import_practices.py
@@ -1,6 +1,6 @@
 import csv
 import glob
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from frontend.models import Practice, PCT
 
 

--- a/openprescribing/frontend/management/commands/import_qof_prevalence.py
+++ b/openprescribing/frontend/management/commands/import_qof_prevalence.py
@@ -1,5 +1,5 @@
 import csv
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from frontend.models import PCT, Practice, QOFPrevalence
 
 

--- a/openprescribing/frontend/management/commands/import_qof_prevalence.py
+++ b/openprescribing/frontend/management/commands/import_qof_prevalence.py
@@ -1,4 +1,5 @@
 import csv
+import sys
 from django.core.management.base import BaseCommand
 from frontend.models import PCT, Practice, QOFPrevalence
 
@@ -23,7 +24,6 @@ class Command(BaseCommand):
             print 'Please supply an option for year, e.g. 2013'
             sys.exit
 
-    def handle(self, *args, **options):
         start_year = options['start_year']
         ccg_file = options['by_ccg']
         practice_file = options['by_practice']

--- a/openprescribing/frontend/tests/commands/test_convert_hscic_prescribing.py
+++ b/openprescribing/frontend/tests/commands/test_convert_hscic_prescribing.py
@@ -1,5 +1,4 @@
 import csv
-import os
 import tempfile
 
 from google.cloud import storage

--- a/openprescribing/frontend/tests/commands/test_create_views.py
+++ b/openprescribing/frontend/tests/commands/test_create_views.py
@@ -1,16 +1,12 @@
 import os
-import unittest
 
-from mock import patch
 from mock import MagicMock
 
 from django.core.management import call_command
 from django.db import connection
 from django.test import SimpleTestCase
 
-from common import utils
 from gcutils.bigquery import Client
-from frontend.management.commands import create_views
 from frontend.models import ImportLog, PCT, PracticeStatistics
 from frontend.bq_schemas import (CCG_SCHEMA, PRACTICE_STATISTICS_SCHEMA,
                                  PRESCRIBING_SCHEMA)

--- a/openprescribing/frontend/tests/commands/test_generate_presentation_replacements.py
+++ b/openprescribing/frontend/tests/commands/test_generate_presentation_replacements.py
@@ -6,7 +6,6 @@ from frontend.models import Product
 from frontend.models import Section
 
 from mock import patch
-from mock import MagicMock
 
 
 @patch('frontend.management.commands.generate_presentation_replacements'

--- a/openprescribing/frontend/tests/commands/test_import_adqs.py
+++ b/openprescribing/frontend/tests/commands/test_import_adqs.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import Presentation

--- a/openprescribing/frontend/tests/commands/test_import_bnf_codes.py
+++ b/openprescribing/frontend/tests/commands/test_import_bnf_codes.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import Section, Product, Presentation

--- a/openprescribing/frontend/tests/commands/test_import_hscic_chemicals.py
+++ b/openprescribing/frontend/tests/commands/test_import_hscic_chemicals.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import Chemical

--- a/openprescribing/frontend/tests/commands/test_import_list_sizes.py
+++ b/openprescribing/frontend/tests/commands/test_import_list_sizes.py
@@ -1,8 +1,6 @@
 from django.core.management import call_command
-from django.core.management.base import CommandError
 from django.test import TestCase
 from frontend.models import Practice, PracticeStatistics, ImportLog
-from frontend.management.commands.import_list_sizes import Command
 
 PRESCRIBING_DATE = '2040-03-01'
 

--- a/openprescribing/frontend/tests/commands/test_import_org_names.py
+++ b/openprescribing/frontend/tests/commands/test_import_org_names.py
@@ -21,7 +21,6 @@ class CommandsTestCase(TestCase):
         opts = {
             'ccg': 'frontend/tests/fixtures/commands/eccg.csv'
         }
-        data_dir = 'data/org_codes'
         call_command('import_org_names', *args, **opts)
 
         ccgs = PCT.objects.filter(org_type='CCG')

--- a/openprescribing/frontend/tests/commands/test_import_org_names.py
+++ b/openprescribing/frontend/tests/commands/test_import_org_names.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 import datetime
 from django.core.management import call_command
 from django.test import TestCase

--- a/openprescribing/frontend/tests/commands/test_import_practice_dispensing_status.py
+++ b/openprescribing/frontend/tests/commands/test_import_practice_dispensing_status.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import Practice

--- a/openprescribing/frontend/tests/commands/test_import_qof_prevalence.py
+++ b/openprescribing/frontend/tests/commands/test_import_qof_prevalence.py
@@ -1,5 +1,3 @@
-import os
-import unittest
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import PCT, Practice, QOFPrevalence

--- a/openprescribing/frontend/tests/test_models.py
+++ b/openprescribing/frontend/tests/test_models.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
-from dmd.models import DMDProduct
 from frontend.models import Chemical
 from frontend.models import EmailMessage
 from frontend.models import MailLog

--- a/openprescribing/gcutils/tests/test_bigquery.py
+++ b/openprescribing/gcutils/tests/test_bigquery.py
@@ -7,7 +7,6 @@ from google.cloud import storage
 from django.test import TestCase
 
 from gcutils.bigquery import Client, TableExporter, build_schema
-from gcutils.table_dumper import TableDumper
 
 from frontend.models import PCT
 

--- a/openprescribing/pipeline/management/commands/hscic_list_sizes.py
+++ b/openprescribing/pipeline/management/commands/hscic_list_sizes.py
@@ -2,7 +2,6 @@ import requests
 from lxml import html
 import datetime
 import subprocess
-import urlparse
 import os
 
 from django.conf import settings


### PR DESCRIPTION
This takes some steps towards getting rid of all `flake8` warnings.

In particular:

 * we ignore errors from migrations (which are autogenerated) and settings files (which contain lots of * imports)
 * we've removed any unused imports
 * we've addressed various other code smell warnings, including a couple of bugs caused by using undefined variables