### PR TITLE
Use explicit "aggregate" flag rather than guesswork

### DIFF
--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -383,7 +383,7 @@ var utils = {
     } else {
       orgId = options.orgId;
     }
-    var isAggregateEntity = ( ! orgId);
+    var isAggregateEntity = options.aggregate;
     if (options.orgType == 'practice') {
       oneEntityUrl = '/measure/' + measureId + '/practice/' + orgId + '/';
       tagsFocusUrl = '/practice/' + orgId + '/measures/?tags=' + d.tagsFocus;
@@ -461,7 +461,7 @@ var utils = {
       options, chartOptions);
     hcOptions.series = [];
     hcOptions.series.push({
-      name: (options.orgId) ? ('This ' + options.orgType) : options.orgName,
+      name: ( ! options.aggregate) ? ('This ' + options.orgType) : options.orgName,
       isNationalSeries: false,
       showTooltip: true,
       data: d.data,


### PR DESCRIPTION
In older versions of the code there wasn't an explict flag to say that
the current chart represented an aggregation of CCGs (as on the All
England page) rather than a single CCG/practice. But now there is and we
should use it as the previous approach caused bugs, for example with
legend labels.

Closes #1199