### PR TITLE
WIP: Check in gunicorn config

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -1,0 +1,41 @@
+#!/bin/bash
+ 
+NAME="openprescribing_prod"                                  # Name of the application
+DJANGODIR=/webapps/openprescribing/openprescribing             # Django project directory
+SOCKFILE=/webapps/openprescribing/run/gunicorn.sock  # we will communicte using this unix socket
+USER=hello                                        # the user to run as
+GROUP=www-data                                    # the group to run as
+NUM_WORKERS=6                                     # how many worker processes should Gunicorn spawn
+DJANGO_SETTINGS_MODULE=openprescribing.settings.production             # which settings file should Django use
+DJANGO_WSGI_MODULE=openprescribing.wsgi                     # WSGI module name
+LOGFILE=/webapps/openprescribing/logs/gunicorn-error.log
+ACCESS_LOGFILE=/webapps/openprescribing/logs/gunicorn-access.log
+TIMEOUT=60
+ 
+echo "Starting $NAME as `whoami`"
+echo "Env variable $GMAIL_PASS"
+echo "DB_USER $DB_USER"
+echo "Test env variable $TEST1" 
+# Activate the virtual environment
+cd $DJANGODIR
+source ../.venv/bin/activate
+export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
+export PYTHONPATH=$DJANGODIR:$PYTHONPATH
+export NEW_RELIC_CONFIG_FILE=/webapps/openprescribing/newrelic.ini 
+export NEW_RELIC_ENVIRONMENT=production
+export NEW_RELIC_LICENSE_KEY=ZZZZZZ
+# Create the run directory if it doesn't exist
+RUNDIR=$(dirname $SOCKFILE)
+test -d $RUNDIR || mkdir -p $RUNDIR
+ 
+# Start your Django Unicorn
+# Programs meant to be run under supervisor should not daemonize themselves (do not use --daemon)
+exec newrelic-admin run-program gunicorn ${DJANGO_WSGI_MODULE}:application \
+  --name $NAME \
+  --workers $NUM_WORKERS \
+  --timeout $TIMEOUT \
+  --user=$USER --group=$GROUP \
+  --bind=unix:$SOCKFILE \
+  --log-level=warn \
+  --log-file=$LOGFILE \
+  --access-logfile=$ACCESS_LOGFILE

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -33,6 +33,9 @@ echo "DB_USER: $DB_USER"
 echo "GUNICORN_USER: $GUNICORN_USER"
 echo "PYTHONPATH: $PYTHONPATH"
 
+# Source environment file
+source "$INSTALL_ROOT/environment"
+
 # Activate the virtual environment
 source "$INSTALL_ROOT/.venv/bin/activate"
  

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-ENVIRONMENT=$1
-NAME="openprescribing_{$ENVIRONMENT}"
+ENV=$1
+
+if [[ $ENV != "production" && $ENV != "staging" ]]
+then
+  echo '$ENV must be "production" or "staging"'
+  exit 1
+fi
+
+NAME="openprescribing_{$ENV}"
 
 # INSTALL_ROOT and SITE_ROOT match definitions in settings
 INSTALL_ROOT=$(dirname $(dirname $0))
@@ -18,15 +25,15 @@ SOCKFILE="$RUNDIR/gunicorn.sock"
 LOGFILE="$LOGDIR/gunicorn-error.log"
 ACCESS_LOGFILE="$LOGDIR/gunicorn-access.log"
 
-# Export environment variables that depend on $ENVIRONMENT
-export DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENVIRONMENT"
+# Export environment variables that depend on $ENV
+export DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENV"
 export PYTHONPATH=$SITE_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$INSTALL_ROOT/newrelic.ini"
-export NEW_RELIC_ENVIRONMENT=$ENVIRONMENT
+export NEW_RELIC_ENVIRONMENT=$ENV
 
 echo "Starting $NAME"
 echo "whoami: $(whoami)"
-echo "ENVIRONMENT: $ENVIRONMENT"
+echo "ENV: $ENV"
 echo "INSTALL_ROOT: $INSTALL_ROOT"
 echo "SITE_ROOT: $SITE_ROOT"
 echo "DB_USER: $DB_USER"

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -1,15 +1,20 @@
 #!/bin/bash
- 
-NAME="openprescribing_prod"                                  # Name of the application
-DJANGODIR=/webapps/openprescribing/openprescribing             # Django project directory
-SOCKFILE=/webapps/openprescribing/run/gunicorn.sock  # we will communicte using this unix socket
+
+ENVIRONMENT=$1
+NAME="openprescribing_{$ENVIRONMENT}"
+
+# INSTALL_ROOT and SITE_ROOT match definitions in settings
+INSTALL_ROOT=$(dirname $(dirname $0))
+SITE_ROOT="$INSTALL_ROOT/openprescribing"
+
+SOCKFILE="$INSTALL_ROOT/run/gunicorn.sock"  # we will communicte using this unix socket
 USER=hello                                        # the user to run as
 GROUP=www-data                                    # the group to run as
 NUM_WORKERS=6                                     # how many worker processes should Gunicorn spawn
-DJANGO_SETTINGS_MODULE=openprescribing.settings.production             # which settings file should Django use
+DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENVIRONMENT"  # which settings file should Django use
 DJANGO_WSGI_MODULE=openprescribing.wsgi                     # WSGI module name
-LOGFILE=/webapps/openprescribing/logs/gunicorn-error.log
-ACCESS_LOGFILE=/webapps/openprescribing/logs/gunicorn-access.log
+LOGFILE="$INSTALL_ROOT/logs/gunicorn-error.log"
+ACCESS_LOGFILE="$INSTALL_ROOT/logs/gunicorn-access.log"
 TIMEOUT=60
  
 echo "Starting $NAME as `whoami`"
@@ -17,12 +22,12 @@ echo "Env variable $GMAIL_PASS"
 echo "DB_USER $DB_USER"
 echo "Test env variable $TEST1" 
 # Activate the virtual environment
-cd $DJANGODIR
+cd $SITE_ROOT
 source ../.venv/bin/activate
 export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
-export PYTHONPATH=$DJANGODIR:$PYTHONPATH
-export NEW_RELIC_CONFIG_FILE=/webapps/openprescribing/newrelic.ini 
-export NEW_RELIC_ENVIRONMENT=production
+export PYTHONPATH=$SITE_ROOT:$PYTHONPATH
+export NEW_RELIC_CONFIG_FILE="$INSTALL_ROOT/newrelic.ini"
+export NEW_RELIC_ENVIRONMENT=$ENVIRONMENT
 export NEW_RELIC_LICENSE_KEY=ZZZZZZ
 # Create the run directory if it doesn't exist
 RUNDIR=$(dirname $SOCKFILE)

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -7,40 +7,43 @@ NAME="openprescribing_{$ENVIRONMENT}"
 INSTALL_ROOT=$(dirname $(dirname $0))
 SITE_ROOT="$INSTALL_ROOT/openprescribing"
 
-SOCKFILE="$INSTALL_ROOT/run/gunicorn.sock"  # we will communicte using this unix socket
-USER=hello                                        # the user to run as
-GROUP=www-data                                    # the group to run as
-NUM_WORKERS=6                                     # how many worker processes should Gunicorn spawn
-DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENVIRONMENT"  # which settings file should Django use
-DJANGO_WSGI_MODULE=openprescribing.wsgi                     # WSGI module name
-LOGFILE="$INSTALL_ROOT/logs/gunicorn-error.log"
-ACCESS_LOGFILE="$INSTALL_ROOT/logs/gunicorn-access.log"
-TIMEOUT=60
- 
-echo "Starting $NAME as `whoami`"
-echo "Env variable $GMAIL_PASS"
-echo "DB_USER $DB_USER"
-echo "Test env variable $TEST1" 
-# Activate the virtual environment
-cd $SITE_ROOT
-source ../.venv/bin/activate
-export DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE
+RUNDIR="$INSTALL_ROOT/run"
+LOGDIR="$INSTALL_ROOT/logs"
+
+# Create the run and logs directories if they don't exist
+mkdir -p $RUNDIR
+mkdir -p $LOGDIR
+
+SOCKFILE="$RUNDIR/gunicorn.sock"
+LOGFILE="$LOGDIR/gunicorn-error.log"
+ACCESS_LOGFILE="$LOGDIR/gunicorn-access.log"
+
+# Export environment variables that depend on $ENVIRONMENT
+export DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENVIRONMENT"
 export PYTHONPATH=$SITE_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$INSTALL_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENVIRONMENT
-export NEW_RELIC_LICENSE_KEY=ZZZZZZ
-# Create the run directory if it doesn't exist
-RUNDIR=$(dirname $SOCKFILE)
-test -d $RUNDIR || mkdir -p $RUNDIR
+
+echo "Starting $NAME"
+echo "whoami: $(whoami)"
+echo "ENVIRONMENT: $ENVIRONMENT"
+echo "INSTALL_ROOT: $INSTALL_ROOT"
+echo "SITE_ROOT: $SITE_ROOT"
+echo "DB_USER: $DB_USER"
+echo "GUNICORN_USER: $GUNICORN_USER"
+echo "PYTHONPATH: $PYTHONPATH"
+
+# Activate the virtual environment
+source "$INSTALL_ROOT/.venv/bin/activate"
  
-# Start your Django Unicorn
-# Programs meant to be run under supervisor should not daemonize themselves (do not use --daemon)
-exec newrelic-admin run-program gunicorn ${DJANGO_WSGI_MODULE}:application \
+# Start gunicorn via newrelic-admin
+exec newrelic-admin run-program gunicorn openprescribing.wsgi:application \
   --name $NAME \
-  --workers $NUM_WORKERS \
-  --timeout $TIMEOUT \
-  --user=$USER --group=$GROUP \
   --bind=unix:$SOCKFILE \
-  --log-level=warn \
+  --workers $GUNICORN_NUM_WORKERS \
+  --timeout $GUNICORN_TIMEOUT \
+  --user=$GUNICORN_USER \
+  --group=$GUNICORN_GROUP \
+  --log-level=$GUNICORN_LOG_LEVEL \
   --log-file=$LOGFILE \
   --access-logfile=$ACCESS_LOGFILE

--- a/environment-sample
+++ b/environment-sample
@@ -23,3 +23,12 @@ SLACK_GENERAL_POST_KEY=slack_general_post_key
 CF_API_KEY=cf_api_key
 CF_API_EMAIL=cf_api_email
 NEWRELIC_API_KEY=newrelic_api_key
+
+# Only required on the server
+GUNICORN_USER=hello
+GUNICORN_GROUP=www-data
+GUNICORN_TIMEOUT=60
+GUNICORN_NUM_WORKERS=6
+GUNICORN_LOG_LEVEL=warn
+
+NEW_RELIC_LICENSE_KEY=new_relic_license_key


### PR DESCRIPTION
This PR contains an updated version of `gunicorn_start` that can be checked in.

It is agnostic about the environment in which it runs, which is now passed in as an argument.

Before merging and deploying, I would like to talk through this at the next sysadmin session.

Deployment checklist:

- [x] Back up `/etc/profile.d/environment.sh`!
- [x] Review `/etc/profile.d/environment.sh` and remove any variables which are unused

For each of staging and production:

- [ ] Back up `gunicorn_start`
- [ ] Deploy
- [ ] Move contents of `/etc/profile.d/environment.sh` to `environment` files
- [ ] Update `environment` with the variables listed under "Only required on the server" in `environment-sample`
- [ ] Remove `source /etc/profile.d/openprescribing.sh` from `.venv/bin/activate`
- [x] Update `/etc/supervisor/conf.d/openprescribing.conf ` and `/etc/supervisor/conf.d/openprescribing_staging.conf` to pass environment (ie `staging` or `production`) to `gunicorn_start`