### PR TITLE
Fix issue caused by duplicate practice names

### DIFF
--- a/openprescribing/media/js/src/analyse-bar-chart.js
+++ b/openprescribing/media/js/src/analyse-bar-chart.js
@@ -68,7 +68,7 @@ var barChart = {
   },
 
   _getCategoriesFromSeries: function (series) {
-    return series.data.map(function(d) { return d.name; });
+    return series.data.map(function(d) { return d.name + ' (' + d.id + ')'; });
   },
 
   update: function(chart, month, ratio, title, formatter, playing, yAxisMax) {


### PR DESCRIPTION
These caused the Analyse bar charts to break because Highcharts assumes
category names are unique. The simple solution (as suggested by
@HelenCEBM) is just to make the names unique by appending their ID
codes. In general the names are long enough that they're truncated on
display anyway so this makes zero visual difference to the chart.

Closes #1119