### PR TITLE
Use psycopg2 binary installation

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,7 @@ openpyxl==2.3.3
 pandas-gbq==0.3.1
 pandas==0.20.2
 premailer==3.0.1
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 python-dateutil==2.6.1
 pytz==2016.7
 raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ pip-tools==2.0.2
 pre-commit==1.10.5
 premailer==3.0.1
 protobuf==3.4.0           # via google-api-core, googleapis-common-protos
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 pyasn1-modules==0.2.1     # via google-auth, oauth2client
 pyasn1==0.4.2             # via oauth2client, paramiko, pyasn1-modules, rsa
 pycodestyle==2.4.0        # via flake8


### PR DESCRIPTION
This is what we're doing currently, but unless we change the package
name we'll have to compile from source once we upgrade to v2.8.

This change is being made because the binary installation can cause
problems under certain circumstances. But this doesn't seem to have
affected us so we're just going to stick to the status quo for now.

For more information see:
http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/

Closes #1183