### PR TITLE
Revert "Loosen column header assertions in import_dmd_snomed"

### DIFF
--- a/openprescribing/dmd/management/commands/import_dmd_snomed.py
+++ b/openprescribing/dmd/management/commands/import_dmd_snomed.py
@@ -31,8 +31,8 @@ class Command(BaseCommand):
         rows = wb.active.rows
 
         headers = rows[0]
-        assert 'bnf code' in headers[0].value.lower()
-        assert 'snomed code' in headers[2].value.lower()
+        assert headers[0].value.lower() == 'bnf code'
+        assert headers[2].value.lower() == 'snomed code'
 
         with transaction.atomic():
             with connection.cursor() as cursor:


### PR DESCRIPTION
This reverts commit 9b3390bb0d69f9f2cf887863668924117d85635c.