### PR TITLE
Add warning banner for IE8 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If required, you can run individual Django tests as follows:
 
     python manage.py test frontend.tests.test_api_views
 
-We support IE8 and above. We have a free account for testing across
+We support IE9 and above. We have a free account for testing across
 multiple browsers, thanks to [BrowserStack](www.browserstack.com).
 
 ![image](https://user-images.githubusercontent.com/211271/29110431-887941d2-7cde-11e7-8c2f-199d85c5a3b5.png)

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -114,6 +114,13 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
       </div>
     </nav>
 
+    <!--[if lt IE 9]>
+    <div class="alert alert-danger" style="width: 100%; max-width: none; text-align: center; margin-top: -10px; font-size: 120%">
+      <strong>Warning!</strong> The charts on this website won't display in
+      <strong>Internet Explorer 8</strong> or other older web browsers.
+    </div>
+    <![endif]-->
+
     <div class="container {% block container_class %}{% endblock %}">
 
       <div class="starter-template">


### PR DESCRIPTION
Our charts currently don't work on IE8. While I did manage to get them
working it involved downgrading some libraries (e.g. the `domready`
package) and polyfilling various various missing Array methods.
Maintaining IE8 compatability therefore looks like it will be a
non-negligable future maintenance burden.

Currently IE8 represents about 1% of our total visitors and 1.7% of our
NHS visitors. So it doesn't seem worthwhile to spend our limited
resources on this. (IE9, by contrast, continues to work without issue.)

Example of the warning in action:
![ie8-warning](https://user-images.githubusercontent.com/19630/45831556-98b8ec00-bcf7-11e8-87fc-f3151c1c7bfe.jpg)
