### PR TITLE
Add warning to patients trying to contact their practice

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -955,12 +955,12 @@ def tariff(request, code=None):
 
 
 def feedback_view(request):
+    url = request.GET.get('from_url', '/')
     if request.POST:
         form = FeedbackForm(request.POST)
         if form.is_valid():
             user_name = form.cleaned_data['name'].strip()
             user_email_addr = form.cleaned_data['email'].strip()
-            url = request.GET.get('from_url', '/')
             send_feedback_mail(
                 user_name=user_name,
                 user_email_addr=user_email_addr,
@@ -978,7 +978,12 @@ def feedback_view(request):
     else:
         form = FeedbackForm()
 
-    return render(request, 'feedback.html', {'form': form})
+    show_warning = '/practice/' in url
+
+    return render(request, 'feedback.html', {
+        'form': form,
+        'show_warning': show_warning
+    })
 
 
 ##################################################

--- a/openprescribing/templates/feedback.html
+++ b/openprescribing/templates/feedback.html
@@ -7,6 +7,16 @@
 {% block content %}
 <h2>Feedback</h2>
 
+{% if show_warning %}
+  <div class="alert alert-warning">
+    <span class="glyphicon glyphicon-exclamation-sign"></span>
+    Note to patients: this form sends feedback to the OpenPrescribing team at
+    Oxford.  If you are trying to contact your practice please
+    <a href="https://www.nhs.uk/service-search/GP/LocationSearch/4">click here</a>
+    to search for them.
+  </div>
+{% endif %}
+
 <form method="post" role="form">
   {% csrf_token %}
   {{ form.non_field_errors }}


### PR DESCRIPTION
Point them to NHS Choices instead.

I decided against adding another warning on the practice homepage on the
basis that in order to actually contact us the user will have to go via
the Feedback page anyway (yes, they could copy/paste the email address
but I assume the people in question aren't the sort to do this) and teh
additonal warning just creates extra noise on the page for our real
users.

Closes #1138 

![staging openprescribing net_feedback__from_url http 3a 2f 2fevans io 2fpractice 2fg85724 2f](https://user-images.githubusercontent.com/19630/47994686-ff009f00-e0ea-11e8-9f86-797b3ea22eb0.png)
