### PR TITLE
Spending API SQL refactors

### DIFF
--- a/openprescribing/api/view_utils.py
+++ b/openprescribing/api/view_utils.py
@@ -3,6 +3,8 @@ from django.db import connection
 from django.shortcuts import get_object_or_404
 from functools import wraps
 
+from enum import Enum
+
 
 def db_timeout(timeout):
     """A decorator that applies a timeout to the current database
@@ -85,6 +87,9 @@ def get_bnf_codes_from_number_str(codes):
     return converted
 
 
+BnfHierarchy = Enum('BnfHierarchy', 'section chemical product presentation')
+
+
 def get_spending_type(codes):
     # Codes must all be of the same length.
     if not codes:
@@ -94,10 +99,10 @@ def get_spending_type(codes):
         if len(c) != code_len:
             return False
     if code_len < 9:
-        return 'bnf-section'
+        return BnfHierarchy.section
     elif code_len == 9:
-        return 'chemical'
+        return BnfHierarchy.chemical
     elif code_len > 9 and code_len <= 11:
-        return 'product'
+        return BnfHierarchy.product
     elif code_len > 11:
-        return 'presentation'
+        return BnfHierarchy.presentation

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -467,10 +467,7 @@ def _get_query_for_total_spending(codes):
     ORDER BY date;"""
 
     if codes:
-        code_clauses = [
-            'presentation_code LIKE %s'
-            for _ in range(len(codes))
-        ]
+        code_clauses = ['presentation_code LIKE %s'] * len(codes)
     else:
         code_clauses = None
 
@@ -496,23 +493,14 @@ def _get_query_for_chemicals_or_sections_by_ccg(codes, pct_ids, spending_type):
     '''
 
     if spending_type == 'bnf-section':
-        chemical_clauses = [
-            'pr.chemical_id LIKE %s'
-            for _ in range(len(codes))
-        ]
+        chemical_clauses = ['pr.chemical_id LIKE %s'] * len(codes)
     elif spending_type == 'chemical':
-        chemical_clauses = [
-            'pr.chemical_id = %s'
-            for _ in range(len(codes))
-        ]
+        chemical_clauses = ['pr.chemical_id = %s'] * len(codes)
     else:
         chemical_clauses = None
 
     if pct_ids:
-        pct_clauses = [
-            'pr.pct_id = %s'
-            for _ in range(len(pct_ids))
-        ]
+        pct_clauses = ['pr.pct_id = %s'] * len(pct_ids)
     else:
         pct_clauses = None
 
@@ -541,16 +529,10 @@ def _get_query_for_presentations_by_ccg(codes, pct_ids):
     ORDER BY date, pc.code
     '''
 
-    code_clauses = [
-        'pr.presentation_code LIKE %s'
-        for _ in range(len(codes))
-    ]
+    code_clauses = ['pr.presentation_code LIKE %s'] * len(codes)
 
     if pct_ids:
-        pct_clauses = [
-            'pr.pct_id = %s'
-            for _ in range(len(pct_ids))
-        ]
+        pct_clauses = ['pr.pct_id = %s'] * len(pct_ids)
     else:
         pct_clauses = None
 
@@ -580,10 +562,7 @@ def _get_total_spending_by_practice(practice_ids, date):
     '''
 
     if practice_ids:
-        practice_clauses = [
-            'pr.practice_id = %s'
-            for _ in range(len(practice_ids))
-        ]
+        practice_clauses = ['pr.practice_id = %s'] * len(practice_ids)
     else:
         practice_clauses = None
 
@@ -620,23 +599,14 @@ def _get_chemicals_or_sections_by_practice(codes, practice_ids, spending_type,
     '''
 
     if spending_type == 'bnf-section':
-        chemical_clauses = [
-            'pr.chemical_id LIKE %s'
-            for _ in range(len(codes))
-        ]
+        chemical_clauses = ['pr.chemical_id LIKE %s'] * len(codes)
     elif spending_type == 'chemical':
-        chemical_clauses = [
-            'pr.chemical_id = %s'
-            for _ in range(len(codes))
-        ]
+        chemical_clauses = ['pr.chemical_id = %s'] * len(codes)
     else:
         assert False
 
     if practice_ids:
-        practice_clauses = [
-            'pr.practice_id = %s'
-            for _ in range(len(practice_ids))
-        ]
+        practice_clauses = ['pr.practice_id = %s'] * len(practice_ids)
     else:
         practice_clauses = None
 
@@ -672,10 +642,7 @@ def _get_presentations_by_practice(codes, org_ids, date):
     ORDER BY date, pc.code
     '''
 
-    code_clauses = [
-        'pr.presentation_code LIKE %s'
-        for _ in range(len(codes))
-    ]
+    code_clauses = ['pr.presentation_code LIKE %s'] * len(codes)
 
     org_clauses = []
     if org_ids:

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -670,18 +670,18 @@ def _get_presentations_by_practice(codes, org_ids, date):
     ORDER BY date, pc.code
     '''
 
-    code_subclauses = [
+    code_clauses = [
         'pr.presentation_code LIKE %s'
         for _ in range(len(codes))
     ]
 
-    org_subclauses = []
+    org_clauses = []
     if org_ids:
         for org_id in org_ids:
             if len(org_id) == 3:
-                org_subclauses.append('pr.pct_id = %s')
+                org_clauses.append('pr.pct_id = %s')
             else:
-                org_subclauses.append('pr.practice_id = %s')
+                org_clauses.append('pr.practice_id = %s')
 
     if date:
         date_clause = 'pr.processing_date = %s'
@@ -689,8 +689,8 @@ def _get_presentations_by_practice(codes, org_ids, date):
         date_clause = None
 
     where_condition = _build_where_condition([
-        code_subclauses,
-        org_subclauses,
+        code_clauses,
+        org_clauses,
         date_clause,
     ])
 

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -619,20 +619,21 @@ def _get_chemicals_or_sections_by_practice(codes, practice_ids, spending_type,
 
 
 def _get_presentations_by_practice(codes, org_ids, date):
-    query = 'SELECT pc.code AS row_id, '
-    query += "pc.name AS row_name, "
-    query += "pc.setting AS setting, "
-    query += "pc.ccg_id AS ccg, "
-    query += "pr.processing_date AS date, "
-    query += 'SUM(pr.actual_cost) AS actual_cost, '
-    query += 'SUM(pr.total_items) AS items, '
-    query += 'CAST(SUM(pr.quantity) AS bigint) AS quantity '
-    query += "FROM frontend_prescription pr "
-    query += "JOIN frontend_practice pc ON pr.practice_id=pc.code "
-    query += "WHERE ("
-    query += "%s"
-    query += ") GROUP BY pc.code, pc.name, date "
-    query += "ORDER BY date, pc.code"
+    query = '''
+    SELECT pc.code AS row_id,
+    pc.name AS row_name,
+    pc.setting AS setting,
+    pc.ccg_id AS ccg,
+    pr.processing_date AS date,
+    SUM(pr.actual_cost) AS actual_cost,
+    SUM(pr.total_items) AS items,
+    CAST(SUM(pr.quantity) AS bigint) AS quantity
+    FROM frontend_prescription pr
+    JOIN frontend_practice pc ON pr.practice_id=pc.code
+    WHERE (%s)
+    GROUP BY pc.code, pc.name, date
+    ORDER BY date, pc.code
+    '''
 
     where_clauses = []
 

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -570,7 +570,8 @@ def _get_total_spending_by_practice(practice_ids, date):
 
 def _get_chemicals_or_sections_by_practice(codes, practice_ids, spending_type,
                                            date):
-    query = 'SELECT pc.code AS row_id, '
+    query = '''
+    SELECT pc.code AS row_id,
     query += "pc.name AS row_name, "
     query += "pc.setting AS setting, "
     query += "pc.ccg_id AS ccg, "
@@ -580,6 +581,9 @@ def _get_chemicals_or_sections_by_practice(codes, practice_ids, spending_type,
     query += 'SUM(pr.quantity) AS quantity '
     query += "FROM vw__chemical_summary_by_practice pr "
     query += "JOIN frontend_practice pc ON pr.practice_id=pc.code "
+    query += "GROUP BY pc.code, pc.name, date "
+    query += "ORDER BY date, pc.code"
+
     has_preceding = False
     if spending_type:
         has_preceding = True
@@ -613,21 +617,21 @@ def _get_chemicals_or_sections_by_practice(codes, practice_ids, spending_type,
         else:
             query += " WHERE ("
         query += "pr.processing_date=%s) "
-    query += "GROUP BY pc.code, pc.name, date "
-    query += "ORDER BY date, pc.code"
+
     return query
 
 
 def _get_presentations_by_practice(codes, org_ids, date):
     query = '''
-    SELECT pc.code AS row_id,
-    pc.name AS row_name,
-    pc.setting AS setting,
-    pc.ccg_id AS ccg,
-    pr.processing_date AS date,
-    SUM(pr.actual_cost) AS actual_cost,
-    SUM(pr.total_items) AS items,
-    CAST(SUM(pr.quantity) AS bigint) AS quantity
+    SELECT
+        pc.code AS row_id,
+        pc.name AS row_name,
+        pc.setting AS setting,
+        pc.ccg_id AS ccg,
+        pr.processing_date AS date,
+        SUM(pr.actual_cost) AS actual_cost,
+        SUM(pr.total_items) AS items,
+        CAST(SUM(pr.quantity) AS bigint) AS quantity
     FROM frontend_prescription pr
     JOIN frontend_practice pc ON pr.practice_id=pc.code
     WHERE %s

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -392,6 +392,7 @@ def spending_by_practice(request, format=None):
     if spending_type is False:
         err = 'Error: Codes must all be the same length'
         return Response(err, status=400)
+
     if spending_type == 'bnf-section' or spending_type == 'product':
         codes = [c + '%' for c in codes]
 
@@ -404,10 +405,12 @@ def spending_by_practice(request, format=None):
     params = [codes]
 
     if spending_type in ['product', 'presentation']:
+        assert len(codes) > 0
         query = _get_presentations_by_practice(codes, org_ids, date)
         params.append(org_ids)
 
     elif spending_type in ['bnf-section', 'chemical']:
+        assert len(codes) > 0
         practice_ids = utils.get_practice_ids_from_org(org_ids)
         query = _get_chemicals_or_sections_by_practice(codes,
                                                        practice_ids,
@@ -417,7 +420,7 @@ def spending_by_practice(request, format=None):
 
     else:
         assert spending_type is None
-        assert codes == []
+        assert len(codes) == 0
 
         practice_ids = utils.get_practice_ids_from_org(org_ids)
         query = _get_total_spending_by_practice(practice_ids, date)

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -153,11 +153,20 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[17]['items'], '40')
         self.assertEqual(rows[17]['quantity'], '1209')
 
-    ########################################
-    # Total spending by CCG.
-    ########################################
+
+class TestSpendingByCCG(ApiTestBase):
+    def _get(self, params):
+        params['format'] = 'csv'
+        url = '/api/1.0/spending_by_ccg/'
+        return self.client.get(url, params)
+
+    def _get_rows(self, params):
+        rsp = self._get(params)
+        return list(csv.DictReader(rsp.content.splitlines()))
+
     def test_total_spending_by_ccg(self):
-        rows = self._rows_from_api('/spending_by_ccg?format=csv')
+        rows = self._get_rows({})
+
         self.assertEqual(len(rows), 9)
         self.assertEqual(rows[6]['row_id'], '03V')
         self.assertEqual(rows[6]['row_name'], 'NHS Corby')
@@ -167,6 +176,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[6]['quantity'], '1241')
 
     def test_total_spending_by_one_ccg(self):
+        params = {
+            'org': '03V',
+        }
+        rows = self._get_rows(params)
+
         rows = self._rows_from_api('/spending_by_ccg?format=csv&org=03V')
         self.assertEqual(len(rows), 5)
         self.assertEqual(rows[-2]['row_id'], '03V')
@@ -177,6 +191,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-2]['quantity'], '1241')
 
     def test_total_spending_by_multiple_ccgs(self):
+        params = {
+            'org': '03V,03Q',
+        }
+        rows = self._get_rows(params)
+
         rows = self._rows_from_api('/spending_by_ccg?format=csv&org=03V,03Q')
         self.assertEqual(len(rows), 9)
         self.assertEqual(rows[6]['row_id'], '03V')
@@ -187,6 +206,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[6]['quantity'], '1241')
 
     def test_spending_by_all_ccgs_on_chemical(self):
+        params = {
+            'code': '0202010B0',
+        }
+        rows = self._get_rows(params)
+
         rows = self._rows_from_api(
             '/spending_by_ccg?format=csv&code=0202010B0')
         self.assertEqual(len(rows), 6)
@@ -204,9 +228,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[5]['quantity'], '2788')
 
     def test_spending_by_all_ccgs_on_multiple_chemicals(self):
-        url = '/spending_by_ccg'
-        url += '?format=csv&code=0202010B0,0202010F0'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0,0202010F0',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 9)
         self.assertEqual(rows[0]['row_id'], '03Q')
         self.assertEqual(rows[0]['row_name'], 'NHS Vale of York')
@@ -222,9 +248,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-3]['quantity'], '1241')
 
     def test_spending_by_all_ccgs_on_product(self):
-        url = '/spending_by_ccg'
-        url += '?format=csv&code=0204000I0BC'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0204000I0BC',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]['row_id'], '03V')
         self.assertEqual(rows[0]['row_name'], 'NHS Corby')
@@ -234,9 +262,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[0]['quantity'], '2350')
 
     def test_spending_by_all_ccgs_on_presentation(self):
-        url = '/spending_by_ccg'
-        url += '?format=csv&code=0202010B0AAABAB'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0AAABAB',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 3)
         self.assertEqual(rows[2]['row_id'], '03V')
         self.assertEqual(rows[2]['row_name'], 'NHS Corby')
@@ -246,9 +276,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[2]['quantity'], '2788')
 
     def test_spending_by_all_ccgs_on_multiple_presentations(self):
-        url = '/spending_by_ccg'
-        url += '?format=csv&code=0202010F0AAAAAA,0202010B0AAACAC'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010F0AAAAAA,0202010B0AAACAC',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 7)
         self.assertEqual(rows[0]['row_id'], '03Q')
         self.assertEqual(rows[0]['row_name'], 'NHS Vale of York')
@@ -258,8 +290,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[0]['quantity'], '56')
 
     def test_spending_by_all_ccgs_on_bnf_section(self):
-        url = '/spending_by_ccg?format=csv&code=2.2.1'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '2.2.1',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 9)
         self.assertEqual(rows[0]['row_id'], '03Q')
         self.assertEqual(rows[0]['row_name'], 'NHS Vale of York')
@@ -275,8 +310,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-1]['quantity'], '2788')
 
     def test_spending_by_all_ccgs_on_multiple_bnf_sections(self):
-        url = '/spending_by_ccg?format=csv&code=2.2,2.4'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '2.2,2.4',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 9)
         self.assertEqual(rows[-1]['row_id'], '03V')
         self.assertEqual(rows[-1]['row_name'], 'NHS Corby')
@@ -287,9 +325,6 @@ class TestAPISpendingViews(ApiTestBase):
 
 
 class TestSpendingByPractice(ApiTestBase):
-    ########################################
-    # Total spending by practice.
-    ########################################
     def _get(self, params):
         params['format'] = 'csv'
         url = '/api/1.0/spending_by_practice/'

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -402,6 +402,21 @@ class TestSpendingByPractice(ApiTestBase):
         self.assertEqual(rows[-1]['items'], '55')
         self.assertEqual(rows[-1]['quantity'], '2599')
 
+    def test_spending_by_two_practices_with_date(self):
+        params = {
+            'org': 'P87629,K83059',
+            'date': '2014-11-01',
+        }
+        rows = self._get_rows(params)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[1]['row_id'], 'P87629')
+        self.assertEqual(rows[1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
+        self.assertEqual(rows[1]['date'], '2014-11-01')
+        self.assertEqual(rows[1]['actual_cost'], '64.26')
+        self.assertEqual(rows[1]['items'], '55')
+        self.assertEqual(rows[1]['quantity'], '2599')
+
     def test_spending_by_one_practice_on_chemical(self):
         params = {
             'code': '0202010B0',
@@ -499,22 +514,6 @@ class TestSpendingByPractice(ApiTestBase):
         self.assertEqual(rows[2]['actual_cost'], '64.26')
         self.assertEqual(rows[2]['items'], '55')
         self.assertEqual(rows[2]['quantity'], '2599')
-
-    def test_spending_by_practice_on_multiple_presentations_with_multiple_orgs_and_date(self):
-        params = {
-            'code': '0204000I0BCAAAB,0202010B0AAABAB',
-            'org': 'P87629,K83059',
-            'date': '2014-11-01',
-        }
-        rows = self._get_rows(params)
-
-        self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[1]['row_id'], 'P87629')
-        self.assertEqual(rows[1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
-        self.assertEqual(rows[1]['date'], '2014-11-01')
-        self.assertEqual(rows[1]['actual_cost'], '64.26')
-        self.assertEqual(rows[1]['items'], '55')
-        self.assertEqual(rows[1]['quantity'], '2599')
 
     def test_spending_by_practice_on_section(self):
         params = {

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -1,3 +1,4 @@
+import csv
 import datetime
 import json
 
@@ -284,19 +285,30 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-1]['items'], '95')
         self.assertEqual(rows[-1]['quantity'], '5142')
 
+
+class TestSpendingByPractice(ApiTestBase):
     ########################################
     # Total spending by practice.
     ########################################
+    def _get(self, params):
+        params['format'] = 'csv'
+        url = '/api/1.0/spending_by_practice/'
+        return self.client.get(url, params)
+
+    def _get_rows(self, params):
+        rsp = self._get(params)
+        return list(csv.DictReader(rsp.content.splitlines()))
+
     def test_spending_by_all_practices_on_product_without_date(self):
-        url = '%s/spending_by_practice' % self.api_prefix
-        url += '?format=csv&code=0204000I0BC'
-        response = self.client.get(url, follow=True)
+        response = self._get({'code': '0204000I0BC'})
         self.assertEqual(response.status_code, 400)
 
     def test_total_spending_by_practice(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&date=2014-11-01'
-        rows = self._rows_from_api(url)
+        params = {
+            'date': '2014-11-01'
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]['row_id'], 'K83059')
         self.assertEqual(rows[0]['row_name'], 'DR KHALID & PARTNERS')
@@ -308,9 +320,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[0]['quantity'], '2543')
 
     def test_spending_by_practice_on_chemical(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0204000I0&date=2014-11-01'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0204000I0',
+            'date': '2014-11-01'
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]['row_id'], 'K83059')
         self.assertEqual(rows[0]['row_name'], 'DR KHALID & PARTNERS')
@@ -322,9 +337,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[0]['quantity'], '1154')
 
     def test_spending_by_all_practices_on_chemical_with_date(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0202010F0&date=2014-09-01'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010F0',
+            'date': '2014-09-01',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]['row_id'], 'N84014')
         self.assertEqual(rows[0]['actual_cost'], '11.99')
@@ -336,8 +354,11 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[1]['quantity'], '32')
 
     def test_spending_by_one_practice(self):
-        url = '/spending_by_practice?format=csv&org=P87629'
-        rows = self._rows_from_api(url)
+        params = {
+            'org': 'P87629',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 5)
         self.assertEqual(rows[-1]['row_id'], 'P87629')
         self.assertEqual(rows[-1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -347,9 +368,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-1]['quantity'], '2599')
 
     def test_spending_by_one_practice_on_chemical(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0202010B0&org=P87629'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0',
+            'org': 'P87629',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 5)
         self.assertEqual(rows[-1]['row_id'], 'P87629')
         self.assertEqual(rows[-1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -361,9 +385,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-1]['quantity'], '1399')
 
     def test_spending_by_practice_on_multiple_chemicals(self):
-        url = '/spending_by_practice?format=csv'
-        url += '&code=0202010B0,0204000I0&org=P87629,K83059'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0,0204000I0',
+            'org': 'P87629,K83059',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 6)
         self.assertEqual(rows[2]['row_id'], 'P87629')
         self.assertEqual(rows[2]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -373,9 +400,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[2]['quantity'], '24')
 
     def test_spending_by_all_practices_on_product(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0202010B0AA&date=2014-11-01'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0AA',
+            'date': '2014-11-01',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]['row_id'], 'K83059')
         self.assertEqual(rows[0]['actual_cost'], '12.13')
@@ -387,9 +417,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[1]['quantity'], '1399')
 
     def test_spending_by_all_practices_on_presentation(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0202010B0AAABAB&date=2014-11-01'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202010B0AAABAB',
+            'date': '2014-11-01',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]['row_id'], 'K83059')
         self.assertEqual(rows[0]['actual_cost'], '12.13')
@@ -401,9 +434,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[1]['quantity'], '1399')
 
     def test_spending_by_practice_on_presentation(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0204000I0BCAAAB&org=03V'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0204000I0BCAAAB',
+            'org': '03V',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[1]['row_id'], 'P87629')
         self.assertEqual(rows[1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -415,9 +451,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[1]['quantity'], '1200')
 
     def test_spending_by_practice_on_multiple_presentations(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0204000I0BCAAAB,0202010B0AAABAB&org=03V'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0204000I0BCAAAB,0202010B0AAABAB',
+            'org': '03V',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 3)
         self.assertEqual(rows[2]['row_id'], 'P87629')
         self.assertEqual(rows[2]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -427,9 +466,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[2]['quantity'], '2599')
 
     def test_spending_by_practice_on_section(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=2&org=03V'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '2',
+            'org': '03V',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 6)
         self.assertEqual(rows[-1]['row_id'], 'P87629')
         self.assertEqual(rows[-1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
@@ -439,9 +481,12 @@ class TestAPISpendingViews(ApiTestBase):
         self.assertEqual(rows[-1]['quantity'], '2599')
 
     def test_spending_by_practice_on_multiple_sections(self):
-        url = '/spending_by_practice'
-        url += '?format=csv&code=0202,0204&org=03Q'
-        rows = self._rows_from_api(url)
+        params = {
+            'code': '0202,0204',
+            'org': '03Q',
+        }
+        rows = self._get_rows(params)
+
         self.assertEqual(len(rows), 4)
         self.assertEqual(rows[0]['row_id'], 'N84014')
         self.assertEqual(rows[0]['row_name'], 'AINSDALE VILLAGE SURGERY')

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -465,6 +465,22 @@ class TestSpendingByPractice(ApiTestBase):
         self.assertEqual(rows[2]['items'], '55')
         self.assertEqual(rows[2]['quantity'], '2599')
 
+    def test_spending_by_practice_on_multiple_presentations_with_multiple_orgs_and_date(self):
+        params = {
+            'code': '0204000I0BCAAAB,0202010B0AAABAB',
+            'org': 'P87629,K83059',
+            'date': '2014-11-01',
+        }
+        rows = self._get_rows(params)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[1]['row_id'], 'P87629')
+        self.assertEqual(rows[1]['row_name'], '1/ST ANDREWS MEDICAL PRACTICE')
+        self.assertEqual(rows[1]['date'], '2014-11-01')
+        self.assertEqual(rows[1]['actual_cost'], '64.26')
+        self.assertEqual(rows[1]['items'], '55')
+        self.assertEqual(rows[1]['quantity'], '2599')
+
     def test_spending_by_practice_on_section(self):
         params = {
             'code': '2',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -20,6 +20,7 @@ django-rest-swagger==0.3.5
 django==1.9.1
 djangorestframework-csv==1.4.1
 djangorestframework>=3.3.2
+enum34
 google-api-python-client==1.6.2
 google-cloud-bigquery==0.30.0
 google-cloud-storage==1.7.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,7 @@ django-rest-swagger==0.3.5
 django==1.9.1
 djangorestframework-csv==1.4.1
 djangorestframework==3.7.3
+enum34==1.1.6
 et-xmlfile==1.0.1         # via openpyxl
 futures==3.2.0            # via google-api-core, requests-futures
 google-api-core==0.1.4    # via google-cloud-bigquery, google-cloud-core, google-cloud-storage


### PR DESCRIPTION
This is with an eye to ensuring that API queries always use current CCG membership, as part of #739.