### PR TITLE
Add summary totals to the Analyse page

### DIFF
--- a/openprescribing/api/views_org_codes.py
+++ b/openprescribing/api/views_org_codes.py
@@ -64,7 +64,7 @@ def _get_practices_like_code(q):
             'postcode': p.postcode,
             'setting': p.setting,
             'setting_name': None,
-            'type': 'Practice',
+            'type': 'practice',
             'ccg': None
         }
         data['setting_name'] = p.get_setting_display()

--- a/openprescribing/frontend/tests/functional/test_charts.py
+++ b/openprescribing/frontend/tests/functional/test_charts.py
@@ -65,3 +65,40 @@ class SmallListTest(SeleniumTestCase):
         xlabels = self.find_by_xpath(
             "//*[contains(@class, 'highcharts-xaxis-labels')]")
         self.assertNotIn('GREEN', xlabels.text)
+
+
+class AnalyseSummaryTotalsTest(SeleniumTestCase):
+
+    def test_summary_totals_on_analyse_page(self):
+        self.browser.get(
+            self.live_server_url +
+            '/analyse/#org=CCG&numIds=0212000AA')
+        expected = {
+            'panel-heading': (
+                u'Total prescribing for Rosuvastatin Calcium across all '
+                u'CCGs in NHS England'
+            ),
+            'js-selected-month': u"Sep '16",
+            'js-financial-year-range': u"Apr—Sep '16",
+            'js-year-range': u"Oct '15—Sep '16",
+            'js-cost-month-total': u'29,720',
+            'js-cost-financial-year-total': u'178,726',
+            'js-cost-year-total': u'379,182',
+            'js-items-month-total': u'1,669',
+            'js-items-financial-year-total': u'9,836',
+            'js-items-year-total': u'20,622',
+        }
+        for classname, value in expected.items():
+            selector = (
+                '//*[@id="{id}"]'
+                '//*[contains(concat(" ", @class, " "), " {classname} ")]'.format(
+                    id='js-summary-totals',
+                    classname=classname
+                )
+            )
+            element = self.find_by_xpath(selector)
+            self.assertTrue(
+                element.is_displayed(),
+                '.{} is not visible'.format(classname)
+            )
+            self.assertEqual(element.text.strip(), value)

--- a/openprescribing/frontend/tests/test_api_org_codes.py
+++ b/openprescribing/frontend/tests/test_api_org_codes.py
@@ -38,7 +38,7 @@ class TestAPIOrgViews(TestCase):
         self.assertEqual(len(content), 1)
         self.assertEqual(content[0]['code'], 'P87629')
         self.assertEqual(content[0]['name'], '1/ST ANDREWS MEDICAL PRACTICE')
-        self.assertEqual(content[0]['type'], 'Practice')
+        self.assertEqual(content[0]['type'], 'practice')
         self.assertEqual(content[0]['setting'], 4)
         self.assertEqual(content[0]['setting_name'], 'GP Practice')
 
@@ -104,4 +104,4 @@ class TestAPIOrgViews(TestCase):
         self.assertEqual(content[0]['type'], 'CCG')
         self.assertEqual(content[-1]['code'], 'B82018')
         self.assertEqual(content[-1]['name'], 'ESCRICK SURGERY')
-        self.assertEqual(content[-1]['type'], 'Practice')
+        self.assertEqual(content[-1]['type'], 'practice')

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -43,6 +43,7 @@ var analyseChart = {
     rowCount: ('#data-rows-count'),
     alertForm: ('#alert-form'),
     outliersToggle: ('.outliers-toggle'),
+    summaryTotals: $('#js-summary-totals'),
   },
 
   renderChart: function(globalOptions) {
@@ -54,6 +55,7 @@ var analyseChart = {
     this.globalOptions = globalOptions;
     this.el.submitButton.button('loading');
     this.el.errorContainer.hide();
+    this.el.summaryTotals.hide();
     this.el.loadingEl.show();
     this.getBackendData();
   },
@@ -203,6 +205,7 @@ var analyseChart = {
       this.setUpSaveUrl();
       this.setUpSaveUrlUI();
       this.setUpAlertSubscription();
+      this.displayTotals();
     } else {
       this.showErrorMessage(
         'No data found for this query. Please try again.', null);
@@ -526,10 +529,115 @@ var analyseChart = {
     this.updateCharts();
   },
 
+  displayTotals: function() {
+    var selectedOrgs;
+    try {
+      selectedOrgs = getOrgSelection(this.globalOptions.org, this.globalOptions.orgIds);
+    } catch(error) {
+      if (/^Unhandled selection:/.test(error)) {
+        // If we can't display a total for this particular selection just bail
+        // out and show nothing
+        return;
+      }
+      throw error;
+    }
+    var allMonths = this.globalOptions.allMonths;
+    var lastMonth = allMonths[allMonths.length - 1];
+    var twelveMonthsAgo = allMonths[allMonths.length - 12];
+    var financialYearStart = getFinancialYearStart(lastMonth);
+    var data = this.globalOptions.data.numeratorData;
+    var activeMonth = this.globalOptions.activeMonth;
+    var itemsMonthTotal = 0, itemsYearTotal = 0, itemsFinancialYearTotal = 0;
+    var costMonthTotal = 0, costYearTotal = 0, costFinancialYearTotal = 0;
+    var entry;
+    for (var i = 0; i < data.length; i++) {
+      entry = data[i];
+      if (selectedOrgs && ! selectedOrgs[entry.row_id]) continue;
+      if (entry.date === activeMonth) {
+        itemsMonthTotal += entry.items;
+        costMonthTotal += entry.actual_cost;
+      }
+      if (entry.date >= twelveMonthsAgo) {
+        itemsYearTotal += entry.items;
+        costYearTotal += entry.actual_cost;
+        if (entry.date >= financialYearStart) {
+          itemsFinancialYearTotal += entry.items;
+          costFinancialYearTotal += entry.actual_cost;
+        }
+      }
+    }
+    var el = this.el.summaryTotals;
+    el.find('.js-friendly-numerator').text(this.globalOptions.friendly.friendlyNumerator);
+    el.find('.js-orgs-description').text(getOrgsDescription(this.globalOptions.org, this.globalOptions.orgIds));
+    el.find('.js-selected-month').text(formatDate(activeMonth));
+    el.find('.js-financial-year-range').text(formatDateRange(financialYearStart, lastMonth));
+    el.find('.js-year-range').text(formatDateRange(twelveMonthsAgo, lastMonth));
+    el.find('.js-cost-month-total').text(formatNum(costMonthTotal));
+    el.find('.js-cost-year-total').text(formatNum(costYearTotal));
+    el.find('.js-cost-financial-year-total').text(formatNum(costFinancialYearTotal));
+    el.find('.js-items-month-total').text(formatNum(itemsMonthTotal));
+    el.find('.js-items-year-total').text(formatNum(itemsYearTotal));
+    el.find('.js-items-financial-year-total').text(formatNum(itemsFinancialYearTotal));
+    el.show();
+  }
+
 };
 
 function formatDate(dateStr) {
   return Highcharts.dateFormat("%b '%y", new Date(dateStr));
+}
+
+function formatNum(n) {
+  return Highcharts.numberFormat(n, 0);
+}
+
+function getFinancialYearStart(dateStr) {
+  var date = new Date(dateStr);
+  // Months are zero-indexed so 3 is April
+  var financialYear = date.getMonth() >= 3 ? date.getFullYear() : date.getFullYear() - 1;
+  var yearStart = new Date(financialYear, 3, 1);
+  return Highcharts.dateFormat('%Y-%m-%d', yearStart);
+}
+
+function formatDateRange(fromDateStr, toDateStr) {
+  var fromDate = new Date(fromDateStr);
+  var toDate = new Date(toDateStr);
+  var formatStr = (fromDate.getFullYear() === toDate.getFullYear()) ? "%b" : "%b '%y";
+  var fromDateFormatted = Highcharts.dateFormat(formatStr, fromDate);
+  var toDateFormatted = Highcharts.dateFormat("%b '%y", toDate);
+  if (fromDateStr !== toDateStr) {
+    return fromDateFormatted + '\u2014' + toDateFormatted;
+  } else {
+    // Handle the case where the start and end of the range is the same
+    return toDateFormatted;
+  }
+}
+
+function getOrgSelection(orgType, orgs) {
+  // Given the current behaviour of the Analyse form it shouldn't be possible
+  // to get practice level data without selecting some practices, and it's
+  // not obvious how we should handle this if we do
+  if (orgs.length === 0) {
+    if (orgType === 'practice') {
+      throw "Unhandled selection: all practices";
+    } else {
+      // A selection of "false" means "select everything"
+      return false;
+    }
+  }
+  var selectedOrgs= {};
+  for(var i = 0; i < orgs.length; i++) {
+    if (orgs[i].type !== orgType) {
+      throw "Unhandled selection: mixed org types";
+    }
+    selectedOrgs[orgs[i].id] = true;
+  }
+  return selectedOrgs;
+}
+
+function getOrgsDescription(orgType, orgs) {
+  if (orgs.length === 0) return 'all CCGs in NHS England';
+  return orgs.map(function(org) { return org.name; }).join(' + ');
 }
 
 module.exports = analyseChart;

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -474,9 +474,7 @@ var analyseChart = {
         stepped: true,
         format: {
           to: function(val) {
-            var d = _this.globalOptions.allMonths[val];
-            return Highcharts.dateFormat('%b \'%y',
-                                         new Date(d.replace(/-/g, '/')));
+            return formatDate(_this.globalOptions.allMonths[val]);
           },
           from: function(val) {
             return _this.globalOptions.allMonths.indexOf[val] + 1;
@@ -503,9 +501,7 @@ var analyseChart = {
         stepped: true,
         format: {
           to: function(val) {
-            var d = _this.globalOptions.allMonths[val];
-            return Highcharts.dateFormat('%b \'%y',
-                                         new Date(d.replace(/-/g, '/')));
+            return formatDate(_this.globalOptions.allMonths[val]);
           },
           from: function(val) {
             return _this.globalOptions.allMonths.indexOf[val] + 1;
@@ -531,4 +527,9 @@ var analyseChart = {
   },
 
 };
+
+function formatDate(dateStr) {
+  return Highcharts.dateFormat("%b '%y", new Date(dateStr));
+}
+
 module.exports = analyseChart;

--- a/openprescribing/media/js/src/analyse-form.js
+++ b/openprescribing/media/js/src/analyse-form.js
@@ -106,7 +106,8 @@ var queryForm = {
         $(this.el.orgHelp).text('Hint: add a CCG to see all its practices');
         $(this.el.orgHelp).fadeIn();
       } else if (this.globalOptions.org === 'CCG') {
-        $(this.el.orgHelp).fadeOut();
+        $(this.el.orgHelp).text('Hint: leave blank to see national totals');
+        $(this.el.orgHelp).fadeIn();
       }
     } else {
       $(this.el.orgHelp).fadeOut();

--- a/openprescribing/media/js/src/analyse-form.js
+++ b/openprescribing/media/js/src/analyse-form.js
@@ -212,6 +212,12 @@ var queryForm = {
           };
           item.name = d.name || d.text;
           item.text = item.name;
+          if (d.type) {
+            item.type = d.type;
+          }
+          if (d.code) {
+            item.code = d.code;
+          }
           _this.globalOptions[optionId].push(item);
         });
         _this.checkIfButtonShouldBeEnabled(_this.globalOptions);

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -208,7 +208,34 @@
       <p><a id="data-link" download="data.csv" class="btn btn-info" href="#">Download as CSV <span id="data-rows-count"></span></a> </p>
     </div>
 
-</div>
+  </div>
+
+  <div id="js-summary-totals" class="panel panel-default" style="margin-top: 18px">
+    <div class="panel-heading">
+      Total prescribing for <em class="js-friendly-numerator"></em>
+      across <span class="js-orgs-description"></span>
+    </div>
+    <table class="table">
+      <tr>
+        <th></th>
+        <th class="text-right js-selected-month"></th>
+        <th class="text-right">Financial YTD (<span class="js-financial-year-range"></span>)</th>
+        <th class="text-right">Last 12 months (<span class="js-year-range"></span>)</th>
+      </tr>
+      <tr>
+        <th>Cost (£)</th>
+        <td class="text-right js-cost-month-total"></td>
+        <td class="text-right js-cost-financial-year-total"></td>
+        <td class="text-right js-cost-year-total"></td>
+      </tr>
+      <tr>
+        <th>Items</th>
+        <td class="text-right js-items-month-total"></td>
+        <td class="text-right js-items-financial-year-total"></td>
+        <td class="text-right js-items-year-total"></td>
+      </tr>
+    </table>
+  </div>
 
 </div>
 


### PR DESCRIPTION
If no CCGs are highlighted then totals are across all of NHS England. Otherwise totals are for the selected CCGs or practices.

Results appear in a table below the chart like so:
![localhost_8000_analyse_](https://user-images.githubusercontent.com/19630/53164578-6f62fb80-35c8-11e9-8527-49b01485ceb4.png)

Closes #1019 and #1500