### PR TITLE
Improve measures layout

### DIFF
--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -622,6 +622,9 @@ def make_email_with_campaign(bookmark, campaign_source):
     return msg
 
 
+def get_chart_id(measure_id):
+    return "#{}-with-title".format(measure_id)
+
 def make_org_email(org_bookmark, stats, preview=False, tag=None):
     msg = make_email_with_campaign(org_bookmark, 'dashboard-alerts')
     dashboard_uri = org_bookmark.dashboard_url()
@@ -641,20 +644,20 @@ def make_org_email(org_bookmark, stats, preview=False, tag=None):
                 msg,
                 org_bookmark.dashboard_url(),
                 getting_worse_file.name,
-                '#' + most_changing['declines'][0]['measure'].id
+                get_chart_id(most_changing['declines'][0]['measure'].id)
             )
         if stats['worst']:
             still_bad_img = attach_image(
                 msg,
                 org_bookmark.dashboard_url(),
                 still_bad_file.name,
-                '#' + stats['worst'][0].id)
+                get_chart_id(stats['worst'][0].id))
         if stats['interesting']:
             interesting_img = attach_image(
                 msg,
                 org_bookmark.dashboard_url(),
                 interesting_file.name,
-                '#' + stats['interesting'][0].id)
+                get_chart_id(stats['interesting'][0].id))
         unsubscribe_link = settings.GRAB_HOST + reverse(
             'bookmark-login',
             kwargs={'key': org_bookmark.user.profile.key})

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -625,6 +625,7 @@ def make_email_with_campaign(bookmark, campaign_source):
 def get_chart_id(measure_id):
     return "#{}-with-title".format(measure_id)
 
+
 def make_org_email(org_bookmark, stats, preview=False, tag=None):
     msg = make_email_with_campaign(org_bookmark, 'dashboard-alerts')
     dashboard_uri = org_bookmark.dashboard_url()

--- a/openprescribing/media/css/dashboard.less
+++ b/openprescribing/media/css/dashboard.less
@@ -58,11 +58,17 @@
 
     .panel-body {
         padding: 5px;
-        .inner {
+        .inner, .measure-description {
           padding: 10px;
           overflow: auto;
           white-space: normal;
         }
+    }
+    .measure-description {
+      font-style: italic;
+      margin-bottom: 0px;
+      padding-bottom: 0px;
+      text-align: center;
     }
     .explanation {
       margin: 5px 10px 10px 10px;

--- a/openprescribing/media/css/dashboard.less
+++ b/openprescribing/media/css/dashboard.less
@@ -36,9 +36,13 @@
 }
 
 #measures {
-
+  font-size: 12px;
   margin-top: 20px;
   clear: both;
+
+  .descriptive {
+    margin-bottom: 10px;
+  }
 
   .loading-wrapper {
     display: block;
@@ -52,9 +56,6 @@
   .panel {
     white-space: nowrap;
     overflow: hidden;
-    .panel-heading {
-      font-size: 12px;
-    }
 
     .panel-body {
         padding: 5px;
@@ -72,7 +73,6 @@
     }
     .explanation {
       margin: 5px 10px 10px 10px;
-      font-size: 12px;
       white-space: normal;
       min-height: 3.5em;
 
@@ -83,9 +83,6 @@
           color: #337ab7;
         }
       }
-    }
-    p, li {
-      font-size: 12px;
     }
     .chart {
       margin-top: 5px;

--- a/openprescribing/media/js/build.js
+++ b/openprescribing/media/js/build.js
@@ -38,7 +38,9 @@ if (inProduction) {
 // * `watchify` observes and re-builds files on changes
 b.plugin('factor-bundle', {outputs: bundles}); //
 if (!inProduction) {
-  b.plugin('watchify');
+  b.plugin('watchify', {
+    poll: true  // work with NFS-within-vagrant
+  });
   b.on('update', bundle);
 }
 

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -496,6 +496,8 @@ var utils = {
           return "National decile";
         } else if (this.name === '50th percentile nationally') {
           return "National median";
+        } else {
+          return this.name;
         }
       }
     };

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -439,6 +439,7 @@ var utils = {
         isNationalSeries: false,
         data: d.data,
         color: 'red',
+        showInLegend: true,
         marker: {
           radius: 2,
         },
@@ -451,6 +452,7 @@ var utils = {
           dashStyle: 'dot',
           color: 'blue',
           lineWidth: 1,
+          showInLegend: false,
           marker: {
             enabled: false,
           },
@@ -458,6 +460,10 @@ var utils = {
         // Distinguish the median visually.
         if (k === '50') {
           e.dashStyle = 'longdash';
+        }
+        // Show median and an arbitrary decile in the legend
+        if (k === '10' || k === '50') {
+          e.showInLegend = true;
         }
         hcOptions.series.push(e);
       });
@@ -480,7 +486,19 @@ var utils = {
     isPercentageMeasure = (d.isPercentage || isPercentageMeasure);
     chOptions.chart.renderTo = d.chartId;
     chOptions.chart.height = 250;
-    chOptions.legend.enabled = false;
+    chOptions.legend = {
+      enabled: true,
+      x: 0,
+      y: 0,
+      labelFormatter: function() {
+        // Rename selected series for the legend
+        if (this.name === '10th percentile nationally') {
+          return "National decile";
+        } else if (this.name === '50th percentile nationally') {
+          return "National median";
+        }
+      }
+    };
     if (options.rollUpBy === 'org_id') {
       ymax = _.max([localMax.y, options.globalYMax.y]);
       ymin = _.min([localMin.y, options.globalYMin.y]);

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -438,6 +438,9 @@ var utils = {
         name: 'This ' + options.orgType,
         isNationalSeries: false,
         data: d.data,
+        events: {
+          legendItemClick: function() { return false; }
+        },
         color: 'red',
         showInLegend: true,
         marker: {
@@ -450,6 +453,9 @@ var utils = {
           isNationalSeries: true,
           data: d.globalCentiles[k],
           dashStyle: 'dot',
+          events: {
+            legendItemClick: function() { return false; }
+          },
           color: 'blue',
           lineWidth: 1,
           showInLegend: false,

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -44,11 +44,11 @@
               </div>
 
               <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
-                  <p><strong>Why it matters:</strong> {{{ why_it_matters }}}</p>
+                  <div class="descriptive"><strong>Why it matters:</strong> {{{ why_it_matters }}}</div>
                  {{#if chartExplanation }}
-                  <p><strong>Performance:</strong> {{{ chartExplanation }}}</p>
+                  <div class="descriptive"><strong>Performance:</strong> {{{ chartExplanation }}}</div>
                  {{/if}}
-                  <p><strong>Explore:</strong>
+                  <div class="descriptive"><strong>Explore:</strong>
                     <ul>
                      {{#if tagsFocus }}
                      <li>
@@ -72,14 +72,14 @@
                      <li><a href="{{ measureUrl }}">Compare all CCGs
                      in England on this measure</a></li>
                     </ul>
-                  </p>
-                  <p>
+                  </div>
+                  <div class="descriptive">
                     <strong>Tagged as:</strong>
                     {{# each tagsForDisplay as |tag index|}}
                       <a href="?tags={{ tag.id }}">{{ tag.name }}</a>{{#unless @last }}, {{/unless}}
                     {{/each}}
                     {{# unless tagsForDisplay }}<em>No tags yet</em>{{/unless}}
-                  </p>
+                  </div>
               </div>
           </div>
 

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -30,9 +30,10 @@
           <div class="panel-body" class="row">
               <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
                 <p class="measure-description">{{{ description }}}</p>
-
-                <div id="{{ chartId }}">
-                  <div class="status"></div>
+                <div id="{{ chartId }}-with-title">
+                  <div id="{{ chartId }}">
+                    <div class="status"></div>
+                  </div>
                 </div>
                 <p class="text-right" style="margin-top: 4px">
                   <a href="#" data-download-chart-id="{{ chartId }}">

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -28,9 +28,22 @@
               <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
           </div>
           <div class="panel-body" class="row">
+              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+                <p class="measure-description">{{{ description }}}</p>
+
+                <div id="{{ chartId }}">
+                  <div class="status"></div>
+                </div>
+                <p class="text-right" style="margin-top: 4px">
+                  <a href="#" data-download-chart-id="{{ chartId }}">
+                    Download data
+                    <span class="glyphicon glyphicon-download-alt"></span>
+                  </a>
+                </p>
+              </div>
+
               <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6 inner">
                   <p><strong>Why it matters:</strong> {{{ why_it_matters }}}</p>
-                  <p><strong>Description:</strong> {{{ description }}}</p>
                  {{#if chartExplanation }}
                   <p><strong>Performance:</strong> {{{ chartExplanation }}}</p>
                  {{/if}}
@@ -66,17 +79,6 @@
                     {{/each}}
                     {{# unless tagsForDisplay }}<em>No tags yet</em>{{/unless}}
                   </p>
-              </div>
-              <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-                <div id="{{ chartId }}">
-                  <div class="status"></div>
-                </div>
-                <p class="text-right" style="margin-top: 4px">
-                  <a href="#" data-download-chart-id="{{ chartId }}">
-                    Download data
-                    <span class="glyphicon glyphicon-download-alt"></span>
-                  </a>
-                </p>
               </div>
           </div>
 


### PR DESCRIPTION
Looks like this:

![image](https://user-images.githubusercontent.com/211271/45946086-ac11d300-bfe7-11e8-804e-1ad22b6ffd83.png)

Note that 2 or 3 of the descriptions (the ones that include BNF codes - the second in that screenshot) are unpleasantly long to function as chart titles. I propose that we deploy anyway (it's an improvement overall) and create a new issue to show a list of the BNF codes used in the numerator and denominator as a mouseover or similar (so we're consistent across all measures)

Closes #1039, and closes #1040 
