### PR TITLE
Ensure import_measure_definitions runs after create_bq_measure_views

### DIFF
--- a/openprescribing/pipeline/metadata/tasks.json
+++ b/openprescribing/pipeline/metadata/tasks.json
@@ -237,7 +237,7 @@
     "import_measure_definitions": {
         "type": "post_process",
         "command": "import_measures --definitions_only",
-        "dependencies": []
+        "dependencies": ["create_bq_measure_views"]
     },
     "create_bq_measure_views": {
         "type": "post_process",


### PR DESCRIPTION
import_measure_definitions now computes numerator_bnf_codes, which for
some measures depends on views defined in create_bq_measure_views.