### PR TITLE
Allow longer lines in PEP8 linter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 88


### PR DESCRIPTION
According to CodeClimate, we do this via a "pep8" section in a setup.cfg
file:
https://docs.codeclimate.com/docs/pep8