### PR TITLE
Fix minor bug in date selector on IE

### DIFF
--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -35,7 +35,7 @@
 
 <form class="form pull-right" action="">
   <select name="breakdown_date" class="form-control js-submit-on-change">
-    <option>Change date</option>
+    <option value="">Change date</option>
     {% for date in available_dates %}
       <option value="{{ date|date:"Y-m-d" }}">{{ date|date:"F Y" }}</option>
     {% endfor %}


### PR DESCRIPTION
If we don't supply a value, IE uses the option label as a value which
then triggers an "invalid date" error.