### PR TITLE
Avoid N+1-type query issue in measures

### DIFF
--- a/openprescribing/api/views_measures.py
+++ b/openprescribing/api/views_measures.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from frontend.models import ImportLog
 from frontend.models import Measure
+from frontend.models import MeasureGlobal
 
 import view_utils as utils
 
@@ -16,62 +17,52 @@ class MissingParameter(APIException):
 @api_view(['GET'])
 def measure_global(request, format=None):
     measure = request.query_params.get('measure', None)
-    tags = request.query_params.get('tags', None)
-    params = []
-    query = 'SELECT mg.month AS date, mg.numerator,  '
-    query += 'mg.denominator, mg.measure_id, '
-    query += 'mg.calc_value, mg.percentiles, mg.cost_savings, '
-    query += 'ms.name, ms.title, ms.description, '
-    query += 'ms.why_it_matters, ms.tags_focus, '
-    query += ' ms.denominator_short, ms.numerator_short, '
-    query += 'ms.url, ms.is_cost_based, ms.is_percentage, '
-    query += 'ms.low_is_good '
-    query += "FROM frontend_measureglobal mg "
-    query += "JOIN frontend_measure ms ON mg.measure_id=ms.id "
+    tags = request.query_params.getlist('tags', None)
+    qs = MeasureGlobal.objects.select_related('measure')
     if measure:
-        query += "WHERE mg.measure_id=%s "
-        params.append(measure)
+        qs = qs.filter(measure_id=measure)
     if tags:
-        for tag in tags.split(','):
-            query += "AND %s = ANY(ms.tags) "
-            params.append(tag)
-    query += "ORDER BY mg.measure_id, mg.month"
-    data = utils.execute_query(query, [params])
+        qs = qs.filter(measure__tags__overlap=tags)
+    qs = qs.order_by('measure_id', 'month')
     rolled = {}
-    for d in data:
-        id = d['measure_id']
-        m = Measure.objects.get(pk=id)
+    for mg in qs:
+        id = mg.measure_id
         d_copy = {
-            'date': d['date'],
-            'numerator': d['numerator'],
-            'denominator': d['denominator'],
-            'calc_value': d['calc_value'],
-            'percentiles': d['percentiles'],
-            'cost_savings': d['cost_savings']
+            'date': mg.month,
+            'numerator': mg.numerator,
+            'denominator': mg.denominator,
+            'calc_value': mg.calc_value,
+            'percentiles': mg.percentiles,
+            'cost_savings': mg.cost_savings
         }
         if id in rolled:
             rolled[id]['data'].append(d_copy)
         else:
-            tags_focus = d['tags_focus'] and ','.join(d['tags_focus']) or ''
+            measure = mg.measure
+            if measure.tags_focus:
+                tags_focus = ','.join(measure.tags_focus)
+            else:
+                tags_focus = ''
             rolled[id] = {
                 'id': id,
-                'name': d['name'],
-                'title': d['title'],
-                'description': d['description'],
-                'why_it_matters': d['why_it_matters'],
-                'numerator_short': d['numerator_short'],
-                'denominator_short': d['denominator_short'],
-                'url': d['url'],
-                'is_cost_based': d['is_cost_based'],
-                'is_percentage': d['is_percentage'],
-                'low_is_good': d['low_is_good'],
+                'name': measure.name,
+                'title': measure.title,
+                'description': measure.description,
+                'why_it_matters': measure.why_it_matters,
+                'numerator_short': measure.numerator_short,
+                'denominator_short': measure.denominator_short,
+                'url': measure.url,
+                'is_cost_based': measure.is_cost_based,
+                'is_percentage': measure.is_percentage,
+                'low_is_good': measure.low_is_good,
                 'tags_focus': tags_focus,
-                'numerator_can_be_queried': m.numerator_can_be_queried(),
+                'numerator_can_be_queried': measure.numerator_can_be_queried(),
                 'data': [d_copy]
             }
     d = {
         'measures': [rolled[k] for k in rolled]
     }
+
     return Response(d)
 
 

--- a/openprescribing/api/views_measures.py
+++ b/openprescribing/api/views_measures.py
@@ -17,7 +17,7 @@ class MissingParameter(APIException):
 @api_view(['GET'])
 def measure_global(request, format=None):
     measure = request.query_params.get('measure', None)
-    tags = request.query_params.getlist('tags', None)
+    tags = [x for x in request.query_params.get('tags', '').split(',') if x]
     qs = MeasureGlobal.objects.select_related('measure')
     if measure:
         qs = qs.filter(measure_id=measure)
@@ -146,7 +146,7 @@ def measure_numerators_by_org(request, format=None):
 def measure_by_ccg(request, format=None):
     measure = request.query_params.get('measure', None)
     orgs = utils.param_to_list(request.query_params.get('org', []))
-    tags = request.query_params.get('tags', None)
+    tags = [x for x in request.query_params.get('tags', '').split(',') if x]
     params = []
     query = 'SELECT mv.month AS date, mv.numerator, mv.denominator, '
     query += 'mv.calc_value, mv.percentile, mv.cost_savings, '
@@ -173,10 +173,9 @@ def measure_by_ccg(request, format=None):
     if measure:
         query += "AND mv.measure_id=%s "
         params.append(measure)
-    if tags:
-        for tag in tags.split(','):
-            query += "AND %s = ANY(ms.tags) "
-            params.append(tag)
+    for tag in tags:
+        query += "AND %s = ANY(ms.tags) "
+        params.append(tag)
     query += "ORDER BY mv.pct_id, measure_id, date"
     data = utils.execute_query(query, [params])
     rolled = {}
@@ -222,7 +221,7 @@ def measure_by_practice(request, format=None):
     orgs = utils.param_to_list(request.query_params.get('org', []))
     if not orgs:
         raise MissingParameter
-    tags = request.query_params.get('tags', None)
+    tags = [x for x in request.query_params.get('tags', '').split(',') if x]
     params = []
     query = 'SELECT mv.month AS date, mv.numerator, mv.denominator, '
     query += 'mv.calc_value, mv.percentile, mv.cost_savings, '
@@ -246,10 +245,9 @@ def measure_by_practice(request, format=None):
     if measure:
         query += "AND mv.measure_id=%s "
         params.append(measure)
-    if tags:
-        for tag in tags.split(','):
-            query += "AND %s = ANY(ms.tags) "
-            params.append(tag)
+    for tag in tags:
+        query += "AND %s = ANY(ms.tags) "
+        params.append(tag)
     query += "ORDER BY mv.practice_id, measure_id, date"
     data = utils.execute_query(query, [params])
     rolled = {}

--- a/openprescribing/frontend/tests/test_api_measures.py
+++ b/openprescribing/frontend/tests/test_api_measures.py
@@ -82,6 +82,12 @@ class TestAPIMeasureViews(TestCase):
         data = json.loads(response.content)
         self.assertEqual(len(data['measures']), 1)
 
+        url = '/api/1.0/measure/?format=json&tags=core,XXX'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(len(data['measures']), 1)
+
     def test_api_measure_by_all_ccgs(self):
         url = '/api/1.0/measure/?format=json'
         data = self._get_json(url)


### PR DESCRIPTION
The previous implementation involved 2400+ separate select queries,
just to load the Measure model for a single field.

This is also more readable.

Fixes part of #620