### PR TITLE
Use pack size from dm+d table for export

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -323,7 +323,7 @@ def tariff(request, format=None):
            dmd_product.bnf_code AS product,
            dmd_ncsoconcession.price_concession_pence AS concession,
            dmd_lookup_dt_payment_category.desc AS tariff_category,
-           dmd_ncsoconcession.pack_size AS pack_size
+           dmd_vmpp.qtyval AS pack_size
     FROM dmd_tariffprice
         INNER JOIN dmd_lookup_dt_payment_category
             ON dmd_tariffprice.tariff_category_id = dmd_lookup_dt_payment_category.cd

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -37,7 +37,7 @@ class TestAPISpendingViewsTariff(ApiTestBase):
              'price_pence': '900',
              'tariff_category': 'Part VIIIA Category A',
              'vmpp': 'Bar tablets 84 tablet',
-             'pack_size': ''}
+             'pack_size': '84.0'}
         ])
 
     def test_tariff_hits(self):
@@ -50,21 +50,21 @@ class TestAPISpendingViewsTariff(ApiTestBase):
              'price_pence': '900',
              'tariff_category': 'Part VIIIA Category A',
              'vmpp': 'Bar tablets 84 tablet',
-             'pack_size': ''},
+             'pack_size': '84.0'},
             {'date': '2010-03-01',
              'concession': '',
              'product': 'EFGH',
              'price_pence': '2400',
              'tariff_category': 'Part VIIIA Category A',
              'vmpp': 'Foo tablets 84 tablet',
-             'pack_size': ''},
+             'pack_size': '84.0'},
             {'date': '2010-04-01',
              'concession': '',
              'product': 'EFGH',
              'price_pence': '1100',
              'tariff_category': 'Part VIIIA Category A',
              'vmpp': 'Foo tablets 84 tablet',
-             'pack_size': ''},
+             'pack_size': '84.0'},
         ])
 
     def test_tariff_miss(self):


### PR DESCRIPTION
This is the correct source for the data, but I didn't notice it at first
because it has a slightly non-obvious column name.

Actually fixes #923