### PR TITLE
Fix NewRelic integration

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -40,6 +40,11 @@ echo "REPO_ROOT: $REPO_ROOT"
 echo "APPS_ROOT: $APPS_ROOT"
 echo "PYTHONPATH: $PYTHONPATH"
 
+# Environment variables that are set in the "environment" file but
+# need to be marked for export otherwise they won't be passed into
+# child processes
+export NEW_RELIC_LICENSE_KEY
+
 # Source environment file
 source "$REPO_ROOT/environment"
 


### PR DESCRIPTION
The root issue here is that sourcing the "environment" file is not
sufficient for setting the environment because the variables it defines
are not marked for export and so won't get passed down to child
processes. The reason that this mostly works at the moment is that the
file at "/etc/profile.d/openprescribing.sh" already marks for export
most of the variables we're interested in (it doesn't matter what values
it gives them, just that they get exported). However one omission is the
NEW_RELIC_LICENSE_KEY variable, so NewRelic doesn't work anymore.

We should fix this issue more comprehensively at some point, but this is
the minimum change that gets NewRelic working again.

Due to an unfortunate series of events this has caused us to exhaust our
quota of log events on Sentry. Specifically what happened was:

 * At some point the way we handled environment variables changed and
   NewRelic stopped working.

 * NewRelic started logging errors, but we didn't notice.

 * I deployed a thing to post errors logged in Python to Sentry so the
   NewRelic errors started getting sent there.

 * Ordinarily this would have generated error emails to us, but the
   tech@ebmdatalab.net address was broken at that time.

 * By the time we the email address was working again Sentry believed it
   had already notified us of the issue and so didn't send anymore
   alerts.

 * By the time I logged into Sentry to check something else we had
   already exhausted our event quota for the month.

This isn't a disaster -- we can live without Sentry for a couple of
weeks -- but the chain of events seems worth recording, if only for
comedy value.