### PR TITLE
Fix race condition when sorting by savings

### DIFF
--- a/openprescribing/media/js/src/measures.js
+++ b/openprescribing/media/js/src/measures.js
@@ -170,13 +170,13 @@ var measures = {
   setUpSortGraphs: function() {
     var _this = this;
     var chartsByPercentile = $(_this.el.chart);
-    var chartsBySaving = $(chartsByPercentile).filter(function(a) {
-      return $(this).data('costsaving') !== 0;
+    var nonCostSavingCharts = $(chartsByPercentile).filter(function(a) {
+      return ! $(this).data('costsaving');
     });
-    chartsBySaving.sort(function(a, b) {
+    chartsBySaving = $(_this.el.chart).sort(function(a, b) {
       return $(b).data('costsaving') - $(a).data('costsaving');
     });
-    if (chartsBySaving.length === 0) {
+    if (nonCostSavingCharts.length === chartsByPercentile.length) {
       chartsBySaving = chartsBySaving.add(
         $(_this.el.noCostSavingWarning).clone().removeClass('hidden')
       );
@@ -185,10 +185,12 @@ var measures = {
       $(this).addClass('active').siblings().removeClass('active');
       if ($(this).data('orderby') === 'savings') {
         $(_this.el.charts).fadeOut(function() {
+          nonCostSavingCharts.hide();
           $(_this.el.charts).html(chartsBySaving).fadeIn();
         });
       } else {
         $(_this.el.charts).fadeOut(function() {
+          nonCostSavingCharts.show();
           $(_this.el.charts).html(chartsByPercentile).fadeIn();
         });
       }


### PR DESCRIPTION
If a user hit the "sort by potential savings" button before Highcharts
had finished rendering the charts then the non-cost-saving measure
charts would get removed from the DOM and then Highcharts would attempt
to render to a non-existing element and throw an error.

We fix this by keeping all charts in the DOM and just hiding them when
needed.