### PR TITLE
Tell Travis to run builds on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,6 @@ addons:
       secure: MlmeHStJ91/CHGiz2wVo8rOsrBjk181DbQPSV4PYlJQyogDuGQrKy8LIkUZlzaXUhhG+H5jdUyfoBGJXhZCCxjwzf4yibZEYpHWvWGfCwb8g4SFr9doDSxmwY0aJgYkJGAMPKxz7MQ4LXgNp/6z+NO1kw3uU0poNQEMz73Do9rd6iVRvjRThj4q0wGv5AoV3+LshVtHKHBpcEs0ZyHzmEuGrpEuR0Ak4g1Dif0HoMmAepmU/pNui18tMHx3HDtBerKuo1+ou4eEtxBUy4OVnAas7+zgw3e1pWawsf3mMTSKGxY6rFTIE5A5N+Te589vVGucpc0XzfoxpFtn13DLMFG4Mf0mdBgHYBo+fCuIrBwPZ0RoD7NV7RfhKKGQ4rpLP6uwjFTCtbG1CyT5+zz/RxxbE+guqmIUZI6oZZQsXx7mk2cypQgV3La41O85VJ6Y74QRCK9c59ChiDxjfYbIMLysP8E4d5GmLnLUFlGjSTr9G8bP3kHZqhE12tg2JPqhMG3eMvQngQfQhgXqh4shBPOJCUthinafJizyJ9lscx0OMmNkb4GMqXAEJNIz7Xp0xFJvsOnLyoWO3rJ2UoZd1tNuv4OnhQOsZvvHePueAyYateXPHsFPOaIhgoAQkGkALI+E8+2dSWUVZo5EqYd00beM4Ni6GTThpZ3tIIfTu2+w=
 after_success:
   - docker-compose run test /bin/bash -c 'pip install coveralls==1.3.0 && cd openprescribing && coveralls'
+branches:
+  only:
+  - master


### PR DESCRIPTION
This is an attempt to fix the issue whereby Coveralls fails to tell us
how a given PR increases or decreases coverage. (See
https://github.com/ebmdatalab/sysadmin/issues/35). We also noticed that
the badge Coveralls generates for us says that the overall coverage
level is unknown (despite it clearly reporting coverage levels for
individual PRs).

The hypothesis is that this is due to Travis not running builds on the
master branch itself, so Coveralls has no baseline to compare to.
Travis's "branches" dashboard states that the last build on master was
two years ago, which supports this.

There is a setting in Travis which runs builds on every branch, but this
is disabled on OpenPrescribing presumably for performance reasons as it
results in two sets of builds for each PR (one on the branch as it is,
and another on how the branch would look after being merged to master).

An alternative to enabling this setting is to explicitly whitelist
branches to be built, as described here:
https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches

Hopefully this won't disrupt our normal PR testing but we shall have to
see.