### PR TITLE
Add ordering for tables and views

### DIFF
--- a/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
+++ b/openprescribing/frontend/management/commands/convert_hscic_prescribing.py
@@ -141,6 +141,8 @@ class Command(BaseCommand):
          WHERE Practice_Code NOT LIKE '%%998'  -- see issue #349
          GROUP BY
            presentation_code, pct_id, practice_code
+         ORDER BY
+           presentation_code, pct_id, practice_code
         ''' % (date, raw_data_table.qualified_name)
 
         fmtd_data_table_name = 'formatted_prescribing_%s' % year_and_month

--- a/openprescribing/frontend/management/commands/views_sql/ccgstatistics.sql
+++ b/openprescribing/frontend/management/commands/views_sql/ccgstatistics.sql
@@ -25,3 +25,5 @@ GROUP BY
   month,
   pct_id,
   name
+ORDER BY
+  pct_id

--- a/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_ccg.sql
+++ b/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_ccg.sql
@@ -12,3 +12,5 @@ GROUP BY
   processing_date,
   pct_id,
   chemical_id
+ORDER BY
+  chemical_id, pct_id

--- a/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_practice.sql
+++ b/openprescribing/frontend/management/commands/views_sql/chemical_summary_by_practice.sql
@@ -12,3 +12,5 @@ GROUP BY
   processing_date,
   practice_id,
   chemical_id
+ORDER BY
+  chemical_id, practice_id

--- a/openprescribing/frontend/management/commands/views_sql/practice_summary.sql
+++ b/openprescribing/frontend/management/commands/views_sql/practice_summary.sql
@@ -10,3 +10,5 @@ WHERE month > TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   practice_id
+ORDER BY
+  practice_id, month

--- a/openprescribing/frontend/management/commands/views_sql/presentation_summary.sql
+++ b/openprescribing/frontend/management/commands/views_sql/presentation_summary.sql
@@ -11,3 +11,5 @@ WHERE month > TIMESTAMP(DATE_SUB(DATE "{{this_month}}", INTERVAL 5 YEAR))
 GROUP BY
   processing_date,
   presentation_code
+ORDER BY
+  presentation_code, processing_date

--- a/openprescribing/frontend/management/commands/views_sql/presentation_summary_by_ccg.sql
+++ b/openprescribing/frontend/management/commands/views_sql/presentation_summary_by_ccg.sql
@@ -13,3 +13,5 @@ GROUP BY
   processing_date,
   pct_id,
   presentation_code
+ORDER BY
+  presentation_code, pct_id


### PR DESCRIPTION
As the prescribing tables are always written anew and never updated or
appended to, this is equivalent to CLUSTERing and should therefore
significantly reduce (for example) index recheck times.