### PR TITLE
Remove deprecated flag

### DIFF
--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -43,7 +43,6 @@
   pip:
     virtualenv: "{{ virtualenv_path }}"
     requirements: "{{ requirements_path }}"
-    extra_args: --process-dependency-links
 
 - name: Install jshint and less
   become: yes


### PR DESCRIPTION
There's no audit trail of why this was used in the first place.

Closes ebmdatalab/sysadmin#41