### PR TITLE
Fix (or work around) practice search performance issue

### DIFF
--- a/openprescribing/media/js/src/list-filter.js
+++ b/openprescribing/media/js/src/list-filter.js
@@ -10,11 +10,19 @@ var listFilter = {
     var fuse;
     var $inputSearch = $(inputSearch);
     var $resultsList = $(resultsList);
+    var minSearchLength = $inputSearch.data('min-search-length');
     $inputSearch.val('');
 
     function search() {
       var searchTerm = $inputSearch.val();
-      var r = (searchTerm === '') ? allItems : fuse.search(searchTerm);
+      var r;
+      if (minSearchLength && searchTerm.length < minSearchLength) {
+        r = [];
+      } else if (searchTerm === '') {
+        r = allItems;
+      } else {
+        r = fuse.search(searchTerm);
+      }
       $resultsList.empty();
       var allHtml = '';
       $.each(r, function() {

--- a/openprescribing/templates/all_practices.html
+++ b/openprescribing/templates/all_practices.html
@@ -10,7 +10,7 @@
 
 <p>Search for a practice by name, and see how this practice compares with its peers across the NHS in England.</p>
 
-<input class="form-control" id="search" placeholder="Search by practice name or postcode" />
+<input class="form-control" id="search" placeholder="Search by practice name or postcode" data-min-search-length="3" />
 
 <ul class="list-unstyled" id="all-results">
 


### PR DESCRIPTION
The current list search system (used for practices, chemicals and BNF
entries) is pretty crude and mobile devices in particular struggle with
the Practices page where the results list is very large.

We should probably review the whole thing at some point, but for now we
workaround this specific issue by requiring a minimum search length of
three characters for the practice page.

Closes #865