### PR TITLE
Fix bug when toggling spending/items after zooming

### DIFF
--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -405,6 +405,7 @@ var analyseChart = {
       $('#items-spending-toggle .btn').removeClass('btn-info').addClass('btn-default');
       $(this).addClass('btn-info').removeClass('btn-default');
       _this.globalOptions.activeOption = $(this).data('type');
+      _this.globalOptions.barChart.zoom();
       _this.updateCharts();
     });
     // select the correct view tab


### PR DESCRIPTION
Doing so would trigger a bug whereby Highcharts would attempt to render
parts of the x-axis which were not associated with any CCG and, when
attempting to generate labels for these parts of the x-axis, would cause
an error in our label formatting function.

It occurred to us when investigating this that toggling between items
and spending should reset the zoom anyway, because there's no benefit to
being left zoomed in to what is now a totally different set of CCGs in
the chart. This has the side effect of making the problem go away.