### PR TITLE
Update docs and uglifyjs requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Install library dependencies (current as of Debian Jessie):
 
     sudo apt-get install nodejs binutils libproj-dev gdal-bin libgeoip1 libgeos-c1 git-core vim sudo screen supervisor libpq-dev python-dev python-pip python-virtualenv python-gdal postgis emacs nginx build-essential libssl-dev libffi-dev unattended-upgrades libblas-dev liblapack-dev libatlas-base-dev gfortran libxml2-dev libxslt1-dev
 
+Ensure pip and setuptools are up to date:
+
+    pip install -U pip setuptools
+
 Install Python dependencies in development:
 
     pip install -r requirements/local.txt --process-dependency-links
@@ -98,12 +102,13 @@ Or in production:
 
     pip install -r requirements.txt --process-dependency-links
 
-And then install JavaScript dependencies. You'll need a version of
-nodejs greater than v0.10.11:
+And then install JavaScript dependencies. Make sure you have the latest version
+of nodejs:
 
     cd openprescribing/media/js
     npm install -g browserify
     npm install -g jshint
+    npm install -g less
     npm install
 
 To generate monthly alert emails (and run the tests for those) you'll
@@ -112,7 +117,7 @@ it from [here](http://phantomjs.org/download.html).
 
 ### Create database and env variables
 
-Set up a Postgres 9.4 database (required for `jsonb` type), with
+Set up a Postgres 9.5 database (required for `jsonb` type), with
 PostGIS extensions, and create a superuser for the database.
 
     createuser -s <myuser>

--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -59,13 +59,13 @@
     "chroma-js": "^1.2",
     "clipboard": "^1.5.12",
     "cookies-js": "1.2.3",
+    "downloadjs": "^1.4.7",
     "handlebars": "4.0.5",
     "humanize": "^0.0.9",
     "jquery": "^1.11.3",
     "mapbox.js": "^2.2.1",
     "moment": "^2.10.3",
-    "underscore": "^1.8.3",
-    "downloadjs": "^1.4.7"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "browserify": "^9.0.8",
@@ -76,7 +76,7 @@
     "eslint-config-google": "latest",
     "less": "^2.5.1",
     "mocha": "^2.2.5",
-    "uglifyjs": "^2.4.10",
+    "uglify-js": "^3.3.16",
     "watchify": "^3.2.1",
     "envify": "^3.4.1"
   }


### PR DESCRIPTION
A few updates to the README for issues that I came across while setting up a non-docker environment.  

- pip and setuptools need to be up to date otherwise some of the requirements fail to install properly
- various JS dependencies complain about the node version (some wanting node > v8.0)
- uglifyjs is deprecated and `npm run build` fails. Updated package.json with uglify-js instead
- `npm install -g less` is also required for `npm run build` to complete successfully
- postgres 9.5 is required for the `replace_matviews` and `import_dmd` management commands that use `CREATE INDEX IF NOT EXISTS` syntax (not available before 9.5)