### PR TITLE
Prevent duplicate import warnings from being displayed

### DIFF
--- a/openprescribing/pipeline/middleware.py
+++ b/openprescribing/pipeline/middleware.py
@@ -2,17 +2,32 @@ from django.contrib import messages
 from pipeline.runner import in_progress
 
 
+IMPORT_WARNING_TAG = 'import_warning'
+
+
 def import_warning_middleware(get_response):
     def middleware(request):
-        if in_progress() and not request.path.startswith('/api/'):
-            # If we add a message to an API request, then depending on whether
-            # the API requests get made in parallel, Django can end up updating
-            # the cookie multiple times, causing the message to be displayed
-            # multiple times.
+        if _should_add_import_warning(request):
             msg = 'We are currently importing the latest prescribing data.  You may see incomplete data across the site.  Please check back in a couple of hours!'
-            messages.add_message(request, messages.WARNING, msg)
+            messages.add_message(request, messages.WARNING, msg, extra_tags=IMPORT_WARNING_TAG)
 
         response = get_response(request)
 
         return response
     return middleware
+
+
+def _should_add_import_warning(request):
+    if not in_progress():
+        return False
+    # If we add a message to an API request, then depending on whether the API
+    # requests get made in parallel, Django can end up updating the cookie
+    # multiple times, causing the message to be displayed multiple times.
+    if request.path.startswith('/api/'):
+        return False
+    storage = messages.get_messages(request)
+    warning_added = any(msg.extra_tags == IMPORT_WARNING_TAG for msg in storage)
+    # This is the documented way to access messages without marking them as
+    # displayed
+    storage.used = False
+    return not warning_added

--- a/openprescribing/pipeline/tests/test_middleware.py
+++ b/openprescribing/pipeline/tests/test_middleware.py
@@ -13,3 +13,8 @@ class TestImportWarningMiddleware(TestCase):
         TaskLog.objects.create(year=2017, month=7, task_name='fetch_and_import')
         response = self.client.get('/')
         self.assertNotContains(response, "We are currently importing")
+
+    def test_no_duplicate_warning_on_redirect(self):
+        TaskLog.objects.create(year=2017, month=7, task_name='task1')
+        response = self.client.get('/caution/', follow=True)
+        self.assertEqual(response.content.count("We are currently importing"), 1)


### PR DESCRIPTION
When a request is redirected the middleware would add an extra warning
message for each hop of the redirect, which could sometimes be three or
more.