### PR TITLE
Fix bar charts broken by Highcharts update

### DIFF
--- a/openprescribing/media/js/src/bar-charts.js
+++ b/openprescribing/media/js/src/bar-charts.js
@@ -84,7 +84,9 @@ var barChart = {
         };
         chart.yAxis[0].update(newYAxisOptions, false);
         var newData = _this.getYValueOfData(data, graphType);
-        chart.series[0].setData(newData, false);
+        // See: https://api.highcharts.com/class-reference/Highcharts.Series#setData
+        // args below are: redraw=false, animation=false, updatePoints=false
+        chart.series[0].setData(newData, false, false, false);
         chart.setTitle({text: _this.getChartTitle(graphType)}, false);
         chart.redraw();
     },


### PR DESCRIPTION
These charts were broken by a change in Highcharts v6.1.0. Specifically
the change:

 * Added feature to animate the series when updating data through
   Series.setData, Series.update or Chart.update. The new logic looks
   for matching X values and can be disabled through setData's
   updatePoints option.

https://www.highcharts.com/documentation/changelog#highcharts-v6.1.0

The fix is to disable the new `updatePoints` logic as described.

Closes #1107