### PR TITLE
Use current CCG membership in presentations by practice API query

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -648,9 +648,9 @@ def _get_presentations_by_practice(codes, org_ids, date):
     if org_ids:
         for org_id in org_ids:
             if len(org_id) == 3:
-                org_clauses.append('pr.pct_id = %s')
+                org_clauses.append('pc.ccg_id = %s')
             else:
-                org_clauses.append('pr.practice_id = %s')
+                org_clauses.append('pc.code = %s')
 
     if date:
         date_clause = 'pr.processing_date = %s'


### PR DESCRIPTION
This will fix the chart at https://openprescribing.net/analyse/#org=practice&orgIds=14L&numIds=0703021Q0BB&denom=nothing&selectedTab=chart

This has no new tests -- updating the test fixtures is too much work as it breaks lots of other tests