### PR TITLE
Remove performance summary from All England page

### DIFF
--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -427,6 +427,9 @@ class MeasuresTests(SeleniumTestCase):
         perf_element = self.find_by_xpath("//*[@id='measure_core_0']//strong[text()='Performance:']/..")
         exp_text = u'Performance: If all CCGs in England had prescribed in line with the median, the NHS would have spent £{} less over the past 6 months. If they had prescribed in line with the best 10%, it would have spent £{} less.'.format(_humanize(cost_saving_50), _humanize(cost_saving_10))
         self.assertEqual(perf_element.text, exp_text)
+        # The performance summary should be hidden for All England
+        perf_summary_element = self.find_by_xpath("//*[@id='perfsummary']")
+        self.assertEqual(perf_summary_element.text.strip(), '')
 
     def test_explanation_for_practice(self):
         # This test verifies that the explanation for a practice's performance

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -180,7 +180,7 @@ var utils = {
           }
         }
       });
-      if (options.rollUpBy === 'measure_id') {
+      if (options.rollUpBy === 'measure_id' && ! options.aggregate) {
         perf.costSavings = 'Over the past ' + numMonths + ' months, if this ';
         perf.costSavings += options.orgType;
         perf.costSavings += ' had prescribed at the median ratio or better ' +


### PR DESCRIPTION
The text as it is doesn't make any sense, and is in any case redundant
given the headline figures we have above.

Fixes #1331