### PR TITLE
Add explanatory text on Drug Tariff search page

### DIFF
--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -12,9 +12,25 @@
 {% block content %}
 
 {% if presentations %}
-<h3>{{ chart_title }}</h3>
+  <h3>{{ chart_title }}</h3>
 {% else %}
-<h3>Tariff and Concession prices</h3>
+  <h3>Tariff and Concession prices</h3>
+
+  <p>
+    The Drug Tariff is the "NHS primary care price list" for thousands of the
+    most commonly-prescribed drugs, and is updated monthly. Sometimes medicines
+    go out-of-stock, and a "price concession" is given so that pharmacists having
+    to buy more expensive versions are not out of pocket.
+  </p>
+  <p>
+    Our data goes back to March 2010. Drug Tariff data is updated as the latest
+    month is released (usually three days before it is active). Price concession
+    data is updated daily!
+  </p>
+  <p>
+    Search to view a medicine's Drug Tariff price and category, and whether it
+    has had a price concession.
+  </p>
 {% endif %}
 
 <div id="no-data">

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -23,9 +23,12 @@
     to buy more expensive versions are not out of pocket.
   </p>
   <p>
-    Our data goes back to March 2010. Drug Tariff data is updated as the latest
-    month is released (usually three days before it is active). Price concession
-    data is updated daily!
+    Our data goes back to March 2010. Drug Tariff data
+    (<a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">source</a>)
+    is updated as the latest month is released (usually three days before it is
+    active). Price concession data
+    (<a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">source</a>)
+    is updated daily!
   </p>
   <p>
     Search to view a medicine's Drug Tariff price and category, and whether it


### PR DESCRIPTION
Closes #684

I've slightly reordered the paragraphs so that the "Search" call to
action comes directly before the search input which made more sense to
me.

I've also made it so that the text doesn't appear if there's already a
search query set, the reason being that it's quite a lot of text and if
you already know what you're looking at it's probably more distracting
than helpful. But happy to take other opinions on that.