### PR TITLE
Display warning when no cost saving measures available

### DIFF
--- a/openprescribing/media/js/src/measures.js
+++ b/openprescribing/media/js/src/measures.js
@@ -23,6 +23,7 @@ var measures = {
     sortButtons: '.btn-group > .btn',
     summaryTemplate: '#summary-panel',
     panelTemplate: '#measure-panel',
+    noCostSavingWarning: '#no-cost-saving-warning'
   },
 
   setUp: function() {
@@ -164,6 +165,11 @@ var measures = {
     chartsBySaving.sort(function(a, b) {
       return $(b).data('costsaving') - $(a).data('costsaving');
     });
+    if (chartsBySaving.length === 0) {
+      chartsBySaving = chartsBySaving.add(
+        $(_this.el.noCostSavingWarning).clone().removeClass('hidden')
+      );
+    }
     $(_this.el.sortButtons).click(function() {
       $(this).addClass('active').siblings().removeClass('active');
       if ($(this).data('orderby') === 'savings') {

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -58,6 +58,10 @@
     </div>
   </div>
 
+  <div class="alert alert-warning hidden" id="no-cost-saving-warning">
+    There is currently no cost savings data available for these measures
+  </div>
+
   {% verbatim %}
   <script id="summary-panel" type="text/x-handlebars-template">
   <p>{{ performanceDescription }}</p>


### PR DESCRIPTION
Partially addresses the issue raised in #725. A subsequent question is
whether any of the lowpriority measures _should_ be flagged as
cost-based.