### PR TITLE
Fix regex pattern in backup_prescribing_table

### DIFF
--- a/openprescribing/pipeline/management/commands/backup_prescribing_table.py
+++ b/openprescribing/pipeline/management/commands/backup_prescribing_table.py
@@ -22,10 +22,7 @@ class Command(BaseCommand):
         prefix_base = 'prescribing/prescribing_backups/'
 
         for blob in bucket.list_blobs(prefix=prefix_base):
-            match = re.search(
-                '{}/(\d{4}_\d{2})-'.format(prefix_base),
-                blob.name
-            )
+            match = re.search('/(\d{4}_\d{2})-', blob.name)
             year_and_months.add(match.groups()[0])
 
         if latest_year_and_month in year_and_months:


### PR DESCRIPTION
The pattern contains both {} (for format) and {4}, for repeated characters.

This confused str.format().