### PR TITLE
Correctly encode user supplied name in mail From header

### DIFF
--- a/openprescribing/frontend/feedback.py
+++ b/openprescribing/frontend/feedback.py
@@ -1,3 +1,5 @@
+from email.utils import formataddr
+
 from django.conf import settings
 from django.core.mail import get_connection, EmailMultiAlternatives
 from django.template.loader import get_template
@@ -19,7 +21,7 @@ def send_feedback_mail(user_name, user_email_addr, subject, message, url):
     email = EmailMultiAlternatives(
         subject='OpenPrescribing Feedback: {}'.format(subject),
         body=body,
-        from_email='{} <{}>'.format(user_name, settings.SUPPORT_FROM_EMAIL),
+        from_email=formataddr((user_name, settings.SUPPORT_FROM_EMAIL)),
         to=[settings.SUPPORT_TO_EMAIL],
         reply_to=[user_email_addr],
         headers={'X-Mailgun-Track': 'no'},

--- a/openprescribing/frontend/tests/test_feedback.py
+++ b/openprescribing/frontend/tests/test_feedback.py
@@ -1,3 +1,4 @@
+# coding=utf8
 from django.conf import settings
 from django.core import mail
 from django.test import TestCase
@@ -62,3 +63,35 @@ This is a copy of the feedback you sent to the OpenPrescribing.net team.
             "OpenPrescribing Feedback: An apple a day...")
         self.assertEqual(email.body, expected_body)
         self.assertEqual(email.extra_headers["X-Mailgun-Track"], "no")
+
+    def test_send_feedback_mail_name_escaped(self):
+        mail.outbox = []
+
+        send_feedback_mail(
+            user_name="Alice Apple, NHS England",
+            user_email_addr="alice@example.com",
+            subject="",
+            message="",
+            url="",
+        )
+        email = mail.outbox[0]
+        self.assertEqual(
+            email.from_email,
+            '"Alice Apple, NHS England" <feedback@openprescribing.net>'
+        )
+
+    def test_send_feedback_mail_name_encoded(self):
+        mail.outbox = []
+
+        send_feedback_mail(
+            user_name=u"Alicé Apple",
+            user_email_addr="alice@example.com",
+            subject="",
+            message="",
+            url="",
+        )
+        email = mail.outbox[0]
+        self.assertEqual(
+            email.from_email,
+            u'Alicé Apple <feedback@openprescribing.net>'
+        )


### PR DESCRIPTION
This broke initially because someone put their address (containing
commas) as their name.