### PR TITLE
Ensure constraint_and_index_reconstructor is actually called

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -655,4 +655,5 @@ def conditional_constraint_and_index_reconstructor(options):
         # updating the entire table.
         yield
     else:
-        yield utils.constraint_and_index_reconstructor('frontend_measurevalue')
+        with utils.constraint_and_index_reconstructor('frontend_measurevalue'):
+            yield

--- a/openprescribing/frontend/tests/commands/test_import_measures.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures.py
@@ -86,25 +86,24 @@ class UnitTests(TestCase):
     """
     fixtures = ['measures']
 
-    @patch('django.db.connection')
-    def test_reconstructor_not_called_when_measures_specified(self, conn):
+    @patch('common.utils.db')
+    def test_reconstructor_not_called_when_measures_specified(self, db):
         from frontend.management.commands.import_measures \
             import conditional_constraint_and_index_reconstructor
         with conditional_constraint_and_index_reconstructor(
                 {'measure': 'thingy'}):
             pass
-        execute = conn.cursor.return_value.__enter__.return_value.execute
+        execute = db.connection.cursor.return_value.__enter__.return_value.execute
         execute.assert_not_called()
 
-    @patch('frontend.management.commands.import_measures.connection')
-    def test_reconstructor_called_when_no_measures_specified(self, conn):
+    @patch('common.utils.db')
+    def test_reconstructor_called_when_no_measures_specified(self, db):
         from frontend.management.commands.import_measures \
             import conditional_constraint_and_index_reconstructor
         with conditional_constraint_and_index_reconstructor({'measure': None}):
             pass
-        calls = conn.cursor.return_value.__enter__\
-                    .return_value.execute.mock_calls
-        self.assertGreater(calls, 0)
+        execute = db.connection.cursor.return_value.__enter__.return_value.execute
+        execute.assert_called()
 
 
 class BigqueryFunctionalTests(TestCase):


### PR DESCRIPTION
constraint_and_index_reconstructor was not used correctly in
import_measures, because although it was called and yielded, the result
was never iterated over.  This PR changes it to be called and used as a
context manager, which was the original intention.

Although this code is exercised in tests, this bug was not detected,
because a test asserted that an empty list (the list of calls) was
greater than zero.  This returns True in Python 2 (where comparing
values of different types is allowed) but raises a TypeError in Python
3.  (Additionally, the wrong thing was being patched.)

This PR fixes the code and the tests to reflect the intended behaviour,
but before merging we should decide whether this is what we actually
want, as we have survived without it for a long time.