### PR TITLE
Fix bug in error handler for ajax requests

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -794,16 +794,16 @@ def feedback_view(request):
 ##################################################
 def custom_500(request):
     type_, value, traceback = sys.exc_info()
-    context = {}
+    reason = 'Server error'
     if 'canceling statement due to statement timeout' in unicode(value):
-        context['reason'] = ("The database took too long to respond.  If you "
-                             "were running an analysis with multiple codes, "
-                             "try again with fewer.")
-    if (request.META.get('HTTP_ACCEPT', '').find('application/json') > -1 or
-       request.is_ajax()):
-        return HttpResponse(context['reason'], status=500)
+        reason = (
+            "The database took too long to respond.  If you were running an"
+            "analysis with multiple codes, try again with fewer."
+        )
+    if request.is_ajax() or 'application/json' in request.META.get('HTTP_ACCEPT', ''):
+        return HttpResponse(reason, status=500)
     else:
-        return render(request, '500.html', context, status=500)
+        return render(request, '500.html', {'reason': reason}, status=500)
 
 
 # This view deliberately triggers an error

--- a/openprescribing/templates/500.html
+++ b/openprescribing/templates/500.html
@@ -14,6 +14,10 @@
   <p class="well">{{ reason }}<p>
 {% endif %}
 
-<p>If you continue to have problems, please contact us at <a href="mailto:{{ SUPPORT_TO_EMAIL }}" class="feedback-show">{{ SUPPORT_TO_EMAIL }}</a>.</p>
+<p>
+  Our team should have been automatically notified of this error, but if you
+  continue to have problems, please contact us at
+  <a href="mailto:{{ SUPPORT_TO_EMAIL }}" class="feedback-show">{{ SUPPORT_TO_EMAIL }}</a>.
+</p>
 
 {% endblock %}


### PR DESCRIPTION
Previously an ajax request which triggered a 500 which wasn't a database
error would result in a KeyError, which made for confusing error alerts.

Also tweak the wording of the error page slightly.