### PR TITLE
Upgrade Sentry JS client

### DIFF
--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -51,7 +51,7 @@
     }
   },
   "dependencies": {
-    "@sentry/browser": "^4.0.5",
+    "@sentry/browser": "^4.5.1",
     "bigtext": "^1.0.1",
     "bootstrap": "^3.3.4",
     "chroma-js": "^1.2",


### PR DESCRIPTION
This will, among other things, mean that we won't get spammed with
ReportingObserver notifications from Chrome extensions.