### PR TITLE
Fix measure links on dashboards

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -412,6 +412,7 @@ def _home_page_context_for_entity(request, entity):
         'possible_savings': total_possible_savings,
         'date': ppu_date,
         'signed_up_for_alert': _signed_up_for_alert(request, entity),
+        'parent_code': None
     }
 
 
@@ -437,6 +438,7 @@ def practice_home_page(request, practice_code):
         return form
     context = _home_page_context_for_entity(request, practice)
     context['form'] = form
+    context['parent_code'] = practice.ccg_id
     request.session['came_from'] = request.path
     return render(request, 'entity_home_page.html', context)
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -378,7 +378,7 @@ def _home_page_context_for_entity(request, entity):
     entity_type = type(entity).lower()
     mv_filter["{}_id".format(entity_type)] = entity.code
     # find the core measurevalue that is most outlierish
-    extreme_measurevalue = MeasureValue.objects.\filter(
+    extreme_measurevalue = MeasureValue.objects.filter(
         **mv_filter
     ).exclude(measure_id='lpzomnibus'
     ).values('measure_id'

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -379,7 +379,7 @@ def _home_page_context_for_entity(request, entity):
         entity_type = 'practice'
     elif isinstance(entity, PCT):
         mv_filter['pct_id'] = entity.code
-        entity_type = 'ccg'
+        entity_type = 'CCG'
     else:
         raise RuntimeError("Can't handle type: {!r}".format(entity))
     # find the core measurevalue that is most outlierish
@@ -405,8 +405,10 @@ def _home_page_context_for_entity(request, entity):
         'measures_count': measures_count,
         'entity': entity,
         'entity_type': entity_type,
-        'entity_price_per_unit_url': '%s_price_per_unit' % entity_type,
-        'measures_for_one_entity_url': 'measures_for_one_%s' % entity_type,
+        'entity_price_per_unit_url': '{}_price_per_unit'.format(
+            entity_type.lower()),
+        'measures_for_one_entity_url': 'measures_for_one_{}'.format(
+            entity_type.lower()),
         'possible_savings': total_possible_savings,
         'date': ppu_date,
         'signed_up_for_alert': _signed_up_for_alert(request, entity),
@@ -419,8 +421,10 @@ def ccg_home_page(request, ccg_code):
         request, ccg)
     if isinstance(form, HttpResponseRedirect):
         return form
+    practices = Practice.objects.filter(ccg=ccg, setting=4).order_by('name')
     context = _home_page_context_for_entity(request, ccg)
     context['form'] = form
+    context['practices'] = practices
     request.session['came_from'] = request.path
     return render(request, 'entity_home_page.html', context)
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -383,14 +383,18 @@ def _home_page_context_for_entity(request, entity):
     else:
         raise RuntimeError("Can't handle type: {!r}".format(entity))
     # find the core measurevalue that is most outlierish
-    extreme_measurevalue = MeasureValue.objects.filter(
-        **mv_filter
-    ).exclude(measure_id='lpzomnibus'
-    ).values('measure_id'
-    ).annotate(average_percentile=Avg('percentile')
-    ).order_by('-average_percentile').first()
+    extreme_measurevalue = (
+        MeasureValue.objects
+        .filter(**mv_filter)
+        .exclude(measure_id='lpzomnibus')
+        .values('measure_id')
+        .annotate(average_percentile=Avg('percentile'))
+        .order_by('-average_percentile')
+        .first()
+    )
     if extreme_measurevalue:
-        extreme_measure = Measure.objects.get(pk=extreme_measurevalue['measure_id'])
+        extreme_measure = Measure.objects.get(
+            pk=extreme_measurevalue['measure_id'])
     else:
         extreme_measure = None
     ppu_date = _specified_or_last_date(request, 'ppu')
@@ -401,8 +405,8 @@ def _home_page_context_for_entity(request, entity):
         'measures_count': measures_count,
         'entity': entity,
         'entity_type': entity_type,
-        'entity_price_per_unit_url': '{}_price_per_unit'.format(entity_type),
-        'measures_for_one_entity_url': 'measures_for_one_{}'.format(entity_type),
+        'entity_price_per_unit_url': '%s_price_per_unit' % entity_type,
+        'measures_for_one_entity_url': 'measures_for_one_%s' % entity_type,
         'possible_savings': total_possible_savings,
         'date': ppu_date,
         'signed_up_for_alert': _signed_up_for_alert(request, entity),

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -138,12 +138,14 @@
   'measure': '{{ measure.id }}',
   'chartContainerId': '#top-measure-container',
   'orgId': '{{ entity.code }}',
+  'parentOrg': {% if parent_code %}'{{ parent_code }}'{% else %}null{% endif %},
   'orgName': '{{ entity.name }}',
   },
   {
   'measure': 'lpzomnibus',
   'chartContainerId': '#lpzomnibus-container',
   'orgId': '{{ entity.code }}',
+  'parentOrg': {% if parent_code %}'{{ parent_code }}'{% else %}null{% endif %},
   'orgName': '{{ entity.name }}',
   },
 


### PR DESCRIPTION
The JS was already in place to handle this, it just required setting the
`parentOrg` field correctly.

Closes #990 

Depends on #994 which must be merged first.