### PR TITLE
Revert "Configure Sentry to alert on ERROR level log events"

### DIFF
--- a/openprescribing/openprescribing/settings/production.py
+++ b/openprescribing/openprescribing/settings/production.py
@@ -90,11 +90,6 @@ LOGGING = {
         },
     },
     'loggers': {
-        '': {
-            'level': 'ERROR',
-            'handlers': ['sentry'],
-            'propagate': True,
-        },
         'django': {
             'handlers': ['gunicorn'],
             'level': 'WARN',

--- a/openprescribing/openprescribing/settings/staging.py
+++ b/openprescribing/openprescribing/settings/staging.py
@@ -77,11 +77,6 @@ LOGGING = {
         },
     },
     'loggers': {
-        '': {
-            'level': 'ERROR',
-            'handlers': ['sentry'],
-            'propagate': True,
-        },
         'django': {
             'level': 'WARN',
             'handlers': ['gunicorn'],


### PR DESCRIPTION
This reverts commit a5ee184f85ad02807022c933a101a3b8d677a808.

Exceptions are still logged to Sentry as before; it's just explicit
calls to `logger.error` which are no longer sent there. The original
idea was that this would give us a way to alert ourselves to issues that
were worth knowing about without having to return a 500. However due to
reasons unknown this causes all log messages of level WARNING and above
to be sent to Sentry, which is unacceptably noisy (every 404 is a
warning).

A some stage we should sort out our logging config, for which there are
some helpful posts here:
https://lincolnloop.com/blog/django-logging-right-way/
https://lincolnloop.com/blog/disabling-error-emails-django/

Fixes #1192