### PR TITLE
Add a temporary hack to block bots from NCSO pages

### DIFF
--- a/openprescribing/frontend/templatetags/template_extras.py
+++ b/openprescribing/frontend/templatetags/template_extras.py
@@ -71,7 +71,10 @@ def sigfigs(value, figures=3):
     """
     if not value:
         value = 0
-    order = int(math.floor(math.log10(math.fabs(value))))
+    if value != 0:
+        order = int(math.floor(math.log10(math.fabs(value))))
+    else:
+        order = 1
     places = figures - order - 1
     format_string = '{:.%df}' % max(0, places)
     return format_string.format(round(value, places))

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1,5 +1,6 @@
 import datetime
 from lxml import html
+import re
 from requests.exceptions import HTTPError
 from urllib import urlencode
 from urlparse import urlparse, urlunparse
@@ -653,6 +654,11 @@ def mailchimp_subscribe(
 ##################################################
 
 def spending_for_one_entity(request, entity_code, entity_type):
+    # Temporary hack as this page is very expensive to render and brings the
+    # site to its knees when bots decide to crawl us (most other pages do the
+    # expensive data loading via JS and so don't have this issue)
+    if _user_is_bot(request):
+        raise Http404()
     entity = _get_entity(entity_type, entity_code)
     monthly_totals = ncso_spending_for_entity(
         entity, entity_type,
@@ -705,6 +711,14 @@ def spending_for_one_entity(request, entity_code, entity_type):
         'national_average_discount_percentage': NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE
     }
     return render(request, 'spending_for_one_entity.html', context)
+
+
+def _user_is_bot(request):
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    # Despite appearances this is actually a fairly robust way of detecting bots
+    # See: https://webmasters.stackexchange.com/a/64805
+    match = re.search('(bot|crawl|spider)', user_agent.lower())
+    return bool(match)
 
 
 def _get_current_month():


### PR DESCRIPTION
For most of our pages the expensive data loading is done in an API call
triggered by JS. This has the side effect that crawling the site puts
very little load on the server. The NCSO pages are an exception as they
embed their data and this makes them very expensive to crawl to the
extent that it's causing a significant slowdown on the site.

This patch blocks all bots from loading these pages while we figure out
a better solution.