### PR TITLE
Fix outlier toggle

### DIFF
--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -361,7 +361,7 @@ var analyseChart = {
       _this.setUpAlertSubscription();
     });
     // Outlier toggle
-    $(_this.el.outliersToggle).on('click', function(e) {
+    $(_this.el.outliersToggle).find('.toggle').on('click', function(e) {
       e.preventDefault();
       if (_this.globalOptions.hasOutliers) {
         if (_this.globalOptions.hideOutliers) {

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -366,14 +366,10 @@ var analyseChart = {
       if (_this.globalOptions.hasOutliers) {
         if (_this.globalOptions.hideOutliers) {
           _this.globalOptions.hideOutliers = false;
-          $(_this.el.outliersToggle).find('a').text(
-            'Remove them from the chart');
           Cookies.set('hide_small_lists', '0');
         } else {
           // set a cookie
           _this.globalOptions.hideOutliers = true;
-          $(_this.el.outliersToggle).find('a').text(
-            'Show them in the chart');
           Cookies.set('hide_small_lists', '1');
         }
         _this.setOutlierLinkText();

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -363,6 +363,8 @@ var analyseChart = {
     // Outlier toggle
     $(_this.el.outliersToggle).find('.toggle').on('click', function(e) {
       e.preventDefault();
+      if (_this.outlierToggleUpdating) return;
+      _this.outlierToggleUpdating = true;
       if (_this.globalOptions.hasOutliers) {
         if (_this.globalOptions.hideOutliers) {
           _this.globalOptions.hideOutliers = false;
@@ -382,7 +384,11 @@ var analyseChart = {
           _this.globalOptions.lineChart = lineChart.setUp(
             chartOptions.lineOptions,
             _this.globalOptions);
-          map.setup(_this.globalOptions);
+          map.setup(_this.globalOptions).then(function() {
+            _this.outlierToggleUpdating = false;
+          });
+        } else {
+          _this.outlierToggleUpdating = false;
         }
       }
     });

--- a/openprescribing/media/js/src/analyse-map.js
+++ b/openprescribing/media/js/src/analyse-map.js
@@ -1,4 +1,5 @@
 require('mapbox.js');
+var $ = require('jquery');
 var chroma = require('chroma-js');
 var utils = require('./chart_utils');
 var formatters = require('./chart_formatters');
@@ -30,6 +31,7 @@ var analyseMap = {
         _this.map.legendControl.removeLegend(_this.legendHtml);
       }
     }
+    var completed = $.Deferred();
 
     _this.popup = new L.Popup({autoPan: false});
     var boundsUrl = this.getBoundsUrl(options);
@@ -65,6 +67,7 @@ var analyseMap = {
       _this.updateMap('items',
                       options);
       $('#play-slider').show();
+      completed.resolve();
     }
 
     function joinFeaturesWithData(currentJson, data) {
@@ -85,6 +88,8 @@ var analyseMap = {
       }
       return joinedFeatures;
     }
+
+    return completed;
   },
 
   addLayerEvents: function(ratio, month) {


### PR DESCRIPTION
Clicking the outlier toggle triggers a call to `map.setup` which is
asynchronous and not reentrant. This means that clicking the toggle
again while the map is still updating causes an error.

This problem happens quite frequently as the update takes a while and
blocks the UI for much of the time so it looks like nothing's happening,
leading to users clicking again and then getting an error.

As the simplest possible fix this patch just introduces a lock on the
update which allows only one to run at a time.

Note that this doesn't introduce a new jQuery dependency into the map
code: the dependency was there already, it just wasn't explicit.