### PR TITLE
Fix incorrect measures link URL

### DIFF
--- a/openprescribing/templates/all_measures.html
+++ b/openprescribing/templates/all_measures.html
@@ -20,7 +20,7 @@
 <ul>
 {% for measure in measures %}
 <li>
-<a href="/measure/{{ measure.id }}">
+<a href="{% url 'measure_for_all_ccgs' measure.id %}">
 {{ measure }}
 </a>
 </li>


### PR DESCRIPTION
The previous version omitted the trailing slash, which works but causes
a needless redirect. But we should be using the `url` tag anyway, rather
than constructing URLs by hand.