### PR TITLE
Temporarily disable play button

### DIFF
--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -137,7 +137,8 @@
     <!-- Time slider and items toggle -->
     <div id="chart-options">
         <div id="chart-options-wrapper">
-          <div id="play-slider" alt="Animate time series" class="glyphicon glyphicon-play-circle"></div>
+          {# Play button temporarily disabled until we fix issue #1368 #}
+          {#<div id="play-slider" alt="Animate time series" class="glyphicon glyphicon-play-circle"></div>#}
           <div id="slider-wrapper"><div id="chart-date-slider"></div></div>
           <div id="items-spending-toggle" class="btn-group btn-toggle" aria-label="Show spending or items on graph">
                 <button class="btn btn-default btn-sm" data-type="actual_cost">spending</button>


### PR DESCRIPTION
This is currently broken (see issue #1368) and by general agreement it's
better to just not display it at all.