### PR TITLE
Use ImportLog to determine latest prescribing date

### DIFF
--- a/openprescribing/frontend/tests/data_factory.py
+++ b/openprescribing/frontend/tests/data_factory.py
@@ -7,7 +7,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil.parser import parse as parse_date
 
 from frontend.models import (
-    Practice, PCT, Prescription, Presentation
+    ImportLog, Practice, PCT, Prescription, Presentation
 )
 from dmd.models import (
     DMDProduct, DMDVmpp, NCSOConcession, TariffPrice, TariffCategory
@@ -99,6 +99,7 @@ class DataFactory(object):
 
     def create_prescribing(self, practice, presentations, months):
         for date in months:
+            self.create_import_log(date)
             for i, presentation in enumerate(presentations):
                 Prescription.objects.create(
                     processing_date=date,
@@ -109,6 +110,12 @@ class DataFactory(object):
                     total_items=0,
                     actual_cost=0,
                 )
+
+    def create_import_log(self, date):
+        ImportLog.objects.create(
+            current_at=date,
+            category='prescribing'
+        )
 
     def populate_presentation_summary_by_ccg_view(self):
         with connection.cursor() as cursor:

--- a/openprescribing/frontend/views/spending_utils.py
+++ b/openprescribing/frontend/views/spending_utils.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from api.view_utils import dictfetchall
 from dmd.models import NCSOConcession
+from frontend.models import ImportLog
 
 
 # The tariff (or concession) price is not what actually gets paid as each CCG
@@ -229,10 +230,9 @@ def _ncso_spending_query(
           )
         """
     sql = sql_template.format(prescribing_table=prescribing_table)
-    with connection.cursor() as cursor:
-        cursor.execute(
-            'SELECT MAX(processing_date) FROM {}'.format(prescribing_table))
-        last_prescribing_date = cursor.fetchone()[0]
+    last_prescribing_date = (
+        ImportLog.objects.latest_in_category('prescribing').current_at
+    )
     params = {
         'last_prescribing_date': last_prescribing_date,
         'start_date': start_date,


### PR DESCRIPTION
This is what we do elsewhere in the system and, because there is no
index on the month column in at least one of the prescribing "view"
tables, querying for the max date is very slow.