### PR TITLE
Pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v1.1.1
+    hooks:
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: debug-statements
+    -   id: detect-private-key
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
 -   repo: git://github.com/pre-commit/mirrors-yapf
     sha: v0.20.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+-   repo: git://github.com/pre-commit/mirrors-yapf
+    sha: v0.20.0
+    hooks:
+    -   id: yapf

--- a/README.md
+++ b/README.md
@@ -314,6 +314,16 @@ Or for staging:
 
     fab deploy:staging,force_build=true,branch=deployment
 
+# Development
+
+Various hooks can be run before committing.  Pre-commit hooks are managed by https://github.com/pre-commit/pre-commit-hooks.
+
+To install the hooks, run once:
+
+    pre-commit install
+
+Details of the hooks are in .pre-commit-config.yaml
+
 # Philosophy
 
 This project follows design practices from [Two Scoops of Django](http://twoscoopspress.org/products/two-scoops-of-django-1-6).

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,5 +8,7 @@ fabric==1.13.1
 flake8
 graphviz
 pip-tools
+pre-commit
 werkzeug
 when-changed
+yapf


### PR DESCRIPTION
Set up various pre-commit hooks.

Each developer will need to run `pip install -r requirements/local.txt` followed by `pre-commit install` to get the benefit of the hooks.

If it turns out any hooks are unhelpful, we can remove them!