### PR TITLE
Allow any hostname in development

### DIFF
--- a/openprescribing/openprescribing/settings/local.py
+++ b/openprescribing/openprescribing/settings/local.py
@@ -15,7 +15,7 @@ TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 # SITE CONFIGURATION
 # Hosts/domain names that are valid for this site
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['localhost', 'openprescribing.net', 'openprescriptions.net', '127.0.0.1']
+ALLOWED_HOSTS = ['*']
 # END SITE CONFIGURATION
 
 


### PR DESCRIPTION
This is handy when trying to load the site from a VM running Windows.
And host header protection is unnecessary in development.