### PR TITLE
Handle invalid dates (somewhat) more gracefully

### DIFF
--- a/openprescribing/common/utils.py
+++ b/openprescribing/common/utils.py
@@ -158,11 +158,15 @@ def constraint_and_index_reconstructor(table_name):
             logger.info("CLUSTERED %s" % table_name)
 
 
+def parse_date(s):
+    return datetime.strptime(s, "%Y-%m-%d")
+
+
 def valid_date(s):
     """Validate ISO-formatted dates. For use in argparse arguments.
     """
     try:
-        return datetime.strptime(s, "%Y-%m-%d")
+        return parse_date(s)
     except ValueError:
         msg = "Not a valid date: '{0}'.".format(s)
         raise argparse.ArgumentTypeError(msg)

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -425,6 +425,10 @@ class TestPPUViews(TransactionTestCase):
         self.assertEqual(response.context['date'].strftime('%Y-%m-%d'),
                          '2014-11-01')
 
+    def test_ccg_price_per_unit_returns_400_on_invalid_date(self):
+        response = self.client.get('/ccg/03V/price_per_unit/', {'date': 'not-a-date'})
+        self.assertEqual(response.status_code, 400)
+
     def test_price_per_unit_histogram_with_ccg(self):
         response = self.client.get('/ccg/03V/0202010F0AAAAAA/price_per_unit/')
         self.assertEqual(response.status_code, 200)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -25,7 +25,7 @@ from allauth.account import app_settings
 from allauth.account.models import EmailAddress
 from allauth.account.utils import perform_login
 
-from common.utils import valid_date
+from common.utils import parse_date
 from dmd.models import DMDProduct
 from frontend.forms import OrgBookmarkForm
 from frontend.forms import SearchBookmarkForm
@@ -122,11 +122,7 @@ def chemical(request, bnf_code):
 # Price per unit
 ##################################################
 def price_per_unit_by_presentation(request, entity_code, bnf_code):
-    date = request.GET.get('date', None)
-    if date:
-        date = valid_date(date)
-    else:
-        date = ImportLog.objects.latest_in_category('ppu').current_at
+    date = _specified_or_last_date(request, 'ppu')
     presentation = get_object_or_404(Presentation, pk=bnf_code)
     product = presentation.dmd_product
     if len(entity_code) == 3:
@@ -187,7 +183,7 @@ def all_practices(request):
 def _specified_or_last_date(request, category):
     date = request.GET.get('date', None)
     if date:
-        date = valid_date(date)
+        date = parse_date(date)
     else:
         date = ImportLog.objects.latest_in_category(category).current_at
     return date

--- a/openprescribing/templates/500.html
+++ b/openprescribing/templates/500.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 {% load template_extras %}
 
-{% block title %}About{% endblock %}
+{% block title %}Error{% endblock %}
 {% block active_class %}more{% endblock %}
 
 {% block content %}
 
-<h2>Error code 500</h2>
+<h2>Error code {{ error_code|default:"500" }}</h2>
 
-Sorry, there's a problem with your request.
+<p>Sorry, there's a problem with your request.</p>
 
-{{ reason }}
+{% if reason %}
+  <p class="well">{{ reason }}<p>
+{% endif %}
 
 <p>If you continue to have problems, please contact us at <a href="mailto:{{ SUPPORT_EMAIL }}" class="doorbell-show">{{ SUPPORT_EMAIL }}</a>.</p>
 


### PR DESCRIPTION
Previously, requesting certain pages with an invalid date parameter would trigger an uncaught exception. Sometimes we'd get a large number of malformed requests from bots which would trigger a large number of errors and flooding our error logs.

We now handle invalid dates more gracefully and return a 400 Bad Request instead.

Closes #832