### PR TITLE
Remove all but IE browser tests and allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,18 @@ env:
     DOCKER_COMPOSE_VERSION: 1.9.0
   matrix:
     - TEST_SUITE=nonfunctional
-    - TEST_SUITE=functional BROWSER="firefox:latest:Windows 2012"
-    - TEST_SUITE=functional BROWSER="safari:8.0:OS X 10.10"
     - TEST_SUITE=functional BROWSER="internet explorer:11.0:Windows 7"
+matrix:
+  # The SauceLabs browser tests are very flaky such that we get frequent
+  # failures which disappear if the tests are re-run. At present, we're not
+  # touching the frontend code much at all and so these failures are just
+  # useless noise and promote the bad habit of ignoring CI results. As a
+  # quick improvement on this situation we now ignore failures in the browser
+  # tests when determining the overall test status, but we still run them so
+  # that the results can be checked manually if you're making frontend
+  # changes.
+  allow_failures:
+    - env: TEST_SUITE=functional BROWSER="internet explorer:11.0:Windows 7"
 sudo: required
 language: python
 before_install:


### PR DESCRIPTION
The SauceLabs browser tests are very flaky such that we get frequent
failures which disappear if the tests are re-run. At present, we're not
touching the frontend code much at all and so these failures are just
useless noise and promote the bad habit of ignoring CI results. As a
quick improvement on this situation we now ignore failures in the
browser tests when determining the overall test status, but we still run
them so that the results can be checked manually if you're making
frontend changes.

The browser tests are also quite slow (which is compounded by Travis
running them in series) and so we now only run the tests on Internet
Explorer which, given that none of the dev team use it, is the browser
we're most likely to unexpectedly break on.