### PR TITLE
Fix the incorrect dates listed in API documentation

### DIFF
--- a/openprescribing/templates/api.html
+++ b/openprescribing/templates/api.html
@@ -28,7 +28,7 @@
 
 <h3>Spending by code</h3>
 
-<p>Queries from August 2010 to date and returns total spending and items by month.</p>
+<p>Queries the last five years of data and returns total spending and items by month.</p>
 
 <p>Total prescribing spending by month: <code><a href="/api/1.0/spending/">/api/1.0/spending</a></code></p>
 
@@ -36,7 +36,7 @@
 
 <h3>Spending by CCG</h3>
 
-<p>Queries from April 2013 to date and returns spending and items by CCG by month.</p>
+<p>Queries the last five years of data and returns spending and items by CCG by month.</p>
 
 <p>Spending by CCG on a chemical: <code><a href="/api/1.0/spending_by_ccg/?code=0212000AA">/api/1.0/spending_by_ccg/?code=0212000AA</a></code></p>
 
@@ -44,7 +44,7 @@
 
 <h3>Spending by practice</h3>
 
-<p>Queries from August 2010 to date and returns total spending and items by practice by month.</p>
+<p>Queries the last five years of data and returns total spending and items by practice by month.</p>
 
 <p>You must specify either an organisation, or a date.</p>
 


### PR DESCRIPTION
We can just say "last five years" rather than giving precise dates.

Closes #1165