### PR TITLE
Fix unsubscribe form for users with just one alert

### DIFF
--- a/openprescribing/frontend/tests/fixtures/bookmark_alerts_extra.json
+++ b/openprescribing/frontend/tests/fixtures/bookmark_alerts_extra.json
@@ -1,0 +1,42 @@
+[
+{
+  "model": "auth.user",
+  "pk": 5,
+  "fields": {
+    "password": "!pZgapyTQg0svG35XcW1qhCthZomwBxMg2ZpTvQv6",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "single-bookmark-user",
+    "first_name": "",
+    "last_name": "",
+    "email": "foo5@baz.com",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2016-09-28T15:08:58.446Z",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "account.emailaddress",
+  "pk": 3,
+  "fields": {
+    "user": 5,
+    "email": "foo5@baz.com",
+    "verified": true,
+    "primary": false
+  }
+},
+{
+  "model": "frontend.orgbookmark",
+  "pk": 5,
+  "fields": {
+    "user": 5,
+    "pct": null,
+    "practice": "P87629",
+    "approved": true,
+    "created_at": "2000-01-01T12:00:00Z"
+  }
+}
+
+]

--- a/openprescribing/frontend/tests/functional/test_bookmarks.py
+++ b/openprescribing/frontend/tests/functional/test_bookmarks.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from django.core.urlresolvers import reverse
+
+from selenium_base import SeleniumTestCase
+
+from frontend.models import User, OrgBookmark
+
+
+class BookmarksTest(SeleniumTestCase):
+    fixtures = ['bookmark_alerts', 'bookmark_alerts_extra']
+
+    def _get_bookmark_url_for_user(self, username='bookmarks-user'):
+        key = User.objects.get(username=username).profile.key
+        return reverse('bookmark-login', kwargs={'key': key})
+
+    def test_unsubscribe_from_one_alert(self):
+        url = self._get_bookmark_url_for_user()
+        bookmark_count = OrgBookmark.objects.count()
+        self.browser.get(self.live_server_url + url)
+        self.find_by_xpath("//input[@name='org_bookmarks']").click()
+        self.find_by_xpath("//input[@value='Unsubscribe']").click()
+        self.find_by_xpath("//div[contains(text(), 'Unsubscribed')]")
+        self.assertEqual(OrgBookmark.objects.count(), bookmark_count - 1)
+
+    def test_unsubscribe_all_at_once(self):
+        url = self._get_bookmark_url_for_user()
+        bookmark_count = OrgBookmark.objects.count()
+        self.browser.get(self.live_server_url + url)
+        self.find_by_xpath("//input[@value='Unsubscribe from all']").click()
+        self.find_by_xpath("//div[contains(text(), 'Unsubscribed')]")
+        self.assertEqual(OrgBookmark.objects.count(), bookmark_count - 2)
+
+    def test_unsubscribe_all_at_once_with_single_bookmark(self):
+        # The form used if you have only a single subscription is different
+        # from the form for multliple subscriptions so we have to test it
+        # separately
+        url = self._get_bookmark_url_for_user(username='single-bookmark-user')
+        bookmark_count = OrgBookmark.objects.count()
+        self.browser.get(self.live_server_url + url)
+        self.find_by_xpath("//input[@value='Unsubscribe']").click()
+        self.find_by_xpath("//div[contains(text(), 'Unsubscribed')]")
+        self.assertEqual(OrgBookmark.objects.count(), bookmark_count - 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openprescribing/frontend/tests/test_bookmark_views.py
+++ b/openprescribing/frontend/tests/test_bookmark_views.py
@@ -1,15 +1,8 @@
-import base64
-from mock import patch
-
 from django.test import TransactionTestCase
 from django.core.urlresolvers import reverse
 
 from frontend.models import OrgBookmark
-from frontend.models import SearchBookmark
-from frontend.models import PCT
-from frontend.models import Practice
 from frontend.models import User
-from frontend.models import Measure
 
 
 class TestBookmarkViews(TransactionTestCase):

--- a/openprescribing/frontend/tests/test_bookmark_views.py
+++ b/openprescribing/frontend/tests/test_bookmark_views.py
@@ -6,7 +6,7 @@ from frontend.models import User
 
 
 class TestBookmarkViews(TransactionTestCase):
-    fixtures = ['bookmark_alerts']
+    fixtures = ['bookmark_alerts', 'bookmark_alerts_extra']
 
     def _get_bookmark_url_for_user(self):
         key = User.objects.get(username='bookmarks-user').profile.key

--- a/openprescribing/frontend/tests/test_bookmark_views.py
+++ b/openprescribing/frontend/tests/test_bookmark_views.py
@@ -30,6 +30,7 @@ class TestBookmarkViews(TransactionTestCase):
     def test_unsubscribe_one_by_one(self):
         # First, log in
         url = self._get_bookmark_url_for_user()
+        bookmark_count = OrgBookmark.objects.count()
         self.client.get(url, follow=True)
         # There should be 2 bookmarks to get rid of
         for _ in range(3):
@@ -39,11 +40,12 @@ class TestBookmarkViews(TransactionTestCase):
             self.assertContains(
                 response,
                 "Unsubscribed from 1 alert")
-        self.assertEqual(OrgBookmark.objects.count(), 1)
+        self.assertEqual(OrgBookmark.objects.count(), bookmark_count - 3)
 
     def test_unsubscribe_all_at_once(self):
         # First, log in
         url = self._get_bookmark_url_for_user()
+        bookmark_count = OrgBookmark.objects.count()
         self.client.get(url, follow=True)
         data = {'unsuball': 1}
         response = self.client.post(
@@ -53,4 +55,4 @@ class TestBookmarkViews(TransactionTestCase):
             "Unsubscribed from 3 alerts")
         # There's one org bookmark which is unapproved, so they don't
         # see it in their list, and it doesn't get deleted.
-        self.assertEqual(OrgBookmark.objects.count(), 2)
+        self.assertEqual(OrgBookmark.objects.count(), bookmark_count - 2)

--- a/openprescribing/openprescribing/settings/production.py
+++ b/openprescribing/openprescribing/settings/production.py
@@ -83,13 +83,21 @@ LOGGING = {
             'formatter': 'verbose',
             'filename': "%s/logs/mail-signals.log" % REPO_ROOT,
             'maxBytes': 1024 * 1024 * 100,  # 100 mb
-        }
-
+        },
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
+        },
     },
     'loggers': {
         'django': {
             'handlers': ['gunicorn'],
             'level': 'WARN',
+            'propagate': True,
+        },
+        'django.security.csrf': {
+            'handlers': ['sentry'],
+            'level': 'WARNING',
             'propagate': True,
         },
         'frontend': {

--- a/openprescribing/openprescribing/settings/staging.py
+++ b/openprescribing/openprescribing/settings/staging.py
@@ -70,12 +70,21 @@ LOGGING = {
             'filename':
             "%s/logs/mail-signals.log" % REPO_ROOT,
             'maxBytes': 1024 * 1024 * 100,  # 100 mb
-            }
+        },
+        'sentry': {
+            'level': 'WARNING',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
+        },
     },
     'loggers': {
         'django': {
             'level': 'WARN',
             'handlers': ['gunicorn'],
+            'propagate': True,
+        },
+        'django.security.csrf': {
+            'handlers': ['sentry'],
+            'level': 'WARNING',
             'propagate': True,
         },
         'frontend': {

--- a/openprescribing/templates/bookmarks/bookmark_list.html
+++ b/openprescribing/templates/bookmarks/bookmark_list.html
@@ -12,6 +12,7 @@
      <strong><a href="{{ single_bookmark.get_absolute_url }}">{{ single_bookmark.name }}</a></strong>
    </p>
    <form class="form" method="post">
+     {% csrf_token %}
      <input class="btn btn-primary" type="submit" name="unsuball" value="Unsubscribe">
    </form>
  {% else %}


### PR DESCRIPTION
The issue was a missing CSRF token which is a single line fix. However I have also added functional tests which now cover this, and also enabled tracking of CSRF failures in Sentry so we get alerted when they happen.