### PR TITLE
Update docker environment for local tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    DOCKER_COMPOSE_VERSION: 1.7.1
+    DOCKER_COMPOSE_VERSION: 1.9.0
   matrix:
     - TEST_SUITE=nonfunctional
     - TEST_SUITE=functional BROWSER="firefox:latest:Windows 2012"

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,7 @@
 FROM ebmdatalab/openprescribing-base:latest
 
+wget -qO- https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz | tar xvz -C /usr/bin
+apt-get update && apt-get install -y firefox-esr xvfb
+
 ADD requirements /tmp/requirements/
 RUN pip install -r /tmp/requirements/test.txt && rm -rf /tmp/requirements

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ using docker.
 
 Install `docker` and `docker-compose` per
 [the instructions](https://docs.docker.com/compose/install/) (you need
-at least Compose 1.6.0+ and Docker Engine of version 1.10.0+.)
+at least Compose 1.9.0+ and Docker Engine of version 1.12.0+.)
 
 In the project root, run
 
     docker-compose run test
 
-This will pull down the relevant images, and run the tests.  In our CI
-system, we also run checks against the production environment, which
+This will pull down the relevant images, and run the tests.  In order for all
+tests to run successfully, you will also need to decrypt the credentials file
+openprescribing/google-credentials.json.
+
+In our CI system, we also run checks against the production environment, which
 you can reproduce with
 
     docker-compose run test-production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   db-test:
     image: mdillon/postgis:latest
@@ -19,7 +19,7 @@ services:
       - USE_SAUCELABS=${USE_SAUCELABS}
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
     extra_hosts:
-      - "saucehost:${SAUCE_HOST}"
+      - saucehost:${SAUCE_HOST-127.0.0.1}
     ports:
       - "6080:6080"
       - "6060:6060"


### PR DESCRIPTION
As it currently stands, the README instructions for running tests locally in docker with `docker-compose run test` need a couple of extra things to get them working.

-  The `SAUCE_HOST` environment variable is required (but not actually used afaict, unless the env variable `USE_SAUCELABS` is True.  It needs a value though.  I've update the docker-compose version to v2.1 so that it will accept a default value.  This also means updating minimum requirements of Compose and Docker Engine.
 
- Selenium tests don't work because they depend on firefox, geckodriver and xvfb.  
I've added install lines to `Dockerfile-test`, on the assumption that you'll want this to be updated in the image.  For testing it locally, I added those to the end of the docker-setup-sh.  Note that apt-get install of firefox on Jessie installs version 52.X which doesn’t work with later versions of geckoworker.

- `google-credentials.json` needs to be decrypted.  I added a comment to the README to that effect - but I guess these will just be expected test failures for external contributors.  Perhaps there could be a flag to pass to the test script that skips tests needing google auth credentials?
