### PR TITLE
Add Sentry's JavaScript error tracking

### DIFF
--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -51,6 +51,7 @@
     }
   },
   "dependencies": {
+    "@sentry/browser": "^4.0.5",
     "bigtext": "^1.0.1",
     "bootstrap": "^3.3.4",
     "chroma-js": "^1.2",

--- a/openprescribing/media/js/src/global.js
+++ b/openprescribing/media/js/src/global.js
@@ -1,3 +1,8 @@
+var Sentry = require('@sentry/browser');
+if (window.SENTRY_PUBLIC_DSN && SENTRY_PUBLIC_DSN !== '') {
+  Sentry.init({dsn: SENTRY_PUBLIC_DSN});
+}
+
 var $ = require('jquery');
 var domready = require('domready');
 var bootstrap = require('bootstrap');

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -1,10 +1,12 @@
 {% load staticfiles %}
 {% load template_extras %}
+{% load raven %}
 
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <script>var SENTRY_PUBLIC_DSN = '{% sentry_public_dsn "https" %}';</script>
     {% if GOOGLE_TRACKING_ID %}
     <script>
       function setParamsFromQueryString(params, keys) {


### PR DESCRIPTION
This involves addding the Sentry error tracking library to our JS and
then passing through the account identfier which allows Sentry to
associated these errors with the correct application.

As this identifier is exposed to the world at large it needs to be the
public one, not not the private one which contains our secret key. Sentry
provide the `raven` templatetag library which generates this public ID
automatically for us.