### PR TITLE
Add link to blog and tidy up homepage HTML

### DIFF
--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -104,6 +104,7 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
                 <li class="active_faq"><a href="{% url 'faq' %}">FAQ</a></li>
                 <li class="active_api"><a href="{% url 'api' %}">For coders</a></li>
                 <li class="active_about"><a href="{% url 'about' %}">About</a></li>
+                <li><a href="https://ebmdatalab.net/category/openprescribing/">Blog <span class="glyphicon glyphicon-new-window small"></span></a></li>
                 <li class="active_privacy"><a href="{% url 'privacy' %}">Privacy Policy</a></li>
               </ul>
             </li>

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -8,67 +8,68 @@
 
 <h1>Explore England's prescribing data</h1>
 
-
 <div class="row">
 
-<div class="col-md-9">
-  <p>Every month, the NHS in England publishes <a href="http://content.digital.nhs.uk/gpprescribingdata">anonymised data</a> about the drugs prescribed by GPs. But the raw data files are large and unwieldy, with more than 700 million rows. We're making it easier for GPs, managers and everyone to explore - supporting safer, more efficient prescribing.</p>
+  <div class="col-md-9">
 
-  <p class="alert alert-info">Got a tricky query for the data? We can provide custom extracts, we know the data well, and we’re keen to collaborate with academics and clinicians. <a href="mailto:{{ SUPPORT_EMAIL }}" class="doorbell-show">Get in touch</a> to find out more.</p>
+    <p>Every month, the NHS in England publishes <a href="http://content.digital.nhs.uk/gpprescribingdata">anonymised data</a> about the drugs prescribed by GPs. But the raw data files are large and unwieldy, with more than 700 million rows. We're making it easier for GPs, managers and everyone to explore - supporting safer, more efficient prescribing.</p>
 
-  <p>How to cite: If you use our data or graphs, please cite as <em>OpenPrescribing.net, EBM DataLab, University of Oxford, 2017</em> so that others can find us and use our tools.</p>
+    <p class="alert alert-info">Got a tricky query for the data? We can provide custom extracts, we know the data well, and we’re keen to collaborate with academics and clinicians. <a href="mailto:{{ SUPPORT_EMAIL }}" class="doorbell-show">Get in touch</a> to find out more.</p>
 
-<h2>Explore the data</h2>
+    <p>How to cite: If you use our data or graphs, please cite as <em>OpenPrescribing.net, EBM DataLab, University of Oxford, 2017</em> so that others can find us and use our tools.</p>
 
 
-<div class="row">
+    <h2>Explore the data</h2>
 
-<div class="col-lg-6 col-md-6 col-sm-6">
-<h3>Look at your CCG</h3>
-<p>We've identified standard <a href="https://openprescribing.net/measure/">prescribing measures</a>, and created dashboards for every Clinical Commissioning Group in the country.</p>
-<a href="{% url 'all_ccgs' %}" class="btn btn-lg btn-info">Find a CCG &raquo;</a>
-</div>
+    <div class="row">
+      <div class="col-lg-6 col-md-6 col-sm-6">
+        <h3>Look at your CCG</h3>
+        <p>We've identified standard <a href="https://openprescribing.net/measure/">prescribing measures</a>, and created dashboards for every Clinical Commissioning Group in the country.</p>
+        <a href="{% url 'all_ccgs' %}" class="btn btn-lg btn-info">Find a CCG &raquo;</a>
+      </div>
 
-<div class="col-lg-6 col-md-6 col-sm-6">
-<h3>Look at your GP practice</h3>
-<p>We've identified standard prescribing measures, and created dashboards for every GP practice in the country.</p>
-<a href="{% url 'all_practices' %}" class="btn btn-lg btn-info">Find a practice &raquo;</a>
-</div>
-</div>
+      <div class="col-lg-6 col-md-6 col-sm-6">
+        <h3>Look at your GP practice</h3>
+        <p>We've identified standard prescribing measures, and created dashboards for every GP practice in the country.</p>
+        <a href="{% url 'all_practices' %}" class="btn btn-lg btn-info">Find a practice &raquo;</a>
+      </div>
+    </div>
 
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-6">
-<h3>Run your own analyses</h3>
-<p>If you have a burning question about the prescribing data, use our flexible query form to get the data you need, quickly and easily.</p>
-<a href="{% url 'analyse' %}" class="btn btn-lg btn-info">Start analysing &raquo;</a>
-</div>
+    <div class="row">
+      <div class="col-lg-6 col-md-6 col-sm-6">
+        <h3>Run your own analyses</h3>
+        <p>If you have a burning question about the prescribing data, use our flexible query form to get the data you need, quickly and easily.</p>
+        <a href="{% url 'analyse' %}" class="btn btn-lg btn-info">Start analysing &raquo;</a>
+      </div>
 
-<div class="col-lg-6 col-md-6 col-sm-6">
-<h3>Spot national trends</h3>
-<p>See how national prescribing trends have changed since 2010, for any drug or <a href="https://en.wikipedia.org/wiki/British_National_Formulary">BNF section</a> that interests you.</p>
-<a href="{% url 'all_chemicals' %}" class="btn btn-lg btn-info">Find a drug &raquo;</a>
-</div>
-</div>
+      <div class="col-lg-6 col-md-6 col-sm-6">
+        <h3>Spot national trends</h3>
+        <p>See how national prescribing trends have changed since 2010, for any drug or <a href="https://en.wikipedia.org/wiki/British_National_Formulary">BNF section</a> that interests you.</p>
+        <a href="{% url 'all_chemicals' %}" class="btn btn-lg btn-info">Find a drug &raquo;</a>
+      </div>
+    </div>
 
-<!--[if !IE 8]><!-->
-<h2>Find out more</h2>
 
-<p>Ben Goldacre explains what the site does and why we built it.</p>
+    <!--[if !IE 8]><!-->
+    <h2>Find out more</h2>
 
-<div class="embed-responsive embed-responsive-16by9" style="border: 1px solid #ccc">
-  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/U-hvuEfUUOM"></iframe>
-</div>
+    <p>Ben Goldacre explains what the site does and why we built it.</p>
 
-<hr/>
-<!--<![endif]-->
+    <div class="embed-responsive embed-responsive-16by9" style="border: 1px solid #ccc">
+      <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/U-hvuEfUUOM"></iframe>
+    </div>
 
-<p>Read more <a href="{% url 'about' %}">about the site</a> and see our <a href="{% url 'faq' %}">FAQs</a>. In particular, note our <a href="{% url 'faq' %}#cite">guidelines for using this data</a>.</p>
+    <hr/>
+    <!--<![endif]-->
 
-</div>
 
-<div class="col-md-3">
-  {% include '_mailchimp_signup.html' %}
-</div>
+    <p>Read more <a href="{% url 'about' %}">about the site</a> and see our <a href="{% url 'faq' %}">FAQs</a>. In particular, note our <a href="{% url 'faq' %}#cite">guidelines for using this data</a>.</p>
+
+  </div>
+
+  <div class="col-md-3">
+    {% include '_mailchimp_signup.html' %}
+  </div>
 
 </div>
 

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -70,11 +70,7 @@
   {% include '_mailchimp_signup.html' %}
 </div>
 
-<hr/>
-
-
-<hr />
-
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
This adds a link the OpenPrescribing posts on the main EBMDataLab blog (as requested in #813) in the "More" section of the menu as that seemed the most sensible place for it. I've used an icon to indicate that it's a link to another site and hopefully slightly reduce any potential surprise there.

In doing this I noticed that the homepage layout was a bit borked due to a missing close div, so I fixed that and also indented it so that things like missing tags are a bit easier to spot.