### PR TITLE
Redirect CCG/practice homepage requests with "tags" query

### DIFF
--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -488,6 +488,13 @@ class TestFrontendViews(TestCase):
         practices = doc('#practices li')
         self.assertEqual(len(practices), 2)
 
+    def test_ccg_homepage_redirects_with_tags_query(self):
+        response = self.client.get('/ccg/03V/?tags=lowpriority')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            '/ccg/03V/measures/?tags=lowpriority')
+
     def test_call_single_measure_for_ccg(self):
         response = self.client.get('/measure/cerazette/ccg/03V/')
         self.assertEqual(response.status_code, 200)
@@ -516,6 +523,13 @@ class TestFrontendViews(TestCase):
             ('Address: ST.ANDREWS MEDICAL CENTRE, 30 RUSSELL STREET '
              'ECCLES, MANCHESTER, M30 0NU'))
         lead = doc('.lead:last')
+
+    def test_practice_homepage_redirects_with_tags_query(self):
+        response = self.client.get('/practice/P87629/?tags=lowpriority')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            '/practice/P87629/measures/?tags=lowpriority')
 
     def test_call_single_measure_for_practice(self):
         response = self.client.get('/measure/cerazette/practice/P87629/')

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -18,9 +18,6 @@ urlpatterns = [
         name="faq"),
     url(r'^long_term_trends/$', TemplateView.as_view(template_name='long_term_trends.html'),
         name="long_term_trends"),
-    url(r'^pca/$',
-        RedirectView.as_view(permanent=True,
-                             pattern_name='long_term_trends')),
     url(r'^price-per-unit-faq/$', TemplateView.as_view(
         template_name='price_per_unit_faq.html'),
         name="price_per_unit_faq"),
@@ -112,7 +109,6 @@ urlpatterns = [
         frontend_views.gdoc_view,
         name='docs'),
 
-
     # Other files.
     url(r'^robots\.txt/$', TemplateView.as_view(template_name='robots.txt',
                                                 content_type='text/plain')),
@@ -141,10 +137,12 @@ urlpatterns = [
     # anymail webhooks
     url(r'^anymail/', include('anymail.urls')),
 
-    # old page redirects
+    # Redirects
+    url(r'^pca/$',
+        RedirectView.as_view(permanent=True,
+                             pattern_name='long_term_trends')),
     url(r'^caution/$', RedirectView.as_view(
         pattern_name='faq', permanent=True)),
-
     # Wrong URL got published
     url(r'^measures/$', RedirectView.as_view(
         pattern_name='all_measures', permanent=True)),

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -87,10 +87,6 @@ urlpatterns = [
         '(?P<bnf_code>[A-Z\d]+)/price_per_unit/$',
         frontend_views.price_per_unit_by_presentation,
         name='price_per_unit_by_presentation'),
-    url(r'^ccg/(?P<ccg_code>[A-Z\d]+)/measures/$',
-        RedirectView.as_view(permanent=True,
-                             pattern_name='measures_for_one_ccg'),
-        name='ccg'),
     url(r'^ccg/(?P<ccg_code>[A-Z\d]+)/(?P<measure>[A-Za-z\d_]+)/$',
         frontend_views.measure_for_practices_in_ccg,
         name='measure_for_practices_in_ccg'),
@@ -148,10 +144,6 @@ urlpatterns = [
     # old page redirects
     url(r'^caution/$', RedirectView.as_view(
         pattern_name='faq', permanent=True)),
-    url(r'^practice/(?P<code>[A-Z\d]+)/measures/$',
-        RedirectView.as_view(
-            permanent=True, pattern_name='measures_for_one_practice'),
-        name='practice'),
 
     # Wrong URL got published
     url(r'^measures/$', RedirectView.as_view(


### PR DESCRIPTION
When the homepages used to show a list of all measures these URLs would
show that list filtered by the selected tags. Now that we only show two
selected measures the URLs don't work as expected. We can fix the
internal links but there are external ones which we don't control and so
it makes sense to set up redirects to handle this.

Closes #1182