### PR TITLE
Fix broken images in (some) alert emails

### DIFF
--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -680,18 +680,31 @@ class OrgBookmark(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     approved = models.BooleanField(default=False)
 
-    def dashboard_url(self):
-        """The 'home page' for this bookmark
-
+    def dashboard_url(self, measure=None):
+        """The 'home page' for a measure for this bookmark, or for all
+        measures if none is specified
         """
         if self.practice is None:
-            return reverse(
-                'measures_for_one_ccg',
-                kwargs={'ccg_code': self.pct.code})
+            kwargs = {
+                'ccg_code': self.pct.code
+            }
+            if measure:
+                view = 'measure_for_one_ccg'
+                kwargs['measure'] = measure
+            else:
+                view = 'measures_for_one_ccg'
         else:
-            return reverse(
-                'measures_for_one_practice',
-                kwargs={'code': self.practice.code})
+            kwargs = {}
+            if measure:
+                view = 'measure_for_one_practice'
+                kwargs['practice_code'] = self.practice.code
+                kwargs['measure'] = measure
+            else:
+                kwargs['code'] = self.practice.code
+                view = 'measures_for_one_practice'
+        return reverse(
+            view,
+            kwargs=kwargs)
 
     @property
     def name(self):

--- a/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
@@ -139,7 +139,9 @@ class FailingEmailTestCase(TestCase):
 
     def test_successful_sends(self, attach_image, finder):
         attach_image.side_effect = [Exception, None, None]
-        test_context = _makeContext(worst=[MagicMock()])
+        measure = MagicMock()
+        measure.id = 'measureid'
+        test_context = _makeContext(worst=[measure])
         self.assertEqual(EmailMessage.objects.count(), 1)
         with self.assertRaises(BatchedEmailErrors):
             call_mocked_command(test_context, finder, max_errors=4)
@@ -149,13 +151,17 @@ class FailingEmailTestCase(TestCase):
     def test_bad_alert_image_error_not_sent_and_not_raised(
             self, attach_image, finder):
         attach_image.side_effect = BadAlertIimageError
-        test_context = _makeContext(worst=[MagicMock()])
+        measure = MagicMock()
+        measure.id = 'measureid'
+        test_context = _makeContext(worst=[measure])
         call_mocked_command(test_context, finder, max_errors=0)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_max_errors(self, attach_image, finder):
         attach_image.side_effect = [Exception, None, None]
-        test_context = _makeContext(worst=[MagicMock()])
+        measure = MagicMock()
+        measure.id = 'measureid'
+        test_context = _makeContext(worst=[measure])
         self.assertEqual(EmailMessage.objects.count(), 1)
         with self.assertRaises(BatchedEmailErrors):
             call_mocked_command(test_context, finder, max_errors=0)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -649,24 +649,26 @@ def make_org_email(org_bookmark, stats, preview=False, tag=None):
         most_changing = stats['most_changing']
         getting_worse_img = still_bad_img = interesting_img = None
         if most_changing['declines']:
+            measure_id = most_changing['declines'][0]['measure'].id
             getting_worse_img = attach_image(
                 msg,
-                org_bookmark.dashboard_url(),
+                org_bookmark.dashboard_url(measure_id),
                 getting_worse_file.name,
-                get_chart_id(most_changing['declines'][0]['measure'].id)
-            )
+                get_chart_id(measure_id))
         if stats['worst']:
+            measure_id = stats['worst'][0].id
             still_bad_img = attach_image(
                 msg,
-                org_bookmark.dashboard_url(),
+                org_bookmark.dashboard_url(measure_id),
                 still_bad_file.name,
-                get_chart_id(stats['worst'][0].id))
+                get_chart_id(measure_id))
         if stats['interesting']:
+            measure_id = stats['interesting'][0].id
             interesting_img = attach_image(
                 msg,
-                org_bookmark.dashboard_url(),
+                org_bookmark.dashboard_url(measure_id),
                 interesting_file.name,
-                get_chart_id(stats['interesting'][0].id))
+                get_chart_id(measure_id))
         unsubscribe_link = settings.GRAB_HOST + reverse(
             'bookmark-login',
             kwargs={'key': org_bookmark.user.profile.key})

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -37,8 +37,8 @@
           </div>
           <div class="panel-body" class="row">
               <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-                <p class="measure-description">{{{ description }}}</p>
                 <div id="{{ chartId }}-with-title">
+                  <p class="measure-description">{{{ description }}}</p>
                   <div id="{{ chartId }}">
                     <div class="status"></div>
                   </div>


### PR DESCRIPTION
This works around the fact that measures "below the fold" on the full measures page were not being rendered before being screenshotted (despite there being code supposedly to handle that).

It also makes the whole process much faster and less resource-intensive.

As a bonus, move the chart description so it appears in the alerts.

Fixes #1087