### PR TITLE
Hide negative values on PPU cost axis

### DIFF
--- a/openprescribing/media/js/src/bubble.js
+++ b/openprescribing/media/js/src/bubble.js
@@ -59,7 +59,13 @@ domready(function() {
           text: 'PPU',
         },
         labels: {
-          format: '£{value}',
+          formatter: function() {
+            if (this.value < 0) {
+              return '';
+            } else {
+              return '£' + this.value;
+            }
+          }
         },
         plotLines: [{
           color: 'black',


### PR DESCRIPTION
These are just generated by Highcharts trying to be clever, but they
don't make any sense in this context.

Closes #1011