### PR TITLE
Update message for resend of confirmation emails

### DIFF
--- a/openprescribing/template_overrides/account/email/email_confirmation_message.html
+++ b/openprescribing/template_overrides/account/email/email_confirmation_message.html
@@ -1,11 +1,13 @@
 {% load account %}
 <p>Hello from OpenPrescribing!</p>
 
-<p>We recently found out that NHSMail has been discarding all our emails as spam.</p>
+<p>You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
 
-<p>As a result, we think that when you signed up for monthly alerts about {{ user.profile.most_recent_bookmark.topic }}, you never received an email requesting that you confirm this.</p>
+<p>However, due to a technical problem, your alerts haven't been sent.</p>
 
-<p>So, to confirm, please follow <a href="{{ activate_url }}">this link</a>.</p>
+<p>If you'd still like to receive these alerts, please click <a href="{{ activate_url }}">this link</a> to confirm.</p>
+
+<p>You can, of course, unsubscribe at any time.</p>
 
 <p>If you no longer want to receive alerts about prescribing behaviour, just ignore this email.</p>
 

--- a/openprescribing/template_overrides/account/email/email_confirmation_message.html
+++ b/openprescribing/template_overrides/account/email/email_confirmation_message.html
@@ -1,7 +1,7 @@
 {% load account %}
 <p>Hello from OpenPrescribing!</p>
 
-<p>You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
+<p>You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}. (This may have been up to two years ago!)</p>
 
 <p>However, due to a technical problem, your alerts haven't been sent.</p>
 

--- a/openprescribing/template_overrides/account/email/email_confirmation_message.txt
+++ b/openprescribing/template_overrides/account/email/email_confirmation_message.txt
@@ -1,10 +1,13 @@
 {% load account %}{% autoescape off %}Hello from OpenPrescribing!
 
-We recently found out that NHSMail has been discarding all our emails as spam.
+You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.
 
-As a result, we think that when you signed up for monthly alerts about {{ user.profile.most_recent_bookmark.topic }}, you never received an email requesting that you confirm this.
+However, due to a technical problem, your alerts haven't been sent.
 
-So, to confirm this is correct, go to {{ activate_url }}
+If you'd still like to receive these alerts, please click below to confirm:
+{{ activate_url }}
+
+You can, of course, unsubscribe at any time.
 
 If you no longer want to receive alerts about prescribing behaviour, just ignore this email.
 {% endautoescape %}

--- a/openprescribing/template_overrides/account/email/email_confirmation_message.txt
+++ b/openprescribing/template_overrides/account/email/email_confirmation_message.txt
@@ -1,6 +1,6 @@
 {% load account %}{% autoescape off %}Hello from OpenPrescribing!
 
-You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}.
+You previously signed up to receive monthly alerts about {{ user.profile.most_recent_bookmark.topic }}. (This may have been up to two years ago!)
 
 However, due to a technical problem, your alerts haven't been sent.
 

--- a/openprescribing/template_overrides/account/email/email_confirmation_subject.txt
+++ b/openprescribing/template_overrides/account/email/email_confirmation_subject.txt
@@ -1,1 +1,1 @@
-Please confirm your alert subscription
+Your subscription to email alerts from OpenPrescribing


### PR DESCRIPTION
We've now stopped requiring confirmation of email address for alerts,
but we're not applying this policy retrospectively so for existing
unconfirmed subscribers we're going to try one last message to get them
to confirm.