### PR TITLE
Remove anymail settings from local and test settings

### DIFF
--- a/openprescribing/openprescribing/settings/local.py
+++ b/openprescribing/openprescribing/settings/local.py
@@ -86,14 +86,6 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 GOOGLE_TRACKING_ID = 'UA-62480003-2'
 
-
-ANYMAIL = {
-    "MAILGUN_API_KEY": "key-b503fcc6f1c029088f2b3f9b3faa303c",
-    "MAILGUN_SENDER_DOMAIN": "staging.openprescribing.net",
-    "WEBHOOK_AUTHORIZATION": "%s" % utils.get_env_setting(
-        'MAILGUN_WEBHOOK_AUTH_STRING', 'example:foo'),
-}
-
 # LOGGING CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#logging
 LOGGING = {

--- a/openprescribing/openprescribing/settings/test.py
+++ b/openprescribing/openprescribing/settings/test.py
@@ -21,12 +21,6 @@ CACHES = {
     }
 }
 INTERNAL_IPS = ('127.0.0.1',)
-ANYMAIL = {
-    "MAILGUN_API_KEY": "key-b503fcc6f1c029088f2b3f9b3faa303c",
-    "MAILGUN_SENDER_DOMAIN": "staging.openprescribing.net",
-    "WEBHOOK_AUTHORIZATION": "%s" % utils.get_env_setting(
-        'MAILGUN_WEBHOOK_AUTH_STRING', 'example:foo'),
-}
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 


### PR DESCRIPTION
The required settings have changed (WEBHOOK_AUTHORIZATION has been
renamed to WEBHOOK_SECRET) causing certain cron jobs running in the test
environment to fail a system check.

In any case, we should be using the environment for these settings.