### PR TITLE
Prevent open redirect

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -955,12 +955,12 @@ def tariff(request, code=None):
 
 
 def feedback_view(request):
+    url = request.GET.get('from_url', '/')
     if request.POST:
         form = FeedbackForm(request.POST)
         if form.is_valid():
             user_name = form.cleaned_data['name'].strip()
             user_email_addr = form.cleaned_data['email'].strip()
-            url = request.GET.get('from_url', '/')
             send_feedback_mail(
                 user_name=user_name,
                 user_email_addr=user_email_addr,
@@ -978,7 +978,12 @@ def feedback_view(request):
     else:
         form = FeedbackForm()
 
-    return render(request, 'feedback.html', {'form': form})
+    show_warning = '/practice/' in url
+
+    return render(request, 'feedback.html', {
+        'form': form,
+        'show_warning': show_warning
+    })
 
 
 ##################################################

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -23,6 +23,7 @@ from django.http import HttpResponse
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.shortcuts import render, get_object_or_404
+from django.utils.http import is_safe_url
 from django.utils.safestring import mark_safe
 
 from allauth.account import app_settings
@@ -974,7 +975,12 @@ def feedback_view(request):
                    "folder for our reply.".format(user_email_addr))
             messages.success(request, msg)
 
-            return HttpResponseRedirect(url)
+            if is_safe_url(url, allowed_hosts=[request.get_host()]):
+                redirect_url = url
+            else:
+                logger.error(u'Unsafe redirect URL: {}'.format(url))
+                redirect_url = '/'
+            return HttpResponseRedirect(redirect_url)
     else:
         form = FeedbackForm()
 

--- a/openprescribing/openprescribing/settings/production.py
+++ b/openprescribing/openprescribing/settings/production.py
@@ -90,6 +90,11 @@ LOGGING = {
         },
     },
     'loggers': {
+        '': {
+            'level': 'ERROR',
+            'handlers': ['sentry'],
+            'propagate': True,
+        },
         'django': {
             'handlers': ['gunicorn'],
             'level': 'WARN',

--- a/openprescribing/openprescribing/settings/staging.py
+++ b/openprescribing/openprescribing/settings/staging.py
@@ -77,6 +77,11 @@ LOGGING = {
         },
     },
     'loggers': {
+        '': {
+            'level': 'ERROR',
+            'handlers': ['sentry'],
+            'propagate': True,
+        },
         'django': {
             'level': 'WARN',
             'handlers': ['gunicorn'],

--- a/openprescribing/templates/feedback.html
+++ b/openprescribing/templates/feedback.html
@@ -7,6 +7,16 @@
 {% block content %}
 <h2>Feedback</h2>
 
+{% if show_warning %}
+  <div class="alert alert-warning">
+    <span class="glyphicon glyphicon-exclamation-sign"></span>
+    Note to patients: this form sends feedback to the OpenPrescribing team at
+    Oxford.  If you are trying to contact your practice please
+    <a href="https://www.nhs.uk/service-search/GP/LocationSearch/4">click here</a>
+    to search for them.
+  </div>
+{% endif %}
+
 <form method="post" role="form">
   {% csrf_token %}
   {{ form.non_field_errors }}


### PR DESCRIPTION
Closes a security vulnerability (more from OCD than genuine operational risk) and configures logging to alert us to `error` events via Sentry (which should be useful more generally).

Depends on #1155 