### PR TITLE
Revert "Fix issue caused by duplicate practice names"

### DIFF
--- a/openprescribing/media/js/src/analyse-bar-chart.js
+++ b/openprescribing/media/js/src/analyse-bar-chart.js
@@ -68,7 +68,7 @@ var barChart = {
   },
 
   _getCategoriesFromSeries: function (series) {
-    return series.data.map(function(d) { return d.name + ' (' + d.id + ')'; });
+    return series.data.map(function(d) { return d.name; });
   },
 
   update: function(chart, month, ratio, title, formatter, playing, yAxisMax) {


### PR DESCRIPTION
This turns out to cause other issues (see #1201) which are more serious
than the issue this was intended to fix and which don't have an
immediately obvious fix.

This reverts commit 85fed67f455166179f60defbb67d20ab2d8199fa.