### PR TITLE
Only produce alerts on `core` measures.

### DIFF
--- a/openprescribing/frontend/tests/fixtures/measurevalues_with_performance.json
+++ b/openprescribing/frontend/tests/fixtures/measurevalues_with_performance.json
@@ -1,0 +1,418 @@
+[
+  {
+    "model": "frontend.measure",
+    "pk": "exotic",
+    "fields": {
+      "name": "Exotic measure",
+      "title": "Exotic measure",
+      "description": "",
+      "why_it_matters": "",
+      "numerator_short": "",
+      "tags": ["exotic"],
+      "denominator_short": "",
+      "start_date": "2001-01-01",
+      "end_date": "2001-01-01",
+      "url": "",
+      "is_percentage": true,
+      "is_cost_based": true,
+      "low_is_good": true
+    }
+  },
+  {
+    "model": "frontend.measure",
+    "pk": "cerazette",
+    "fields": {
+      "name": "Cerazette vs. Desogestrel",
+      "title": "cerazette",
+      "description": "",
+      "why_it_matters": "",
+      "numerator_short": "",
+      "tags": ["core"],
+      "denominator_short": "",
+      "start_date": "2001-01-01",
+      "end_date": "2001-01-01",
+      "url": "",
+      "is_percentage": true,
+      "is_cost_based": true,
+      "low_is_good": true
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 847,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": null,
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 848,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 849,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 850,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": null,
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 851,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 852,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2017-11-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 853,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": null,
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 854,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 855,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 856,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": null,
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 857,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 858,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2017-12-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 859,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": null,
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 860,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 861,
+    "fields": {
+      "measure": "cerazette",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 862,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": null,
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 863,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87629",
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 95,
+      "cost_savings": null
+    }
+  },
+  {
+    "model": "frontend.measurevalue",
+    "pk": 864,
+    "fields": {
+      "measure": "exotic",
+      "pct": "03V",
+      "practice": "P87630",
+      "month": "2018-01-08",
+      "numerator": null,
+      "denominator": null,
+      "calc_value": null,
+      "num_items": null,
+      "denom_items": null,
+      "num_cost": null,
+      "denom_cost": null,
+      "num_quantity": null,
+      "denom_quantity": null,
+      "percentile": 5,
+      "cost_savings": null
+    }
+  }
+]

--- a/openprescribing/frontend/tests/test_bookmark_utils.py
+++ b/openprescribing/frontend/tests/test_bookmark_utils.py
@@ -168,42 +168,16 @@ class TestCUSUM(unittest.TestCase):
 
 
 class TestBookmarkUtilsPerforming(TestCase):
-    fixtures = ['bookmark_alerts', 'measures']
+    fixtures = ['bookmark_alerts',
+                'measurevalues_with_performance',
+                'importlog']
 
     def setUp(self):
-        self.measure_id = 'cerazette'
-        self.measure = Measure.objects.get(pk=self.measure_id)
-        self.measure.low_is_good = True
-        self.measure.save()
+        self.measure = Measure.objects.get(pk='cerazette')
+        self.exotic_measure = Measure.objects.get(pk='exotic')
         pct = PCT.objects.get(pk='03V')
         practice_with_high_percentiles = Practice.objects.get(pk='P87629')
         practice_with_low_percentiles = Practice.objects.get(pk='P87630')
-        ImportLog.objects.create(
-            category='prescribing',
-            current_at=datetime.today())
-        for i in range(3):
-            month = datetime.today() + relativedelta(months=i)
-            MeasureValue.objects.create(
-                measure=self.measure,
-                practice=None,
-                pct=pct,
-                percentile=95,
-                month=month
-            )
-            MeasureValue.objects.create(
-                measure=self.measure,
-                practice=practice_with_high_percentiles,
-                pct=pct,
-                percentile=95,
-                month=month
-            )
-            MeasureValue.objects.create(
-                measure=self.measure,
-                practice=practice_with_low_percentiles,
-                pct=pct,
-                percentile=5,
-                month=month
-            )
         self.pct = pct
         self.high_percentile_practice = practice_with_high_percentiles
         self.low_percentile_practice = practice_with_low_percentiles
@@ -215,6 +189,7 @@ class TestBookmarkUtilsPerforming(TestCase):
             pct=self.pct)
         worst_measures = finder.worst_performing_in_period(3)
         self.assertIn(self.measure, worst_measures)
+        self.assertNotIn(self.exotic_measure, worst_measures)
 
     def test_miss_where_not_enough_global_data(self):
         finder = bookmark_utils.InterestingMeasureFinder(

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -238,7 +238,7 @@ class InterestingMeasureFinder(object):
         worst = []
         measure_filter = {
             'month__gte': self.months_ago(period),
-            'measure__tags': ['core']
+            'measure__tags__contains': ['core']
         }
         if self.practice:
             measure_filter['practice'] = self.practice
@@ -297,7 +297,8 @@ class InterestingMeasureFinder(object):
         window_multiplier = 1.5
         window_plus = int(round(window * window_multiplier))
         measure_filter = {
-            'month__gte': self.months_ago(window_plus)
+            'month__gte': self.months_ago(window_plus),
+            'measure__tags__contains': ['core']
         }
         if self.practice:
             measure_filter['practice'] = self.practice
@@ -373,7 +374,8 @@ class InterestingMeasureFinder(object):
         achieved_savings = []
         total_savings = 0
         measure_filter = {
-            'month__gte': self.months_ago(period)}
+            'month__gte': self.months_ago(period),
+            'measure__tags__contains': ['core']}
         if self.practice:
             measure_filter['practice'] = self.practice
         else:


### PR DESCRIPTION
Low Priority measures are still in "labs" status and we're not sure of the impact of including them in our overall summaries.

Also, the chart-grabbing logic for adding images to emails would need changing to support these; so the Aug mailouts broke.

