### PR TITLE
Add beginnings of data flow visualisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ openprescribing/media/js/node_modules
 openprescribing/static/js/*js
 openprescribing/static/css/index.css
 openprescribing/assets
+openprescribing/docs/*.svg
 analysis/
-docs/
 cache-warming/
 openprescribing/pipeline/e2e-test-data/data
 openprescribing/pipeline/e2e-test-data/log.json

--- a/openprescribing/docs/api_endpoints.yml
+++ b/openprescribing/docs/api_endpoints.yml
@@ -1,0 +1,134 @@
+- label: total_spending
+  view_fn: views_spending.total_spending
+  path: ^spending/$
+  dependencies:
+    - tables.Section
+    - tables.vw__presentation_summary
+
+- label: bubble
+  view_fn: views_spending.bubble
+  path: ^bubble/$
+  dependencies:
+    - tables.GenericCodeMapping
+    - tables.Prescription
+    - tables.Presentation
+    - tables.Practice
+
+- label: tariff
+  view_fn: views_spending.tariff
+  path: ^tariff/$
+  dependencies:
+    - tables.DMDTariffPrice
+    - tables.DMDProduct
+    - tables.DMDVmpp
+    - tables.NCSOConcession
+    - tables.dmd_lookup_dt_payment_category
+
+- label: spending_by_ccg
+  view_fn: views_spending.spending_by_ccg
+  path: ^spending_by_ccg/$
+  example_url: https://openprescribing.net/api/1.0/spending_by_ccg/?format=json&code=0703021Q0BB
+  dependencies:
+    - tables.Section
+    - tables.vw__chemical_summary_by_ccg
+    - tables.vw__presentation_summary_by_ccg
+    - tables.PCT
+
+- label: spending_by_practice
+  view_fn: views_spending.spending_by_practice
+  path: ^spending_by_practice/$
+  example_urls:
+    - https://openprescribing.net/api/1.0/spending_by_practice/?format=json&code=0703021Q0BB&org=11M
+    - https://openprescribing.net/api/1.0/spending_by_practice/?format=json&code=0703021Q0BB&org=L84613
+  dependencies:
+    - tables.Section
+    - tables.Practice
+    - tables.Prescription
+    - tables.vw__chemical_summary_by_practice
+    - tables.vw__practice_summary
+
+- label: measure
+  view_fn: views_measures.measure_global
+  path: ^measure/$
+  dependencies:
+    - tables.MeasureGlobal
+
+- label: measure_by_ccg
+  view_fn: views_measures.measure_by_ccg
+  path: ^measure_by_ccg/$
+  dependencies:
+    - tables.MeasureValue
+
+- label: measure_numerators_by_org
+  view_fn: views_measures.measure_numerators_by_org
+  path: ^measure_numerators_by_org/$
+  dependencies:
+    - tables.Measure
+    - tables.DMDProduct
+    - tables.Prescription
+    - tables.Presentation
+
+- label: measure_by_practice
+  view_fn: views_measures.measure_by_practice
+  path: ^measure_by_practice/$
+  dependencies:
+    - tables.MeasureValue
+
+- label: price_per_unit
+  view_fn: views_spending.price_per_unit
+  path: ^price_per_unit/$
+  dependencies:
+    - tables.Presentation
+    - tables.Practice
+    - tables.PPUSaving
+    - tables.DMDProduct
+    - tables.DMDVmpp
+    - tables.NCSOConcession
+
+- label: org_details
+  view_fn: views_org_details.org_details
+  path: ^org_details/$
+  example_urls:
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=ccg&keys=nothing
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=ccg&keys=star_pu.oral_antibacterials_item
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=ccg&keys=total_list_size
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=practice&keys=nothing&org=11M
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=practice&keys=star_pu.oral_antibacterials_item&org=11M
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=practice&keys=star_pu.oral_antibacterials_item&org=L84613
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=practice&keys=total_list_size&org=11M
+    - https://openprescribing.net/api/1.0/org_details/?format=json&org_type=practice&keys=total_list_size&org=L84613
+  dependencies:
+    - tables.PracticeStatistics
+    - tables.Practice
+    - tables.vw__ccgstatistics
+
+- label: bnf_codes
+  view_fn: views_bnf_codes.bnf_codes
+  path: ^bnf_code/$
+  example_urls:
+    - https://openprescribing.net/api/1.0/bnf_code/?format=json&q=cer
+    - https://openprescribing.net/api/1.0/bnf_code/?format=json&exact=true&q=0703021Q0BB,
+  dependencies:
+    - tables.Chemical
+    - tables.Section
+    - tables.Product
+    - tables.Presentation
+
+- label: org_codes
+  view_fn: views_org_codes.org_codes
+  path: ^org_code/$
+  example_url: https://openprescribing.net/api/1.0/org_code/?org_type=CCG&format=json&q=glouc
+  dependencies:
+    - tables.PCT
+    - tables.Practice
+
+- label: org_location
+  view_fn: views_org_location.org_location
+  path: ^org_location/$
+  example_urls:
+    - https://openprescribing.net/api/1.0/org_location/?format=json&org_type=ccg
+    - https://openprescribing.net/api/1.0/org_location/?format=json&org_type=practice&q=11M,
+    - https://openprescribing.net/api/1.0/org_location/?format=json&org_type=practice&q=L84613,
+  dependencies:
+    - tables.PCT
+    - tables.Practice

--- a/openprescribing/docs/commands.yml
+++ b/openprescribing/docs/commands.yml
@@ -1,0 +1,80 @@
+# This is not finished...
+
+- label: backup_bq_tables
+  dependencies:
+  - bq_tables.hscic_prescribing
+  - bq_tables.hscic_practice_statistics
+- label: bigquery_upload
+  dependencies:
+  - bq_tables.hscic_prescribing
+  - storage_files.hscic_bnf_codes
+  - tables.Practice
+  - tables.Presentation
+  - tables.PracticeStatistics
+  - tables.PCT
+- label: bulk_import_drug_tariff
+  dependencies:
+- label: calculate_star_pu_weights
+  dependencies:
+- label: convert_hscic_prescribing
+  dependencies:
+- label: create_bq_measure_views
+  dependencies:
+- label: create_views
+  dependencies:
+- label: fetch_and_import_drug_tariff
+  dependencies:
+- label: fetch_bnf_codes
+  dependencies:
+  - sources.nhsbsa_bnf_codes
+- label: fetch_prescribing_data
+  dependencies:
+  - sources.nhsbsa_prescribing
+- label: fetch_prescribing_metadata
+  dependencies:
+  - sources.hscic_addr_bnft
+  - sources.hscic_chem_subs
+- label: generate_presentation_replacements
+  dependencies:
+- label: geocode_practices
+  dependencies:
+- label: hscic_list_sizes
+  dependencies:
+  - sources.hscic_list_sizes
+- label: import_adqs
+  dependencies:
+- label: import_bnf_codes
+  dependencies:
+- label: import_ccg_boundaries
+  dependencies:
+- label: import_dmd
+  dependencies:
+- label: import_dmd_snomed
+  dependencies:
+- label: import_generic_mappings
+  dependencies:
+- label: import_hscic_chemicals
+  dependencies:
+- label: import_hscic_prescribing
+  dependencies:
+- label: import_list_sizes
+  dependencies:
+- label: import_measures
+  dependencies:
+- label: import_ncso_concessions
+  dependencies:
+- label: import_org_names
+  dependencies:
+- label: import_ppu_savings
+  dependencies:
+- label: import_practice_dispensing_status
+  dependencies:
+- label: import_practices
+  dependencies:
+- label: import_qof_prevalence
+  dependencies:
+- label: org_codes
+  dependencies:
+  - sources.eccg
+  - sources.epracur
+  - sources.gridall

--- a/openprescribing/docs/draw_data_flow.py
+++ b/openprescribing/docs/draw_data_flow.py
@@ -1,0 +1,95 @@
+'''
+This script produces graphs to show how data flows through the openprescribing
+app.  It reads data from the .yml files in this directory, and currently shows
+tables, API endpoints, and pages.  In the future it should include BQ tables,
+management commands, and data sources.  These files will need to be manuualy
+kept up to date.
+
+To use, run:
+
+    $ python draw_data_flow.py [label, [label...]]
+
+The full output is hard to make sense of, so you can pass labels of nodes you
+are interested in.  For instance, the following command will only show API
+endpoints and pages that use MeasureValue:
+
+    $ python draw_data_flow.py tables.MeasureValue
+
+Output is produced in a file called openp-data-flow.svg.  (This could be made
+configurable.)
+'''
+
+from __future__ import print_function
+
+from collections import defaultdict
+import os
+import sys
+
+from graphviz import Digraph
+import networkx as nx
+from networkx.algorithms.dag import ancestors, descendants
+import yaml
+
+
+CATEGORIES = ['tables', 'api_endpoints', 'pages']
+
+
+def build_graph():
+    G = nx.DiGraph()
+
+    for category in CATEGORIES:
+        with open(category + '.yml') as f:
+            records = yaml.load(f)
+
+        for record in records:
+            full_label = '{}.{}'.format(category, record['label'])
+            G.add_node(full_label)
+
+            for dependency_label in record.get('dependencies') or []:
+                dependency_category, _ = dependency_label.split('.')
+
+                # We can remove this `if` once all .yml files are complete.
+                if dependency_category not in CATEGORIES:
+                    continue
+
+                G.add_edge(dependency_label, full_label)
+
+    return G
+
+
+def filter_graph(G, nodes):
+    nbunch = set()
+    for node in nodes:
+        nbunch.add(node)
+        nbunch |= ancestors(G, node)
+        nbunch |= descendants(G, node)
+    return G.subgraph(nbunch)
+
+
+def draw_graph(G):
+    graph = Digraph(format='svg')
+    graph.graph_attr['rankdir'] = 'LR'
+
+    nodes_by_category = defaultdict(list)
+    for node in G.nodes():
+        category, label = node.split('.')
+        nodes_by_category[category].append(node)
+
+    for category in CATEGORIES:
+        with graph.subgraph(name=category, graph_attr={'rank': 'same'}) as subgraph:
+            for node in nodes_by_category[category]:
+                subgraph.node(node)
+
+    for node1, node2 in G.edges():
+        graph.edge(node1, node2)
+
+    graph.render('openp-data-flow', cleanup=True)
+
+
+if __name__ == '__main__':
+    G = build_graph()
+
+    if len(sys.argv) > 1:
+        G = filter_graph(G, sys.argv[1:])
+
+    draw_graph(G)

--- a/openprescribing/docs/pages.yml
+++ b/openprescribing/docs/pages.yml
@@ -1,0 +1,202 @@
+- label: analyse
+  view_fn: frontend_views.analyse
+  pattern: r'^analyse/$'
+  example_urls:
+    - https://openprescribing.net/analyse/
+    - https://openprescribing.net/analyse/#org=CCG&numIds=0703021Q0BB&denom=nothing
+    - https://openprescribing.net/analyse/#org=CCG&numIds=0703021Q0BB&denom=star_pu.oral_antibacterials_item
+    - https://openprescribing.net/analyse/#org=CCG&numIds=0703021Q0BB&denom=total_list_size
+    - https://openprescribing.net/analyse/#org=CCG&numIds=0703021Q0BB&denomIds=0703021Q0
+    - https://openprescribing.net/analyse/#org=CCG&orgIds=11M&numIds=0703021Q0BB&denom=nothing
+    - https://openprescribing.net/analyse/#org=CCG&orgIds=11M&numIds=0703021Q0BB&denom=star_pu.oral_antibacterials_item
+    - https://openprescribing.net/analyse/#org=CCG&orgIds=11M&numIds=0703021Q0BB&denom=total_list_size
+    - https://openprescribing.net/analyse/#org=CCG&orgIds=11M&numIds=0703021Q0BB&denomIds=0703021Q0
+    - https://openprescribing.net/analyse/#org=practice&orgIds=11M&numIds=0703021Q0BB&denom=nothing
+    - https://openprescribing.net/analyse/#org=practice&orgIds=11M&numIds=0703021Q0BB&denom=star_pu.oral_antibacterials_item
+    - https://openprescribing.net/analyse/#org=practice&orgIds=11M&numIds=0703021Q0BB&denom=total_list_size
+    - https://openprescribing.net/analyse/#org=practice&orgIds=11M&numIds=0703021Q0BB&denomIds=0703021Q0
+    - https://openprescribing.net/analyse/#org=practice&orgIds=L84613&numIds=0703021Q0BB&denom=nothing
+    - https://openprescribing.net/analyse/#org=practice&orgIds=L84613&numIds=0703021Q0BB&denom=star_pu.oral_antibacterials_item
+    - https://openprescribing.net/analyse/#org=practice&orgIds=L84613&numIds=0703021Q0BB&denom=total_list_size
+    - https://openprescribing.net/analyse/#org=practice&orgIds=L84613&numIds=0703021Q0BB&denomIds=0703021Q0
+  dependencies:
+    - api_endpoints.bnf_codes
+    - api_endpoints.org_codes
+    - api_endpoints.org_details
+    - api_endpoints.org_location
+    - api_endpoints.spending_by_ccg
+    - api_endpoints.spending_by_practice
+
+- label: all_chemicals
+  view_fn: frontend_views.all_chemicals
+  pattern: r'^chemical/$'
+  example_url: https://openprescribing.net/chemical/
+  dependencies:
+    - tables.Chemical
+
+- label: chemical
+  view_fn: frontend_views.chemical
+  pattern: r'^chemical/(?P<bnf_code>[A-Z\d]+)/$'
+  example_url: https://openprescribing.net/chemical/0101010C0/
+  dependencies:
+    - tables.Chemical
+    - tables.Section
+    - api_endpoints.total_spending
+
+- label: all_practices
+  view_fn: frontend_views.all_practices
+  pattern: r'^practice/$'
+  example_url: https://openprescribing.net/practice/
+  dependencies:
+    - tables.Practice
+
+- label: measures_for_one_practice
+  view_fn: frontend_views.measures_for_one_practice
+  pattern: r'^practice/(?P<code>[A-Z\d]+)/$'
+  example_url: https://openprescribing.net/practice/B83620/
+  dependencies:
+    - tables.Practice
+    - api_endpoints.measure
+    - api_endpoints.measure_by_practice
+    - api_endpoints.org_location
+
+- label: practice_price_per_unit
+  view_fn: frontend_views.practice_price_per_unit
+  pattern: r'^practice/(?P<code>[A-Z\d]+)/price_per_unit/$'
+  example_url: https://openprescribing.net/practice/B83620/price_per_unit/
+  dependencies:
+    - tables.Practice
+    - api_endpoints.price_per_unit
+
+- label: price_per_unit_by_presentation_practice
+  view_fn: frontend_views.price_per_unit_by_presentation
+  pattern: r'^practice/(?P<entity_code>[A-Z\d]+)/(?P<bnf_code>[A-Z\d]+)/price_per_unit/$'
+  example_url: https://openprescribing.net/practice/B83620/0407010F0AAAAAA/price_per_unit/?date=2018-01-01
+  dependencies:
+    - tables.Presentation
+    - tables.DMDProduct
+    - tables.Practice
+    - api_endpoints.bubble
+    - api_endpoints.price_per_unit
+
+- label: all_measures
+  view_fn: frontend_views.all_measures
+  pattern: r'^measure/$'
+  example_url: https://openprescribing.net/measure/
+  dependencies:
+    - tables.Measure
+
+- label: measure_for_all_ccgs
+  view_fn: frontend_views.measure_for_all_ccgs
+  pattern: r'^measure/(?P<measure>[A-Za-z\d_]+)/$'
+  example_url: https://openprescribing.net/measure/ktt9_cephalosporins/
+  dependencies:
+    - tables.Measure
+    - api_endpoints.measure
+    - api_endpoints.measure_by_ccg
+
+- label: measure_for_one_ccg
+  view_fn: frontend_views.measure_for_one_ccg
+  pattern: r'^measure/(?P<measure>[A-Za-z\d_]+)/ccg/(?P<ccg_code>[A-Z\d]+)/$'
+  example_url: https://openprescribing.net/measure/ktt9_cephalosporins/ccg/02N/
+  dependencies:
+    - tables.Measure
+    - tables.PCT
+    - api_endpoints.measure
+    - api_endpoints.measure_by_ccg
+    - api_endpoints.measure_numerators_by_org
+
+- label: measure_for_one_practice
+  view_fn: frontend_views.measure_for_one_practice
+  example_url: https://openprescribing.net/measure/ktt9_cephalosporins/practice/B83620/
+  pattern: r'^measure/(?P<measure>[A-Za-z\d_]+)/practice/(?P<practice_code>[A-Z\d]+)/$'
+  dependencies:
+    - tables.Measure
+    - tables.PCT
+    - api_endpoints.measure
+    - api_endpoints.measure_by_practice
+    - api_endpoints.measure_numerators_by_org
+
+- label: all_ccgs
+  view_fn: frontend_views.all_ccgs
+  pattern: r'^ccg/$'
+  example_url: https://openprescribing.net/ccg/
+  dependencies:
+    - tables.PCT
+
+- label: measures_for_one_ccg
+  view_fn: frontend_views.measures_for_one_ccg
+  pattern: r'^ccg/(?P<ccg_code>[A-Z\d]+)/$'
+  example_url: https://openprescribing.net/ccg/02N/
+  dependencies:
+    - tables.PCT
+    - tables.Practice
+    - api_endpoints.measure
+    - api_endpoints.measure_by_ccg
+    - api_endpoints.org_location
+
+- label: ccg_price_per_unit
+  view_fn: frontend_views.ccg_price_per_unit
+  pattern: r'^ccg/(?P<code>[A-Z\d]+)/price_per_unit/$'
+  example_url: https://openprescribing.net/ccg/02N/price_per_unit/
+  dependencies:
+    - tables.PCT
+    - api_endpoints.price_per_unit
+
+- label: price_per_unit_by_presentation
+  view_fn: frontend_views.price_per_unit_by_presentation
+  pattern: r'^ccg/(?P<entity_code>[A-Z\d]+)/(?P<bnf_code>[A-Z\d]+)/price_per_unit/$'
+  example_url: https://openprescribing.net/ccg/02N/0407010F0AAAAAA/price_per_unit/?date=2018-01-01
+  dependencies:
+    - tables.Presentation
+    - tables.DMDProduct
+    - tables.PCT
+    - api_endpoints.bubble
+    - api_endpoints.price_per_unit
+
+- label: measure_for_practices_in_ccg
+  view_fn: frontend_views.measure_for_practices_in_ccg
+  pattern: r'^ccg/(?P<ccg_code>[A-Z\d]+)/(?P<measure>[A-Za-z\d_]+)/$'
+  example_url: https://openprescribing.net/ccg/02N/ktt9_cephalosporins/
+  dependencies:
+    - tables.PCT
+    - tables.Measure
+    - tables.Practice
+    - api_endpoints.measure
+    - api_endpoints.measure_by_practice
+
+- label: bnf_section
+  view_fn: frontend_views.bnf_section
+  pattern: r'^bnf/(?P<section_id>[\d]+)/$'
+  example_url: https://openprescribing.net/bnf/01/
+  dependencies:
+    - tables.Section
+    - tables.Chemical
+    - api_endpoints.total_spending
+
+- label: all_bnf
+  view_fn: frontend_views.all_bnf
+  pattern: r'^bnf/$'
+  example_url: https://openprescribing.net/bnf/
+  dependencies:
+    - tables.Section
+
+- label: tariff_index
+  view_fn: frontend_views.tariff
+  pattern: r'^tariff/$'
+  example_urls:
+    - https://openprescribing.net/tariff/
+    - https://openprescribing.net/tariff/?codes=0202030C0AAACAC
+  dependencies:
+    - tables.DMDProduct
+    - tables.Presentation
+    - api_endpoints.tariff
+
+- label: tariff
+  view_fn: frontend_views.tariff
+  pattern: r'^tariff/(?P<code>[A-Z\d]+)/$'
+  example_url: https://openprescribing.net/tariff/0202030C0AAACAC/
+  dependencies:
+    - tables.DMDProduct
+    - tables.Presentation
+    - api_endpoints.tariff

--- a/openprescribing/docs/tables.yml
+++ b/openprescribing/docs/tables.yml
@@ -1,0 +1,91 @@
+- label: AvailabilityRestriction
+  dependencies:
+  - commands.import_dmd
+- label: Chemical
+  dependencies:
+  - commands.generate_presentation_replacements
+  - commands.import_hscic_chemicals
+  - commands.import_hscic_prescribing
+- label: ControlledDrugCategory
+  dependencies:
+  - commands.import_dmd
+- label: DMDProduct
+  dependencies:
+  - commands.import_dmd
+- label: DMDVmpp
+  dependencies:
+  - commands.import_dmd
+- label: GenericCodeMapping
+  dependencies:
+  - commands.import_generic_mappings
+- label: ImportLog
+  dependencies:
+  - commands.bulk_import_drug_tariff
+  - commands.fetch_and_import_drug_tariff
+  - commands.import_hscic_prescribing
+  - commands.import_list_sizes
+  - commands.import_ppu_savings
+- label: Measure
+  dependencies:
+  - commands.import_measures
+- label: MeasureGlobal
+  dependencies:
+  - commands.import_measures
+- label: MeasureValue
+  dependencies:
+  - commands.import_measures
+- label: NCSOConcession
+  dependencies:
+  - commands.import_ncso_concessions
+- label: PCT
+  dependencies:
+  - commands.import_hscic_prescribing
+  - commands.import_org_names
+  - commands.import_practices
+- label: PPUSaving
+  dependencies:
+  - commands.import_ppu_savings
+- label: Practice
+  dependencies:
+  - commands.import_practices
+  - commands.import_hscic_prescribing
+- label: PracticeIsDispensing
+  dependencies:
+  - commands.import_practice_dispensing_status
+- label: PracticeStatistics
+  dependencies:
+  - commands.import_list_sizes
+- label: Prescribability
+  dependencies:
+  - commands.import_dmd
+- label: Prescription
+  dependencies:
+  - commands.import_hscic_prescribing
+- label: Presentation
+  dependencies:
+  - commands.generate_presentation_replacements
+  - commands.import_bnf_codes
+  - commands.import_hscic_prescribing
+  - commands.import_ppu_savings
+- label: Product
+  dependencies:
+  - commands.generate_presentation_replacements
+  - commands.import_bnf_codes
+  - commands.import_hscic_prescribing
+- label: QOFPrevalence
+  dependencies:
+  - commands.import_qof_prevalence
+- label: Section
+  dependencies:
+  - commands.generate_presentation_replacements
+  - commands.import_bnf_codes
+  - commands.import_hscic_prescribing
+- label: TariffCategory
+  dependencies:
+  - commands.import_dmd
+- label: TariffPrice
+  dependencies:
+  - commands.import_tariff
+- label: VMPNonAvailability
+  dependencies:
+  - commands.import_dmd


### PR DESCRIPTION
Addresses #831.

Lets us produce graphs like

![image](https://user-images.githubusercontent.com/28734/39049528-bb7e67b4-4499-11e8-9cb8-983668c4d942.png)

which demonstrates how the org_location API endpoint is used and where it gets its data from.

Further work required to include BQ tables, source data, and management commands.

@sebbacon, feel free to review if you're interested.