### PR TITLE
Use more friendly name for alerts "from" address

### DIFF
--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -617,7 +617,7 @@ def make_email_with_campaign(bookmark, campaign_source):
     msg = EmailMultiAlternatives(
         truncate_subject(subject_prefix, bookmark.name),
         "This email is only available in HTML",
-        settings.SUPPORT_FROM_EMAIL,
+        settings.DEFAULT_FROM_EMAIL,
         [bookmark.user.email])
     metadata = {"subject": msg.subject,
                 "campaign_name": campaign_name,


### PR DESCRIPTION
Somehow in the rejigging of various email related settings issue #1023
has recurred and our alerts appear to come from "feedback" rather than
"OpenPrescribing"