### PR TITLE
Remove {% if not debug %} from base.html

### DIFF
--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -54,14 +54,6 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     <script src="https://use.typekit.net/hkz3kmo.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
-    <script>
-    (function(_,e,rr,s){_errs=[s];var c=_.onerror;_.onerror=function(){var a=arguments;_errs.push(a);
-    c&&c.apply(this,a)};var b=function(){var c=e.createElement(rr),b=e.getElementsByTagName(rr)[0];
-    c.src="//beacon.errorception.com/"+s+".js";c.async=!0;b.parentNode.insertBefore(c,b)};
-    _.addEventListener?_.addEventListener("load",b,!1):_.attachEvent("onload",b)})
-    (window,document,"script","522f5e54238d18034c0017fc");
-    </script>
-
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous" />
     <link href="{% static 'css/index.css' %}?q=1234567" rel="stylesheet">
 

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -54,7 +54,6 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     <script src="https://use.typekit.net/hkz3kmo.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
-    {% if not debug %}
     <script>
     (function(_,e,rr,s){_errs=[s];var c=_.onerror;_.onerror=function(){var a=arguments;_errs.push(a);
     c&&c.apply(this,a)};var b=function(){var c=e.createElement(rr),b=e.getElementsByTagName(rr)[0];
@@ -62,8 +61,6 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     _.addEventListener?_.addEventListener("load",b,!1):_.attachEvent("onload",b)})
     (window,document,"script","522f5e54238d18034c0017fc");
     </script>
-    {% endif %}
-
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous" />
     <link href="{% static 'css/index.css' %}?q=1234567" rel="stylesheet">


### PR DESCRIPTION
As far as I can tell, debug is never set in a template's context.  This
has been in the code since day one, and is responsible for a lot of
noise in the test output on Travis, where we're logging everything at
debug level.

(Also: do we ever use errorception?)