### PR TITLE
Update requirements.txt with new transitive requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,13 @@ cffi==1.11.5              # via bcrypt, cryptography, pynacl
 cfgv==1.1.0               # via pre-commit
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
+configparser==3.5.0       # via flake8
+contextlib2==0.5.5        # via raven
 coverage==4.5.1
 cryptography==2.3.1       # via paramiko, pyopenssl, requests
 cssselect==1.0.1          # via premailer, pyquery
 cssutils==1.0.2           # via premailer
 decorator==4.1.2          # via networkx
-defusedxml==0.5.0         # via python3-openid
 diff-match-patch==20121119  # via django-import-export
 django-allauth==0.25.2
 django-anymail[mailgun]==2.2
@@ -42,6 +43,8 @@ et-xmlfile==1.0.1         # via openpyxl
 fabric==1.13.1
 first==2.0.1              # via pip-tools
 flake8==3.6.0
+funcsigs==1.0.2           # via mock
+futures==3.2.0            # via google-api-core, requests-futures
 google-api-core==0.1.4    # via google-cloud-bigquery, google-cloud-core, google-cloud-storage
 google-api-python-client==1.6.2
 google-auth-oauthlib==0.2.0  # via pandas-gbq
@@ -57,6 +60,7 @@ html2text==2016.9.19
 httplib2==0.10.3          # via google-api-python-client, oauth2client
 identify==1.1.4           # via pre-commit
 idna==2.6                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography
 jdcal==1.3                # via openpyxl
 lxml==3.6.4
 mailchimp3==2.0.18
@@ -89,7 +93,7 @@ pynacl==1.2.1             # via paramiko
 pyopenssl==18.0.0         # via requests
 pyquery==1.4.0
 python-dateutil==2.6.1
-python3-openid==3.1.0     # via django-allauth
+python-openid==2.2.5      # via django-allauth
 pytz==2016.7
 pyvirtualdisplay==0.2.1
 pyyaml==3.13              # via aspy.yaml, pre-commit, tablib, watchdog
@@ -105,6 +109,7 @@ tablib==0.12.1            # via django-import-export
 titlecase==0.8.2
 toml==0.9.4               # via pre-commit
 tqdm==4.14.0
+typing==3.6.6             # via django-extensions
 unicodecsv==0.14.1        # via tablib
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.22             # via requests, selenium


### PR DESCRIPTION
Dependabot has made various changes to versions in requirements.txt, but
has not updated transitive requirements.  As such, there are
dependencies that are missing from requirements.txt.

This means that an environment set up with pip-sync is incomplete.
(pip-sync is part of pip-tools, and makes an environment match
requirements.txt exactly.)

This PR fixes that, with the updated requirements.txt generated by
running pip-compile.

This is something we'll have to be aware of as Dependabot keeps itself
busy.