### PR TITLE
Don't trigger error if we have no NCSO data

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -659,6 +659,10 @@ def spending_for_one_entity(request, entity_code, entity_type):
         num_months=12,
         current_month=_get_current_month()
     )
+    # In the very rare cases where we don't have data we just return a 404
+    # rather than triggering an error
+    if not monthly_totals:
+        raise Http404('No data available')
     end_date = max(row['month'] for row in monthly_totals)
     last_prescribing_date = monthly_totals[-1]['last_prescribing_date']
     rolling_annual_total = sum(row['additional_cost'] for row in monthly_totals)


### PR DESCRIPTION
Where we don't have NCSO spending data for an entity (e.g.
https://openprescribing.net/practice/B82099/) it's better to return a
404 than a 500 which triggers a Sentry alert. Better still would be an
informative error page saying that there's no data, but that seems more
effort than it's worth for this edge case.