### PR TITLE
Add direct links to measure charts

### DIFF
--- a/openprescribing/media/css/dashboard.less
+++ b/openprescribing/media/css/dashboard.less
@@ -57,6 +57,10 @@
     white-space: nowrap;
     overflow: hidden;
 
+    .panel-heading {
+      white-space: normal;
+    }
+
     .panel-body {
         padding: 5px;
         .inner, .measure-description {

--- a/openprescribing/media/js/src/global.js
+++ b/openprescribing/media/js/src/global.js
@@ -45,4 +45,31 @@ domready(function() {
     $elementsToHide.css('display', 'none');
     $button.appendTo($container);
   });
+
+  // We have to attach the listener to the chart container, rather than to the
+  // individual links, because at this point the charts and their links may not
+  // exist
+  $('#charts').on('click', '.js-shareable-link', function() {
+    var $link   = $(this);
+    var $input = $link.siblings('input');
+    $input.val($link.prop('href'));
+    $input.one('blur', function() {
+      $input.tooltip('destroy');
+      $input.hide();
+      $link.show();
+    });
+    $link.hide();
+    $input.show();
+    $input.select();
+    var copied = false;
+    try {
+      document.execCommand('copy');
+      copied = true;
+    } catch(err) {}
+    if (copied) {
+      $input.tooltip({trigger: 'manual', title: 'Copied to clipboard'});
+      $input.tooltip('show');
+    }
+    return false;
+  });
 });

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -28,6 +28,10 @@
     <div id="measure_{{ chartId }}" class="col-xs-12 col-sm-12 col-md-12 col-lg-12 chart" data-id="{{ chartId }}" data-costsaving="{{ costSaving50th }}">
       <div class="panel panel-info">
         <div class="panel-heading">
+          <span class="pull-right">
+            <a class="js-shareable-link" href="#{{ chartId }}"><span class="glyphicon glyphicon-link"></span> Link to chart</a>
+            <input type="text" class="form-control input-sm" readonly style="display: none; margin-top: -6px; right: -10px; position: relative; background-color: #fff;">
+          </span>
           {{# if chartTitleUrl }}
             <a href="{{ chartTitleUrl }}">{{ chartTitle }}</a>
           {{else}}

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -29,7 +29,9 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <span class="pull-right">
-            <a class="js-shareable-link" href="#{{ chartId }}"><span class="glyphicon glyphicon-link"></span> Link to chart</a>
+            <a class="js-shareable-link" href="{{# if oneEntityUrl }}{{ oneEntityUrl }}{{else}}#{{ chartId }}{{/if}}">
+              <span class="glyphicon glyphicon-link"></span> Link to chart
+            </a>
             <input type="text" class="form-control input-sm" readonly style="display: none; margin-top: -6px; right: -10px; position: relative; background-color: #fff;">
           </span>
           {{# if chartTitleUrl }}


### PR DESCRIPTION
We already supported this, but there was no easy way to find out the
correct link for a given chart. This patch adds the link into the panel
heading for each chart and, as an extra usability feature, clicking the
link temporarily replaces it with a text input with the link text
already selected and copies it to the clipboard (where the browser
supports that).

Closes #1227

Screenshot before clicking:
![192 168 1 127_8000_ccg_02n_measures__tags eye 2](https://user-images.githubusercontent.com/19630/51608942-c2d22300-1f10-11e9-8d6b-89a99a202dd4.png)

Screenshot after clicking:
![192 168 1 127_8000_ccg_02n_measures__tags eye 1](https://user-images.githubusercontent.com/19630/51608952-c8c80400-1f10-11e9-8038-151d3f125915.png)