### PR TITLE
Tweaks and fixes to the price concessions dashboard

### DIFF
--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.db.models import Max
 
 from dateutil.relativedelta import relativedelta
+from dateutil.parser import parse as parse_date
 
 from frontend.models import Prescription
 from dmd.models import NCSOConcession, TariffPrice
@@ -61,7 +62,8 @@ class TestSpendingViews(TestCase):
             # https://docs.python.org/3/library/unittest.html#subtests
             # with self.subTest(entity=entity, entity_type=entity_type):
             self.validate_ncso_spending_for_entity(
-                entity, entity_type, len(self.months)
+                entity, entity_type, len(self.months),
+                current_month=parse_date(self.months[-1]).date()
             )
             self.validate_ncso_spending_breakdown_for_entity(
                 entity, entity_type, self.months[0]
@@ -108,7 +110,8 @@ class TestSpendingViews(TestCase):
 ##############################################################################
 
 
-def recalculate_ncso_spending_for_entity(entity, entity_type, num_months):
+def recalculate_ncso_spending_for_entity(entity, entity_type, num_months,
+                                         current_month=None):
     prescriptions = get_prescriptions_for_entity(entity, entity_type)
     last_prescribing_date = get_last_prescribing_date()
     quantities = aggregate_quantities_by_date_and_bnf_code(prescriptions)
@@ -120,13 +123,16 @@ def recalculate_ncso_spending_for_entity(entity, entity_type, num_months):
     concessions = calculate_costs_for_concessions(concessions)
     results = []
     for row in aggregate_by_date(concessions):
-        results.append({
+        result = {
             'month': row['date'],
             'tariff_cost': round(row['tariff_cost'], 5),
             'additional_cost': round(row['additional_cost'], 5),
             'is_estimate': row['is_estimate'],
             'last_prescribing_date': last_prescribing_date
-        })
+        }
+        if current_month is not None:
+            result['is_incomplete_month'] = result['month'] >= current_month
+        results.append(result)
     results.sort(key=lambda row: row['month'])
     return results
 

--- a/openprescribing/media/js/src/spending-chart.js
+++ b/openprescribing/media/js/src/spending-chart.js
@@ -31,7 +31,8 @@ $(function() {
       date: parseDate(row.month),
       tariffCost: row.tariff_cost,
       addCost: row.additional_cost,
-      isEstimate: row.is_estimate
+      isEstimate: row.is_estimate,
+      isIncomplete: row.is_incomplete_month
     };
     point.x = point.date;
     point.y = point[valueKey];
@@ -49,7 +50,12 @@ $(function() {
 
   var additionalCosts = data.map(function(row) { return rowToPoint(row, 'addCost'); });
   var actualCosts = additionalCosts.filter(function(point) { return ! point.isEstimate; });
-  var estimatedCosts = additionalCosts.filter(function(point) { return point.isEstimate; });
+  var estimatedCosts = additionalCosts.filter(function(point) {
+    return point.isEstimate && ! point.isIncomplete;
+  });
+  var incompleteCosts = additionalCosts.filter(function(point) {
+    return point.isEstimate && point.isIncomplete;
+  });
 
   options.title.text = 'Additional cost of price concessions';
   options.chart.type = 'column';
@@ -58,7 +64,7 @@ $(function() {
   options.legend.align = 'right';
   options.legend.verticalAlign = 'bottom';
   options.legend.x = 0;
-  options.legend.y = 0;
+  options.legend.y = 6;
   options.legend.itemMarginBottom = 4;
   options.plotOptions.series = {stacking: 'normal'};
   options.yAxis.title = {enabled: true, text: 'Cost (£)'};
@@ -70,12 +76,13 @@ $(function() {
     formatter: function() {
       var template =
         '<strong>{date}</strong><br>' +
-        '<strong>£{value}</strong> {estimated} additional cost<br>' +
+        '<strong>£{value}</strong> {estimated} additional cost{incomplete}<br>' +
         '<a href="?breakdown_date={date_param}">View cost breakdown &rarr;</a>';
       var params = {
         '{date}': Highcharts.dateFormat('%B %Y', this.x),
         '{value}': Highcharts.numberFormat(this.y, 0),
-        '{estimated}': this.point.isEstimate ? 'estimated' : '',
+        '{estimated}': this.point.isEstimate ? 'projected' : '',
+        '{incomplete}': this.point.isIncomplete ? '<br>based on concessions so far this month' : '',
         '{date_param}': Highcharts.dateFormat('%Y-%m-%d', this.x)
       };
       return template.replace(/{.+?}/g, function(param) {
@@ -87,7 +94,11 @@ $(function() {
   };
   options.series = [
     {name: 'Estimated cost', data: actualCosts, color: 'rgba(0, 0, 255, .8)'},
-    {name: 'Projected cost', data: estimatedCosts, color: 'rgba(255, 0, 0, .8)'}
+    {name: 'Projected cost', data: estimatedCosts, color: 'rgba(255, 0, 0, .8)'},
+    {
+      name: 'Projected cost (basd on concessions so far this month)',
+      data: incompleteCosts,
+      color: 'rgba(255, 128, 0, .8)'}
   ];
   var chart = Highcharts.chart('monthly-totals-chart', options);
 });

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -122,16 +122,16 @@
         <p>
           See the full breakdown of this estimate, and view costs for other months on
           the <a href="{% url spending_for_one_entity_url entity.code %}">
-            price concessions dashboard
-          </a>.
+            price concessions dashboard.
+          </a>
         </p>
       {% else %}
         <p>
           We don't have current data for the impact of price concessions on
           {{ entity.cased_name }}. For historical data see the
           <a href="{% url spending_for_one_entity_url entity.code %}">
-            price concessions dashboard
-          </a>.
+            price concessions dashboard.
+          </a>
         </p>
       {% endif %}
     </div>

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -10,9 +10,9 @@
 
 <p>
   Price concessions are a short term agreement by the NHS to pay for more
-  expensive versions of a medicine because the cheaper version has temporarily
-  gone out-of-stock. This dashboard tracks the additional costs these
-  concessions create.
+  expensive versions of a generic medicine because pharmacists are unable to
+  obtain the generic at its usual price. This dashboard tracks the additional
+  costs these concessions create.
 </p>
 <p>
   Standard prices are updated monthly from

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -20,6 +20,14 @@
   concession data is updated daily from
   <a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">PSNC</a>.
 </p>
+<p>
+  Over the last 12 months we estimate that price concessions have cost
+  {{ entity_name }} an additional<br>
+  <strong>£{{ rolling_annual_total|sigfigs:5|floatformat:"0"|intcomma }}</strong>
+  (of which
+  <strong>£{{ financial_ytd_total|sigfigs:5|floatformat:"0"|intcomma }}</strong>
+  is in the current financial year)
+</p>
 
 <div id="monthly-totals-chart"></div>
 

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -43,6 +43,11 @@
     These are projected costs, produced by combining drug tariff and price
     concession data for {{ breakdown_date|date:"F Y" }} with the latest available
     prescribing data for {{ last_prescribing_date|date:"F Y" }}.
+    {% if breakdown_is_incomplete_month %}
+      Note that as the full set of price concessions for
+      {{ breakdown_date|date:"F" }} has not yet been released, costs for this
+      month may well rise further.
+    {% endif %}
     <br><br>
   {% endif %}
   Actual costs are estimated from the Net Ingredient Cost by applying a national average discount of

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -18,9 +18,11 @@
 
   <p>
     The Drug Tariff is the "NHS primary care price list" for thousands of the
-    most commonly-prescribed drugs, and is updated monthly. Sometimes medicines
-    go out-of-stock, and a "price concession" is given so that pharmacists having
-    to buy more expensive versions are not out of pocket.
+    most commonly-prescribed drugs, and is updated monthly. Sometimes there are
+    difficulties in obtaining a medicine at its usual price (e.g. due to supply
+    problems or currency exchange rates) and a "price concession" is given so
+    that pharmacists having to buy more expensive versions are not out of
+    pocket.
   </p>
   <p>
     Our data goes back to March 2010. Drug Tariff data


### PR DESCRIPTION
This addresses most of the issues raised in #1284 (the larger ones have been split out into separate tickets).

Closes #1284 

## Screenshots

The changes to flag the latest month as incomplete look like this (note the text change in the alert as well as the legend):
![localhost_8000_practice_g85724_concessions__breakdown_date 2018-12-01](https://user-images.githubusercontent.com/19630/50235690-62e7da00-03b0-11e9-89bf-d10f06501aa1.png)

The financial YTD and 12-month totals look like this:
![ytd_totals](https://user-images.githubusercontent.com/19630/50235721-7abf5e00-03b0-11e9-9b91-85361dd577e4.png)



