### PR TITLE
Only show one line per BNF-code in PPU tables

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -230,7 +230,7 @@ def price_per_unit(request, format=None):
     if savings:
         codes_with_metadata = DMDProduct.objects.filter(
             bnf_code__in=[d['presentation'] for d in savings], concept_class=1).only(
-                'bnf_code', 'name', 'is_non_bioequivalent').all()
+                'bnf_code', 'name', 'is_non_bioequivalent').distinct('bnf_code').all()
         combined = pd.DataFrame(savings).set_index('presentation')
         combined['presentation'] = combined.index
         metadata = pd.DataFrame([

--- a/openprescribing/frontend/tests/fixtures/dmdproducts.json
+++ b/openprescribing/frontend/tests/fixtures/dmdproducts.json
@@ -30,6 +30,37 @@
   }
 },
 {
+  "model": "dmd.dmdproduct",
+  "pk": 526311000001107,
+  "fields": {
+    "bnf_code": "0202010F0AAAAAA",
+    "vpid": 318248001,
+    "name": "Verapamil 160mg tablets",
+    "full_name": "Verapamil 160mg tablets (dupe)",
+    "ema": null,
+    "prescribability": 1,
+    "availability_restrictions": 1,
+    "vmp_non_availability": 0,
+    "concept_class": 1,
+    "product_type": 3,
+    "is_in_nurse_formulary": false,
+    "is_in_dentist_formulary": false,
+    "product_order_no": null,
+    "is_blacklisted": false,
+    "is_schedule_2": false,
+    "can_have_personal_administration_fee": false,
+    "is_fp10": false,
+    "is_borderline_substance": false,
+    "has_assorted_flavours": false,
+    "controlled_drug_category": 0,
+    "tariff_category": 1,
+    "is_imported": false,
+    "is_broken_bulk": false,
+    "is_non_bioequivalent": false,
+    "is_special_container": false
+  }
+},
+{
   "model": "dmd.availabilityrestriction",
   "pk": 1,
   "fields": {

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -451,6 +451,7 @@ class TestAPISpendingViewsPPUTable(ApiTestBase):
             "id": 5,
             "possible_savings": 100.0
         }
+        self.assertEqual(len(data), 1)
         self.assertEqual(data[0], expected)
 
 


### PR DESCRIPTION
Fixes #686 