### PR TITLE
Last-minute GBG improvements

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -316,38 +316,30 @@ def ghost_generics(request, format=None):
     else:
         assert False, "Not implemented for {}".format(entity)
     sql = """
-        SELECT dt.date,
-          practice.code AS practice_id,
-          practice.ccg_id AS pct,
-          dt.median_ppu,
-          CASE
-            WHEN rx.quantity > 0
-            THEN round((rx.net_cost / rx.quantity)::numeric, 4)
-            ELSE 0
-          END AS price_per_unit,
-          rx.quantity,
-          rx.presentation_code AS bnf_code,
-          product.name AS product_name,
-            net_cost - (round(dt.median_ppu::numeric, 4) * rx.quantity)
-            AS possible_savings
-          FROM vw__medians_for_tariff dt
-            JOIN dmd_product product ON dt.product_id = product.dmdid
-            JOIN frontend_prescription rx
-              ON rx.processing_date = dt.date
-              AND rx.presentation_code = product.bnf_code
-            JOIN frontend_practice practice
-              ON practice.code = rx.practice_id
-        WHERE date = %(date)s {extra_conditions}
-        AND
-          -- lantanaprost quantities are broken in data
-          rx.presentation_code <> '1106000L0AAAAAA'
-        AND (
-         net_cost - (round(dt.median_ppu::numeric, 4) * rx.quantity)
-           >= {min_delta}
-        OR
-         net_cost - (round(dt.median_ppu::numeric, 4) * rx.quantity)
-           <= -{min_delta})
-        ORDER BY possible_savings DESC
+       WITH savings AS (
+         SELECT dt.date,
+            practice.code AS practice_id,
+            practice.ccg_id AS pct,
+            dt.median_ppu,
+                CASE
+                    WHEN rx.quantity > 0::double precision THEN round((rx.net_cost / rx.quantity)::numeric, 4)
+                    ELSE 0
+                END AS price_per_unit,
+            rx.quantity,
+            rx.presentation_code AS bnf_code,
+            product.name AS product_name,
+            rx.net_cost - round(dt.median_ppu::numeric, 4)::double precision * rx.quantity AS possible_savings
+           FROM vw__medians_for_tariff dt
+             JOIN dmd_product product ON dt.product_id = product.dmdid
+             JOIN frontend_prescription rx ON rx.processing_date = dt.date AND rx.presentation_code = product.bnf_code
+             JOIN frontend_practice practice ON practice.code = rx.practice_id
+          WHERE rx.processing_date = %(date)s {extra_conditions}
+        )
+        SELECT *
+          FROM savings s
+         WHERE s.bnf_code::text <> '1106000L0AAAAAA'
+         AND (s.possible_savings >= {min_delta} OR s.possible_savings <= -{min_delta})
+               ORDER BY possible_savings DESC
     """.format(
         min_delta=MIN_GHOST_GENERIC_DELTA,
         extra_conditions=extra_conditions

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -4,10 +4,10 @@
     "Ghost-branded generic excess spend as a percentage of all generic spending"
   ],
   "description": [
-    "Excess spend on ghost-branded generics (<a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>more info</a>) as a percentage of all spending on generics"
+    "Excess spend on ghost-branded generics (<a href='/faq/#ghostgenerics'>more info</a>) as a percentage of all spending on generics"
   ],
   "why_it_matters": [
-    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. Read more on <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>our blog info</a>)"
+    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. Read more in <a href='/faq/#ghostgenerics'>our FAQ</a> and <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>our blog</a>."
   ],
   "numerator_short": "Ghost-branded generic excess spending",
   "denominator_short": "All generic spending",

--- a/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/frontend/management/commands/measure_definitions/ghost_generic_measure.json
@@ -7,7 +7,7 @@
     "Excess spend on ghost-branded generics (<a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>more info</a>) as a percentage of all spending on generics"
   ],
   "why_it_matters": [
-    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. "
+    "When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive. A list of products which have been prescribed as ghost-generics is available on every CCG and Practice dashboard page. Read more on <a href='https://ebmdatalab.net/ghost-branded-generics-a-new-dashboard-on-openprescribing/'>our blog info</a>)"
   ],
   "numerator_short": "Ghost-branded generic excess spending",
   "denominator_short": "All generic spending",
@@ -16,7 +16,7 @@
   "is_cost_based": false,
   "low_is_good": true,
   "tags": [
-    "cost", "core"
+    "cost", "core", "generic"
   ],
   "numerator_columns": [
     "SUM(possible_savings) AS numerator, "

--- a/openprescribing/templates/_ghost_generics_data_table.html
+++ b/openprescribing/templates/_ghost_generics_data_table.html
@@ -5,7 +5,7 @@
         Presentation
       </th>
       <th>
-        Possible savings <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Possible savings" data-content="The total amount we estimate {{ entity.cased_name}} could save in a month by switching from ghost generics"><span class="glyphicon glyphicon-question-sign"></span></a>
+        Possible savings <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Possible savings" data-content="The total amount we estimate {{ entity.cased_name}} could save in a month by switching from ghost generics. A negative number indicates a saving which has been made by using ghost generics."><span class="glyphicon glyphicon-question-sign"></span></a>
       </th>
       <th>
         PPU <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Price per Unit" data-content="Mean price-per-unit paid by {{ entity.cased_name}}"><span class="glyphicon glyphicon-question-sign"></span></a>

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -163,9 +163,10 @@
     <div class="landing-panel">
       <h3>Ghost-branded generics</h3>
       <strong>New</strong>: many practices are mistakenly prescribing generics as if they are brands.
+      See a list of generics that may be affected
+      <a href="{% url entity_ghost_generics_url entity.code %}">here</a>.
       <span id="ghost-total-text" class="invisible">
         {{ entity.cased_name }} <span id="ghost-total"></span>.
-        See a list of generics that may be affected <a href="{% url entity_ghost_generics_url entity.code %}">here</a>.
       </span>
     </div>
   </div>


### PR DESCRIPTION
The headline statistics on the dashboards for ghost-branded generics take many seconds to load, and users don't get to follow a link to the GBG breakdown until its loaded. Therefore, this PR mitigates some of the SQL slowness, and allows people to click through in the absence of the JSON loading.

Also tweaks to the measure wording and tags. 