### PR TITLE
 Add "pack_size" column to drug tariff download

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -322,7 +322,8 @@ def tariff(request, format=None):
            dmd_vmpp.nm AS vmpp,
            dmd_product.bnf_code AS product,
            dmd_ncsoconcession.price_concession_pence AS concession,
-           dmd_lookup_dt_payment_category.desc AS tariff_category
+           dmd_lookup_dt_payment_category.desc AS tariff_category,
+           dmd_ncsoconcession.pack_size AS pack_size
     FROM dmd_tariffprice
         INNER JOIN dmd_lookup_dt_payment_category
             ON dmd_tariffprice.tariff_category_id = dmd_lookup_dt_payment_category.cd

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from django.db import connection
 from django.db.models import Q
-from django.forms.models import model_to_dict
 from django.shortcuts import get_object_or_404
 
 from rest_framework.decorators import api_view

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -36,7 +36,8 @@ class TestAPISpendingViewsTariff(ApiTestBase):
              'product': 'ABCD',
              'price_pence': '900',
              'tariff_category': 'Part VIIIA Category A',
-             'vmpp': 'Bar tablets 84 tablet'}
+             'vmpp': 'Bar tablets 84 tablet',
+             'pack_size': ''}
         ])
 
     def test_tariff_hits(self):
@@ -48,19 +49,22 @@ class TestAPISpendingViewsTariff(ApiTestBase):
              'product': 'ABCD',
              'price_pence': '900',
              'tariff_category': 'Part VIIIA Category A',
-             'vmpp': 'Bar tablets 84 tablet'},
+             'vmpp': 'Bar tablets 84 tablet',
+             'pack_size': ''},
             {'date': '2010-03-01',
              'concession': '',
              'product': 'EFGH',
              'price_pence': '2400',
              'tariff_category': 'Part VIIIA Category A',
-             'vmpp': 'Foo tablets 84 tablet'},
+             'vmpp': 'Foo tablets 84 tablet',
+             'pack_size': ''},
             {'date': '2010-04-01',
              'concession': '',
              'product': 'EFGH',
              'price_pence': '1100',
              'tariff_category': 'Part VIIIA Category A',
-             'vmpp': 'Foo tablets 84 tablet'},
+             'vmpp': 'Foo tablets 84 tablet',
+             'pack_size': ''},
         ])
 
     def test_tariff_miss(self):


### PR DESCRIPTION
Closes #923

This feature isn't really tested properly as it hits the issue discussed in #895 where setting up the necessary test data becomes complicated very quickly. As this is such a straightforward change we've agreed to punt on writing comprehensive tests for it until we come up with a more general solution.