### PR TITLE
Catch correct exception in MailChimp client

### DIFF
--- a/openprescribing/frontend/tests/test_mailchimp_utils.py
+++ b/openprescribing/frontend/tests/test_mailchimp_utils.py
@@ -1,0 +1,34 @@
+from mock import patch, Mock
+from unittest import TestCase
+
+from django.http import HttpRequest
+from mailchimp3.mailchimpclient import MailChimpError
+
+from frontend.views.mailchimp_utils import mailchimp_subscribe
+
+
+@patch('frontend.views.mailchimp_utils.MailChimp')
+class MailChimpSubscribeTests(TestCase):
+    def setUp(self):
+        request = HttpRequest()
+        request.session = {'newsletter_email': 'alice@example.com'}
+        self.args = (
+            request,
+            'alice@example.com',
+            'Alice',
+            'Apple',
+            'The Orchard',
+            'Chief Juicer',
+        )
+
+    def test_mailchimp_subscribe_with_existing_subscriber(self, MailChimp):
+        self.assertTrue(mailchimp_subscribe(*self.args))
+
+    def test_mailchimp_subscribe_with_new_subscriber(self, MailChimp):
+        MailChimp.lists.members.get = Mock(side_effect=MailChimpError())
+        self.assertTrue(mailchimp_subscribe(*self.args))
+
+    def test_mailchimp_subscribe_with_blacklisted_subscriber(self, MailChimp):
+        MailChimp.return_value.lists.members.get = Mock(side_effect=MailChimpError())
+        MailChimp.return_value.lists.members.create = Mock(side_effect=MailChimpError())
+        self.assertFalse(mailchimp_subscribe(*self.args))

--- a/openprescribing/frontend/views/mailchimp_utils.py
+++ b/openprescribing/frontend/views/mailchimp_utils.py
@@ -1,0 +1,48 @@
+import hashlib
+import logging
+
+from django.conf import settings
+from mailchimp3 import MailChimp
+from mailchimp3.mailchimpclient import MailChimpError
+
+from common.utils import get_env_setting
+
+logger = logging.getLogger(__name__)
+
+
+def mailchimp_subscribe(
+        request, email, first_name, last_name,
+        organisation, job_title):
+    """Subscribe `email` to newsletter.
+
+    Returns boolean indicating success
+    """
+    del(request.session['newsletter_email'])
+    email_hash = hashlib.md5(email).hexdigest()
+    data = {
+        'email_address': email,
+        'status': 'subscribed',
+        'merge_fields': {
+            'FNAME': first_name,
+            'LNAME': last_name,
+            'MMERGE3': organisation,
+            'MMERGE4': job_title
+        }
+    }
+    client = MailChimp(
+        mc_user=get_env_setting('MAILCHIMP_USER'),
+        mc_api=get_env_setting('MAILCHIMP_API_KEY'))
+    try:
+        client.lists.members.get(
+            list_id=settings.MAILCHIMP_LIST_ID,
+            subscriber_hash=email_hash)
+        return True
+    except MailChimpError:
+        try:
+            client.lists.members.create(
+                list_id=settings.MAILCHIMP_LIST_ID, data=data)
+            return True
+        except MailChimpError:
+            # things like blacklisted emails, etc
+            logger.warn("Unable to subscribe %s to newsletter", email)
+            return False


### PR DESCRIPTION
This wouldn't have caught the exception class changing when the
dependency was updated (we'd need something like VCR for that) but this
code was untested and now it's not!