### PR TITLE
Remove August 2013 limit for CCG analyse queries

### DIFF
--- a/openprescribing/media/js/src/chart_utils.js
+++ b/openprescribing/media/js/src/chart_utils.js
@@ -269,13 +269,6 @@ var utils = {
     var monthRange = [];
     if (combinedData.length > 0) {
       var firstMonth = combinedData[0].date;
-      if (options.org === 'CCG') {
-        // CCGs were formed in Aug 2013. This special-casing can be
-        // removed after Aug 2018, as we only deal with 5 years of
-        // data.
-        var firstCCGDate = '2013-08-01';
-        firstMonth = firstMonth > firstCCGDate ? firstMonth : firstCCGDate;
-      }
       var lastMonth = combinedData[combinedData.length - 1].date;
       var startDate = moment(firstMonth);
       var endDate = moment(lastMonth);

--- a/openprescribing/media/js/test/test_utils.js
+++ b/openprescribing/media/js/test/test_utils.js
@@ -388,7 +388,8 @@ describe('Utils', function () {
                              "2010-08-01", "2010-09-01", "2010-10-01", "2010-11-01",
                              "2010-12-01", "2011-01-01", "2011-02-01"]);
     });
-    it('should start in Aug 2013 for CCGs', function () {       var options = {
+    it('should start in Aug 2013 for CCGs', function () {
+      var options = {
         org: 'CCG',
         data: {
           combinedData : [
@@ -398,7 +399,8 @@ describe('Utils', function () {
         }
       };
       var months = utils.getAllMonthsInData(options);
-      expect(months).to.eql(["2013-08-01", "2013-09-01"]);
+      expect(months).to.eql(["2013-04-01", "2013-05-01", "2013-06-01",
+                             "2013-07-01", "2013-08-01", "2013-09-01"]);
     });
   });
 


### PR DESCRIPTION
The limit should have been April 2013 (as this is when CCGs were formed)
but April and August are easy to mix up!

We can remove the limit completeyl now as we only hold five years of
data, and we have now imported data from April 2018.

Fixes #920.