### PR TITLE
Add command to load data for local development

### DIFF
--- a/openprescribing/frontend/management/commands/load_development_data.py
+++ b/openprescribing/frontend/management/commands/load_development_data.py
@@ -1,0 +1,15 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from frontend.tests.test_api_spending import TestAPISpendingViewsPPUTable
+
+
+class Command(BaseCommand):
+
+    help = 'Loads sample data intended for use in local development'
+
+    def handle(self, *args, **options):
+        # For now we just piggyback off the set of test fixtures used by the
+        # API tests
+        fixtures = TestAPISpendingViewsPPUTable.fixtures
+        call_command('loaddata', *fixtures)


### PR DESCRIPTION
At present this just loads a bunch of test fixtures (those recommended
by @inglesp) but there's obviously scope for doing something else in
future. The main thing is that there's a single command to run which
does all this and we can update what that command actually does at our
leisure.

Thinking more broadly, it might make sense to make it a convention
across all projects that they have such a command.