### PR TITLE
Make alert sending idempotent within a single month

### DIFF
--- a/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
+++ b/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
@@ -110,12 +110,34 @@
   }
 },
 {
+  "model": "frontend.orgbookmark",
+  "pk": 4,
+  "fields": {
+    "user": 4,
+    "pct": null,
+    "practice": "P87629",
+    "approved": true,
+    "created_at": "2000-01-01T12:00:00Z"
+  }
+},
+{
   "model": "frontend.searchbookmark",
   "pk": 1,
   "fields": {
     "user": 1,
     "url": "foo",
     "name": "foo",
+    "approved": true,
+    "created_at": "2000-01-01T12:00:00Z"
+  }
+},
+{
+  "model": "frontend.searchbookmark",
+  "pk": 2,
+  "fields": {
+    "user": 4,
+    "url": "foo",
+    "name": "foo-already-seen-user",
     "approved": true,
     "created_at": "2000-01-01T12:00:00Z"
   }
@@ -177,6 +199,18 @@
   }
 },
 {
+  "model": "frontend.emailmessage",
+  "pk": 1,
+  "fields": {
+    "message_id": "123",
+    "to": ["foo@baz.com"],
+    "subject":"test",
+    "user_id": 4,
+    "tags": ["2014-11-01", "measures", "analyse"],
+    "created_at": "2014-12-01"
+  }
+},
+{
   "model": "auth.user",
   "pk": 3,
   "fields": {
@@ -188,6 +222,24 @@
     "last_name": "",
     "email": "foo3@baz.com",
     "is_staff": true,
+    "is_active": true,
+    "date_joined": "2016-09-28T15:08:58.446Z",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "pk": 4,
+  "fields": {
+    "password": "!pZgapyTQg0svG35XcW1qhCthZomwBxMg2ZpTvQv6",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "bookmarks-already-sent-user",
+    "first_name": "",
+    "last_name": "",
+    "email": "foo3@baz.com",
+    "is_staff": false,
     "is_active": true,
     "date_joined": "2016-09-28T15:08:58.446Z",
     "groups": [],

--- a/openprescribing/frontend/tests/test_bookmark_views.py
+++ b/openprescribing/frontend/tests/test_bookmark_views.py
@@ -46,7 +46,7 @@ class TestBookmarkViews(TransactionTestCase):
             self.assertContains(
                 response,
                 "Unsubscribed from 1 alert")
-        self.assertEqual(OrgBookmark.objects.count(), 0)
+        self.assertEqual(OrgBookmark.objects.count(), 1)
 
     def test_unsubscribe_all_at_once(self):
         # First, log in
@@ -60,7 +60,7 @@ class TestBookmarkViews(TransactionTestCase):
             "Unsubscribed from 3 alerts")
         # There's one org bookmark which is unapproved, so they don't
         # see it in their list, and it doesn't get deleted.
-        self.assertEqual(OrgBookmark.objects.count(), 1)
+        self.assertEqual(OrgBookmark.objects.count(), 2)
 
     @patch('frontend.views.bookmark_utils.InterestingMeasureFinder')
     @patch('frontend.views.bookmark_utils.subprocess')

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -615,7 +615,7 @@ def make_email_with_campaign(bookmark, campaign_source):
     return msg
 
 
-def make_org_email(org_bookmark, stats, preview=False):
+def make_org_email(org_bookmark, stats, preview=False, tag=None):
     msg = make_email_with_campaign(org_bookmark, 'dashboard-alerts')
     dashboard_uri = org_bookmark.dashboard_url()
     if preview:
@@ -680,11 +680,11 @@ def make_org_email(org_bookmark, stats, preview=False):
             msg.body = text
         msg.attach_alternative(html, "text/html")
         msg.extra_headers['list-unsubscribe'] = "<%s>" % unsubscribe_link
-        msg.tags = ["monthly_update", "measures"]
+        msg.tags = ["monthly_update", "measures", tag]
         return msg
 
 
-def make_search_email(search_bookmark, preview=False):
+def make_search_email(search_bookmark, preview=False, tag=None):
     msg = make_email_with_campaign(search_bookmark, 'analyse-alerts')
     html_email = get_template('bookmarks/email_for_searches.html')
     parsed_url = urlparse.urlparse(search_bookmark.dashboard_url())
@@ -729,7 +729,7 @@ def make_search_email(search_bookmark, preview=False):
             msg.body = text
         msg.attach_alternative(html, "text/html")
         msg.extra_headers['list-unsubscribe'] = "<%s>" % unsubscribe_link
-        msg.tags = ["monthly_update", "analyse"]
+        msg.tags = ["monthly_update", "analyse", tag]
         return msg
 
 


### PR DESCRIPTION
We record the month of an alert bookmark in each message as it goes
out; this allows us to exclude alerts that have already gone out this
month.

Closes #620 

For the current month, as 25 emails have already gone out, we need to add the relevant time stamp as a tag.