### PR TITLE
Order PPU bubbles by weighted mean PPU, not simple mean

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -119,8 +119,9 @@ def bubble(request, format=None):
         ordered_ppus_sql = binned_ppus_sql + (
             "SELECT * FROM ("
             " SELECT *, "
-            " AVG(ppu) OVER ("
-            "  PARTITION BY presentation_code) AS mean_ppu, "
+            " SUM(ppu * quantity) OVER (PARTITION BY presentation_code)"
+            "  / SUM(quantity) OVER (PARTITION BY presentation_code)"
+            "      AS mean_ppu, "
             " NTILE(%s) OVER (ORDER BY ppu) AS ntiled "
             " FROM binned_ppus "
             " ORDER BY mean_ppu, presentation_name) ranked "
@@ -130,7 +131,9 @@ def bubble(request, format=None):
 
         ordered_ppus_sql = binned_ppus_sql + (
             "SELECT *, "
-            "AVG(ppu) OVER (PARTITION BY presentation_code) AS mean_ppu "
+            "SUM(ppu * quantity) OVER (PARTITION BY presentation_code) "
+            " / SUM(quantity) OVER (PARTITION BY presentation_code)"
+            "     AS mean_ppu "
             "FROM binned_ppus "
             "ORDER BY mean_ppu, presentation_name, ppu"
         )

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -804,10 +804,10 @@ class TestAPISpendingViewsPPUBubble(ApiTestBase):
             {'series': [
                 {'y': 0.09, 'x': 1, 'z': 32.0,
                  'name': 'Chlortalidone_Tab 50mg',
-                 'mean_ppu': 0.095},
+                 'mean_ppu': 0.098},
                 {'y': 0.1, 'x': 1, 'z': 128.0,
                  'name': 'Chlortalidone_Tab 50mg',
-                 'mean_ppu': 0.095}],
+                 'mean_ppu': 0.098}],
              'categories': [
                  {'is_generic': True, 'name': 'Chlortalidone_Tab 50mg'}],
              'plotline': 0.08875}
@@ -825,7 +825,7 @@ class TestAPISpendingViewsPPUBubble(ApiTestBase):
             {'series': [
                 {'y': 0.09, 'x': 1, 'z': 32.0,
                  'name': 'Chlortalidone_Tab 50mg',
-                 'mean_ppu': 0.095}],
+                 'mean_ppu': 0.098}],
              'categories': [
                  {'is_generic': True, 'name': 'Chlortalidone_Tab 50mg'}],
              'plotline': 0.08875}


### PR DESCRIPTION
The previous method caused odd looking charts when a small number of
prescriptions at a high PPU (whether through data error or for some
other reason) dragged the simple mean up and caused bubbles to appear in
the "wrong" place (i.e. they didn't look right visually).

Closes #1008