### PR TITLE
Make year in citation notice dynamically update

### DIFF
--- a/openprescribing/frontend/templatetags/template_extras.py
+++ b/openprescribing/frontend/templatetags/template_extras.py
@@ -3,6 +3,7 @@ import math
 from django import template
 from django.utils.safestring import mark_safe
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.utils import timezone
 
 register = template.Library()
 
@@ -58,3 +59,8 @@ def url_toggle(request, field):
     else:
         dict_[field] = 1
     return dict_.urlencode()
+
+
+@register.simple_tag
+def current_time(format_string):
+    return timezone.now().strftime(format_string)

--- a/openprescribing/frontend/tests/test_template_extras.py
+++ b/openprescribing/frontend/tests/test_template_extras.py
@@ -1,3 +1,5 @@
+import datetime
+import mock
 import unittest
 
 from frontend.templatetags import template_extras as t
@@ -25,3 +27,8 @@ class TestTemplateExtras(unittest.TestCase):
 
     def test_deltawords_negative(self):
         self.assertEqual(t.deltawords(29, 0), "considerably")
+
+    @mock.patch('{.__name__}.timezone.now'.format(t))
+    def test_current_time(self, timezone_now):
+        timezone_now.return_value = datetime.date(2018, 1, 3)
+        self.assertEqual(t.current_time('%Y-%m-%d'), '2018-01-03')

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -16,7 +16,7 @@
 
     <p class="alert alert-info">Got a tricky query for the data? We can provide custom extracts, we know the data well, and we’re keen to collaborate with academics and clinicians. <a href="mailto:{{ SUPPORT_EMAIL }}" class="doorbell-show">Get in touch</a> to find out more.</p>
 
-    <p>How to cite: If you use our data or graphs, please cite as <em>OpenPrescribing.net, EBM DataLab, University of Oxford, 2017</em> so that others can find us and use our tools.</p>
+    <p>How to cite: If you use our data or graphs, please cite as <em>OpenPrescribing.net, EBM DataLab, University of Oxford, {% current_time "%Y" %}</em> so that others can find us and use our tools.</p>
 
 
     <h2>Explore the data</h2>


### PR DESCRIPTION
There is a question here as to whether we want to show a date at all.
But if we do, the only date that makes sense is the current one.