### PR TITLE
Allow manage.py to be called without arguments

### DIFF
--- a/openprescribing/manage.py
+++ b/openprescribing/manage.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     dotenv.read_dotenv(env_path)
 
     if 'DJANGO_SETTINGS_MODULE' not in os.environ:
-        if sys.argv[1] in ['test', 'pipeline_e2e_tests']:
+        if len(sys.argv) > 1 and sys.argv[1] in ['test', 'pipeline_e2e_tests']:
             settings = 'test'
         else:
             settings = 'local'


### PR DESCRIPTION
This is needed to support tab-completion for management commands. See:
https://github.com/django/django/blob/2bc014750adb093131f77e4c20bc17ba64b75cac/extras/django_bash_completion