### PR TITLE
Tweaks to single measure page

### DIFF
--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -181,15 +181,17 @@ var utils = {
         }
       });
       if (options.rollUpBy === 'measure_id' && ! options.aggregate) {
-        perf.costSavings = 'Over the past ' + numMonths + ' months, if this ';
-        perf.costSavings += options.orgType;
-        perf.costSavings += ' had prescribed at the median ratio or better ' +
-          'on all cost-saving measures below, then it would have spent £' +
-          humanize.numberFormat(potentialSavings50th, 0) +
-          ' less. (We use the national median as a suggested ' +
-          'target because by definition, 50% of practices were already ' +
-          'prescribing at this level or better, so we think it ought ' +
-          'to be achievable.)';
+        if (potentialSavings50th > 0) {
+          perf.costSavings = 'Over the past ' + numMonths + ' months, if this ';
+          perf.costSavings += options.orgType;
+          perf.costSavings += ' had prescribed at the median ratio or better ' +
+            'on all cost-saving measures below, then it would have spent £' +
+            humanize.numberFormat(potentialSavings50th, 0) +
+            ' less. (We use the national median as a suggested ' +
+            'target because by definition, 50% of practices were already ' +
+            'prescribing at this level or better, so we think it ought ' +
+            'to be achievable.)';
+        }
       } else if (options.isCostBasedMeasure) {
         perf.costSavings = 'Over the past ' + numMonths + ' months, if all ';
         perf.costSavings += options.orgType;

--- a/openprescribing/templates/measure_for_one_entity.html
+++ b/openprescribing/templates/measure_for_one_entity.html
@@ -10,18 +10,22 @@
 {% endblock extra_css %}
 
 {% block content %}
-  <h1>{{ entity.name }}: {{ measure.name }}</h2>
+  <h1>
+    {{ measure.name }}
+    <br><small>{{ entity.name }}</small>
+  </h1>
+  <p>
+    <a href="{% url measures_url_name entity.code %}" class="btn btn-default">
+      View all measures for this {{ entity_type }} &rarr;
+    </a>
+  </p>
 
   <p>This measure shows how this organisation compares with its peers across NHS England. This is indicative only, and should be approached with caution. <a href='{% url 'faq' %}#measureinterpret'>Read more about measures</a>.</p>
 
   {% include '_measures_heading.html' with entity_type=entity_type %}
   {% include '_measures_panel.html' %}
 
-  <p>
-    <a href="{% url measures_url_name entity.code %}">View all measures for {{ entity.name }}</a>
-  </p>
-
-  <hr/>
+  <hr>
 
   {% if measure.numerator_can_be_queried %}
 

--- a/openprescribing/templates/measure_for_one_entity.html
+++ b/openprescribing/templates/measure_for_one_entity.html
@@ -11,6 +11,18 @@
 
 {% block content %}
   <h1>{{ entity.name }}: {{ measure.name }}</h2>
+
+  <p>This measure shows how this organisation compares with its peers across NHS England. This is indicative only, and should be approached with caution. <a href='{% url 'faq' %}#measureinterpret'>Read more about measures</a>.</p>
+
+  {% include '_measures_heading.html' with entity_type=entity_type %}
+  {% include '_measures_panel.html' %}
+
+  <p>
+    <a href="{% url measures_url_name entity.code %}">View all measures for {{ entity.name }}</a>
+  </p>
+
+  <hr/>
+
   <h2>Presentations contributing to variation</h2>
 
   <p>In the quarter ending {{ current_at|date:"M Y" }}, the numerator in this measure was composed of the following presentations:</p>
@@ -37,17 +49,6 @@
   <a class="btn btn-primary" href="{% url 'measure_numerators_by_org' %}?org={{ entity.code }}&measure={{ measure.id }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
 
   <hr>
-
-  <p>This measure shows how this organisation compares with its peers across NHS England. This is indicative only, and should be approached with caution. <a href='{% url 'faq' %}#measureinterpret'>Read more about measures</a>.</p>
-
-  {% include '_measures_heading.html' with entity_type=entity_type %}
-  {% include '_measures_panel.html' %}
-
-  <p>
-    <a href="{% url measures_url_name entity.code %}">View all measures for {{ entity.name }}</a>
-  </p>
-
-  <hr/>
 
   {% include '_get_in_touch.html' %}
 {% endblock %}

--- a/openprescribing/templates/measure_for_one_entity.html
+++ b/openprescribing/templates/measure_for_one_entity.html
@@ -23,32 +23,36 @@
 
   <hr/>
 
-  <h2>Presentations contributing to variation</h2>
+  {% if measure.numerator_can_be_queried %}
 
-  <p>In the quarter ending {{ current_at|date:"M Y" }}, the numerator in this measure was composed of the following presentations:</p>
+    <h2>Presentations contributing to variation</h2>
 
-  <table id="numerator_breakdown" class="table">
-    <thead>
-      <tr>
-        <th>Presentation</th>
-        <th>Items</th>
-        <th>Quantity</th>
-        <th>Cost</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th>Loading...</th>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
+    <p>In the quarter ending {{ current_at|date:"M Y" }}, the numerator in this measure was composed of the following presentations:</p>
 
-  <a class="btn btn-primary" href="{% url 'measure_numerators_by_org' %}?org={{ entity.code }}&measure={{ measure.id }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
+    <table id="numerator_breakdown" class="table">
+      <thead>
+        <tr>
+          <th>Presentation</th>
+          <th>Items</th>
+          <th>Quantity</th>
+          <th>Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>Loading...</th>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
 
-  <hr>
+    <a class="btn btn-primary" href="{% url 'measure_numerators_by_org' %}?org={{ entity.code }}&measure={{ measure.id }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
+
+    <hr>
+
+  {% endif %}
 
   {% include '_get_in_touch.html' %}
 {% endblock %}


### PR DESCRIPTION
This addresses the four requirements we had before we can make this a generic landing page for a single measure on a single organisation:
- "Presentations contributing to variation" should be moved below the chart- 
  That section should also be hidden for measures without the ability to show presentations
-   Make the "View all measures for X CCG" link more prominent, more like a main navigation element
-  I note a bug on that page whereby the text describing total possible savings for all measures appears - which it shouldn't

Closes #1380

Screenshot for a measure which does support numerator breakdown:
![localhost_8000_measure_lyrica_ccg_99p_](https://user-images.githubusercontent.com/19630/52014806-6c4c8200-24d8-11e9-8f3a-c8a4206839cd.png)

And screenshot for one that doesn't:
![localhost_8000_measure_bdzper1000_ccg_99p_](https://user-images.githubusercontent.com/19630/52014815-6fe00900-24d8-11e9-84a6-2948b178b383.png)
