### PR TITLE
Fix error when resetting zoom on Analyse bar charts

### DIFF
--- a/openprescribing/media/js/src/analyse-bar-chart.js
+++ b/openprescribing/media/js/src/analyse-bar-chart.js
@@ -63,7 +63,12 @@ var barChart = {
       barOptions.yAxis.max = globalOptions.maxRatioItems;
     }
     barOptions.series = utils.createChartSeries(dataForMonth);
+    barOptions.xAxis.categories = this._getCategoriesFromSeries(barOptions.series[0]);
     return new Highcharts.Chart(barOptions);
+  },
+
+  _getCategoriesFromSeries: function (series) {
+    return series.data.map(function(d) { return d.name; });
   },
 
   update: function(chart, month, ratio, title, formatter, playing, yAxisMax) {
@@ -85,6 +90,7 @@ var barChart = {
       chart.series[0].setData([], false);
     }
     chart.yAxis[0].setExtremes(null, yAxisMax);
+    chart.xAxis[0].setCategories(this._getCategoriesFromSeries(chart.series[0]), false);
     try {
       chart.redraw();
     } catch (err) {


### PR DESCRIPTION
This was caused by the Highcharts upgrade. Specifically, v4.2.7 has this
issue and v4.2.6 doesn't. The solution (or *a* solution) seems to be to
set the x-axis categories explicity rather than relying on each data
point having a `name` property.

It's not entirely obvious how or why this works although the upgrade
contains various changes to the label display logic for category axes so
this fix is at least plausible.

Closes #1116

Highcharts changelog:
https://www.highcharts.com/documentation/changelog#highcharts-v4.2.7

Difference between versions:
https://github.com/highcharts/highcharts/compare/v4.2.6..v4.2.7