### PR TITLE
Create normalised_prescribing_legacy table in tests when required

### DIFF
--- a/openprescribing/frontend/tests/commands/test_import_measures.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
 
+from frontend.bq_schemas import PRESCRIBING_SCHEMA
 from frontend.management.commands.import_measures import Command
 from frontend.models import Measure
 from frontend.models import MeasureValue, MeasureGlobal, Chemical
@@ -490,7 +491,10 @@ class BigqueryFunctionalTests(TestCase):
                 'prescribing_bigquery_fixture.csv'
             )
             client = Client('measures')
-            table = client.get_table(settings.BQ_PRESCRIBING_TABLE_NAME)
+            table = client.get_or_create_table(
+                settings.BQ_PRESCRIBING_TABLE_NAME,
+                PRESCRIBING_SCHEMA
+            )
             table.insert_rows_from_csv(prescribing_fixture_path)
         month = '2015-09-01'
         measure_id = 'cerazette'


### PR DESCRIPTION
Fixes #622.

The fix is by analogy to [this code](https://github.com/ebmdatalab/openprescribing/blob/master/openprescribing/frontend/tests/commands/test_create_views.py#L50-L53) in `test_create_views.py`.