### PR TITLE
New ghost-generics measure

### DIFF
--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -1,15 +1,15 @@
 {
   "name": "Ghost-branded generic excess spend",
   "title": [
-    "Ghost-generic excess spend as a percentage of all generic spending"
+    "Ghost-branded generic excess spend as a percentage of all generic spending"
   ],
   "description": [
-    "Ghost-branded generics are items when the prescription incorrectly includes a manufacturer name, leading to unecessary excess cost.   <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
+    "Excess spend on ghost-branded generics (<a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>more info</a>) as a percentage of all spending on generics"
   ],
   "why_it_matters": [
     "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. "
   ],
-  "numerator_short": "Ghost-generic excess spending",
+  "numerator_short": "Ghost-branded generic excess spending",
   "denominator_short": "All generic spending",
   "url": null,
   "is_percentage": true,

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -23,7 +23,7 @@
   ],
   "numerator_from": "{measures}.vw__ghost_generic_measure p",
   "numerator_where": [
-    "(possible_savings >= 5 OR possible_savings <=-5)"
+    "(possible_savings >= 2 OR possible_savings <=-2)"
   ],
   "denominator_columns": [
     "SUM(net_cost) AS denominator, "

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -23,7 +23,7 @@
   ],
   "numerator_from": "{measures}.vw__ghost_generic_measure p",
   "numerator_where": [
-    "1 = 1"
+    "(possible_savings >= 5 OR possible_savings <=-5)"
   ],
   "denominator_columns": [
     "SUM(net_cost) AS denominator, "

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -1,13 +1,13 @@
 {
-  "name": "Ghost-generic excess spend",
+  "name": "Ghost-branded generic excess spend",
   "title": [
     "Ghost-generic excess spend as a percentage of all generic spending"
   ],
   "description": [
-    "Ghost-branded generics are generic items which have unintentionally been prescribed with a manufacturer name. For example, Naratriptan 2.5mg Tablets is the correct generic name; a ghost-branded version is Naratriptan 2.5mg Tablets (Teva UK Limited). A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page.  <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
+    "Ghost-branded generics are items when the prescription incorrectly includes a manufacturer name, leading to unecessary excess cost.   <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
   ],
   "why_it_matters": [
-    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive."
+    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. "
   ],
   "numerator_short": "Ghost-generic excess spending",
   "denominator_short": "All generic spending",
@@ -16,7 +16,7 @@
   "is_cost_based": false,
   "low_is_good": true,
   "tags": [
-    "cost"
+    "cost", "core"
   ],
   "numerator_columns": [
     "SUM(possible_savings) AS numerator, "

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -4,7 +4,7 @@
     "Ghost-generic excess spend as a percentage of all generic spending"
   ],
   "description": [
-    "Ghost-branded generics are generic items which have unintentionally been prescribed with a manufacturer name. For example, Naratriptan 2.5mg Tablets is the correct generic name; a ghost-branded version is Naratriptan 2.5mg Tablets (Teva UK Limited). A breakdown of which products have bee prescribed in this way is linked to from every CCG and Practice dashboard page.  <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
+    "Ghost-branded generics are generic items which have unintentionally been prescribed with a manufacturer name. For example, Naratriptan 2.5mg Tablets is the correct generic name; a ghost-branded version is Naratriptan 2.5mg Tablets (Teva UK Limited). A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page.  <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
   ],
   "why_it_matters": [
     "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive."

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -1,0 +1,35 @@
+{
+  "name": "Ghost-generic excess spend",
+  "title": [
+    "Ghost-generic excess spend as a percentage of all generic spending"
+  ],
+  "description": [
+    "Ghost-branded generics are generic items which have unintentionally been prescribed with a manufacturer name. For example, Naratriptan 2.5mg Tablets is the correct generic name; a ghost-branded version is Naratriptan 2.5mg Tablets (Teva UK Limited). A breakdown of which products have bee prescribed in this way is linked to from every CCG and Practice dashboard page.  <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>Read more on our blog</a>."
+  ],
+  "why_it_matters": [
+    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive."
+  ],
+  "numerator_short": "Ghost-generic excess spending",
+  "denominator_short": "All generic spending",
+  "url": null,
+  "is_percentage": true,
+  "is_cost_based": false,
+  "low_is_good": true,
+  "tags": [
+    "cost"
+  ],
+  "numerator_columns": [
+    "SUM(possible_savings) AS numerator, "
+  ],
+  "numerator_from": "{measures}.vw__ghost_generic_measure p",
+  "numerator_where": [
+    "1 = 1"
+  ],
+  "denominator_columns": [
+    "SUM(net_cost) AS denominator, "
+  ],
+  "denominator_from": "{measures}.vw__ghost_generic_measure p",
+  "denominator_where": [
+    "1 = 1"
+  ]
+}

--- a/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
+++ b/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
@@ -60,6 +60,4 @@ ON
 WHERE
   -- lantanaprost quantities are broken in data
   rx.bnf_code <> '1106000L0AAAAAA'
-  -- discount trivial savings / costs
-  AND ( net_cost - (ROUND(dt.median_price_per_unit, 4) * rx.quantity) >= 5
-    OR net_cost - (ROUND(dt.median_price_per_unit, 4) * rx.quantity) <= -5)
+  -- trivial savings / costs are discounted in the measure definition

--- a/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
+++ b/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
@@ -7,9 +7,9 @@ WITH
     DISTINCT date,
     product
   FROM
-    ebmdatalab.dmd.tariffprice dt
+    {project}.{dmd}.tariffprice dt
   INNER JOIN
-    ebmdatalab.dmd.vmpp vmpp
+    {project}.{dmd}.vmpp vmpp
   ON
     dt.vmpp = vmpp.vppid
   GROUP BY
@@ -27,9 +27,9 @@ WITH
     product.bnf_code,
     dt.median_price_per_unit
   FROM
-    `ebmdatalab.measures.vw__median_price_per_unit` dt
+    `{project}.{measures}.vw__median_price_per_unit` dt
   INNER JOIN
-    `ebmdatalab.dmd.product` product
+    `{project}.{dmd}.product` product
   ON
     product.bnf_code = dt.bnf_code
   INNER JOIN
@@ -53,7 +53,7 @@ SELECT
 FROM
   dt_prices dt
 JOIN
-  ebmdatalab.hscic.normalised_prescribing_standard rx
+  {project}.{hscic}.normalised_prescribing_standard rx
 ON
   rx.month = dt.date
   AND rx.bnf_code = dt.bnf_code

--- a/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
+++ b/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
@@ -1,0 +1,65 @@
+WITH
+  single_ppu_dt AS (
+  -- skips anything in the DT with more than one PPU (e.g. different
+  -- per-pill prices for 7 and 28 pill packs), as we can't distinguish
+  -- these in the dispensing data
+  SELECT
+    DISTINCT date,
+    product
+  FROM
+    ebmdatalab.dmd.tariffprice dt
+  INNER JOIN
+    ebmdatalab.dmd.vmpp vmpp
+  ON
+    dt.vmpp = vmpp.vppid
+  GROUP BY
+    product,
+    date
+  HAVING
+    STDDEV(price_pence/qtyval) = 0
+    OR STDDEV(price_pence/qtyval) IS NULL),
+  dt_prices AS (
+  -- median prices for things in the Drug Tariff and not with multiple PPUs.
+  -- We use median prices because the DT prices for the reimbursement
+  -- month are not necessarily the ones used for reimbursements
+  SELECT
+    DISTINCT dt.date,
+    product.bnf_code,
+    dt.median_price_per_unit
+  FROM
+    `ebmdatalab.measures.vw__median_price_per_unit` dt
+  INNER JOIN
+    `ebmdatalab.dmd.product` product
+  ON
+    product.bnf_code = dt.bnf_code
+  INNER JOIN
+    single_ppu_dt
+  ON
+    dt.date= single_ppu_dt.date
+    AND single_ppu_dt.product = product.dmdid)
+-- now calculate possible savings against the median price
+SELECT
+  dt.date AS month,
+  practice,
+  --dt.median_price_per_unit,
+  --CASE
+  --  WHEN rx.quantity > 0 THEN ROUND((rx.net_cost / rx.quantity), 4)
+  --  ELSE 0
+  --END AS price_per_unit,
+  --rx.quantity,
+  rx.bnf_code,
+  net_cost,
+  net_cost - (ROUND(dt.median_price_per_unit, 4) * rx.quantity) AS possible_savings
+FROM
+  dt_prices dt
+JOIN
+  ebmdatalab.hscic.normalised_prescribing_standard rx
+ON
+  rx.month = dt.date
+  AND rx.bnf_code = dt.bnf_code
+WHERE
+  -- lantanaprost quantities are broken in data
+  rx.bnf_code <> '1106000L0AAAAAA'
+  -- discount trivial savings / costs
+  AND ( net_cost - (ROUND(dt.median_price_per_unit, 4) * rx.quantity) >= 5
+    OR net_cost - (ROUND(dt.median_price_per_unit, 4) * rx.quantity) <= -5)

--- a/openprescribing/pipeline/management/commands/create_bq_measure_views.py
+++ b/openprescribing/pipeline/management/commands/create_bq_measure_views.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
             'practice_data_all_low_priority',
             'pregabalin_total_mg',
             'vw__median_price_per_unit',
+            'vw__ghost_generic_measure',
         ]:
             path = os.path.join(base_path, table_name + '.sql')
             with open(path, "r") as sql_file:

--- a/openprescribing/templates/ghost_generics.html
+++ b/openprescribing/templates/ghost_generics.html
@@ -12,7 +12,7 @@
 <div class="row">
   <div class="col-md-7">
     <p>
-      <strong>Ghost-branded generics</strong> are generic items which have unintentionally been prescribed with a manufacturer name. For example, <em>Naratriptan 2.5mg Tablets</em> is the correct generic name; a ghost-branded version is <em>Naratriptan 2.5mg Tablets (Teva UK Limited)</em>. When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. <a href="/faq#ghostgenerics">Read more in our FAQ</a>.</p>
+      <strong>Ghost-branded generics</strong> are generic items which have unintentionally been prescribed with a manufacturer name. For example, <em>Naratriptan 2.5mg Tablets</em> is the correct generic name; a ghost-branded version is <em>Naratriptan 2.5mg Tablets (Teva UK Limited)</em>. When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. <a href="/faq#ghostgenerics">Read more in our FAQ</a>, or <a href="../ghost_generic_measure/">view change over time</a>.</p>
 
     <p>This is a list of all generic items where the price paid has differed significantly from the Drug Tariff price. We estimate <strong>{{entity_name }} could have saved at least £<span id="total-savings"></span> in {{ date|date:"F Y"}} by avoiding ghost-branded generics.</strong></p>
     </p>


### PR DESCRIPTION
Unusually, the id has `_measure` appened. This is to avoid clashing
with the ghost-generics dashboard URL.

Closes #1363 