### PR TITLE
Change wording on confirmation emails to be less false

### DIFF
--- a/openprescribing/templates/account/email/email_confirmation_signup_message.html
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.html
@@ -1,11 +1,11 @@
 {% load account %}
 <p>Hello from OpenPrescribing!</p>
 
-<p>You're receiving this e-mail because someone has requested monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
+<p>You've been subscribed to monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
 
-<p>To confirm this is correct, please follow <a href="{{ activate_url }}">this link</a>.</p>
+<p>Please confirm your email address by following <a href="{{ activate_url }}">this link</a>.</p>
 
-<p>If that wasn't you, just ignore this email.</p>
+<p>You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.</p>
 
 <p>Thanks,</p>
 

--- a/openprescribing/templates/account/email/email_confirmation_signup_message.txt
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.txt
@@ -1,10 +1,11 @@
 {% load account %}{% autoescape off %}Hello from OpenPrescribing!
 
-You're receiving this e-mail because someone has requested monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.
+You've been subscribed to monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.
 
-To confirm this is correct, go to {{ activate_url }}
+Please confirm your email address by visiting {{ activate_url }}
 
-If that wasn't you, just ignore this email.
+You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.
+
 {% endautoescape %}
 
 Thanks,

--- a/openprescribing/templates/account/email/email_confirmation_subject.txt
+++ b/openprescribing/templates/account/email/email_confirmation_subject.txt
@@ -1,1 +1,1 @@
-Please confirm your alert subscription
+Your OpenPrescribing alert subscription


### PR DESCRIPTION
We stil send confirmation emails even though we don't now require
verification before sending alerts (because if we turn them off
altogether than anyone can view and edit anyone else's alerts just by
entering their email address). But the wording in our confirmation
emails needs to be tweaked so we don't say that you can ignore the email
if you don't want alerts.