### PR TITLE
Enable JS sourcemaps in development

### DIFF
--- a/openprescribing/media/js/build.js
+++ b/openprescribing/media/js/build.js
@@ -25,6 +25,8 @@ var bundles = modules.map((x) => `${deployDir}/${x}.js`);
 var b = browserify(files, {
   cache: {},
   packageCache: {},
+  // Enable sourcemaps when not in production mode
+  debug: ! inProduction
 });
 
 // Transforms


### PR DESCRIPTION
These make JS debugging marginally less insane.