### PR TITLE
Use hashed names to reference static assets

### DIFF
--- a/openprescribing/frontend/templatetags/template_extras.py
+++ b/openprescribing/frontend/templatetags/template_extras.py
@@ -4,6 +4,7 @@ import math
 from django import template
 from django.utils.safestring import mark_safe
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import timezone
 
 
@@ -23,12 +24,11 @@ else:
 
 
 @register.simple_tag(takes_context=True)
-def conditional_js(context, filename):
-    tag_format = '<script src="/static/js/%s.%sjs"></script>'
-    if context.get('DEBUG', True):
-        tag = tag_format % (filename, '')
-    else:
-        tag = tag_format % (filename, 'min.')
+def conditional_js(context, script_name):
+    suffix = '' if context.get('DEBUG', True) else '.min'
+    filename = 'js/{}{}.js'.format(script_name, suffix)
+    url = staticfiles_storage.url(filename)
+    tag = '<script src="{}"></script>'.format(url)
     return mark_safe(tag)
 
 

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -106,6 +106,8 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
+
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 # END STATIC FILE CONFIGURATION
 
 

--- a/openprescribing/openprescribing/settings/test.py
+++ b/openprescribing/openprescribing/settings/test.py
@@ -96,3 +96,8 @@ PIPELINE_IMPORT_LOG_PATH = os.path.join(
 )
 
 SLACK_SENDING_ACTIVE = False
+
+# Running with a different storage backend in test is not ideal but it's what
+# the Django docs recommend:
+# https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'

--- a/openprescribing/templates/_chart.html
+++ b/openprescribing/templates/_chart.html
@@ -1,3 +1,4 @@
+{% load staticfiles %}
 <div id="no-data">
 <p>No prescriptions found.</p>
 </div>

--- a/openprescribing/templates/_chart.html
+++ b/openprescribing/templates/_chart.html
@@ -18,7 +18,7 @@
 
 <!-- <div id="detailed-spending" class="chart">
 <div class="status">
-<p>Getting the data...</p><img src="/static/img/ajax-loader.gif" alt="Loading icon" />
+<p>Getting the data...</p><img src="{% static 'img/ajax-loader.gif' %}" alt="Loading icon" />
 </div>
 </div> -->
 

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -1,3 +1,4 @@
+{% load staticfiles %}
 <p id="perfsummary">Loading...</p>
 
 <div id="measures">

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -5,7 +5,7 @@
   <div id="charts" class="row">
     <div class="loading-wrapper col-xs-12">
       <hr/>
-      <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+      <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
       <br/>Fetching data...
       <br/><br/>
     </div>

--- a/openprescribing/templates/alert_example.html
+++ b/openprescribing/templates/alert_example.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}FAQs{% endblock %}

--- a/openprescribing/templates/alert_example.html
+++ b/openprescribing/templates/alert_example.html
@@ -14,7 +14,7 @@ highlighting measures where the specified CCG or practice is an
 outlier.  They look something like this:
 </p>
 
-<img src="/static/img/alert-example.png" >
+<img src="{% static 'img/alert-example.png' %}" >
 
 {% endblock %}
 

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -6,9 +6,9 @@
 {% block active_class %}analyse{% endblock %}
 
 {% block extra_css %}
-<link href="/static/css/select2.min.css" rel="stylesheet">
-<link href="/static/css/jquery.nouislider.css" rel="stylesheet">
-<link href="/static/css/jquery.nouislider.pips.css" rel="stylesheet">
+<link href="{% static 'css/select2.min.css' %}" rel="stylesheet">
+<link href="{% static 'css/jquery.nouislider.css' %}" rel="stylesheet">
+<link href="{% static 'css/jquery.nouislider.pips.css' %}" rel="stylesheet">
 <link href='https://api.tiles.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />
 {% endblock %}
 
@@ -105,7 +105,7 @@
 
 <div class="loading-wrapper">
     <hr/>
-    <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+    <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
     <br/>Fetching data...
 </div>
 
@@ -251,7 +251,7 @@
 
 {% block extra_js %}
 <!--[if !IE 8]><!-->
-  <script src="/static/js/clipboard.min.js?q=123456"></script>
+  <script src="{% static 'js/clipboard.min.js?q=123456' %}"></script>
 <!--<![endif]-->
 {% conditional_js 'analyse-form' %}
 

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}Analyse{% endblock %}

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -251,7 +251,7 @@
 
 {% block extra_js %}
 <!--[if !IE 8]><!-->
-  <script src="{% static 'js/clipboard.min.js?q=123456' %}"></script>
+  <script src="{% static 'js/clipboard.min.js' %}"></script>
 <!--<![endif]-->
 {% conditional_js 'analyse-form' %}
 

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -53,9 +53,9 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     <title>{% block title %}{% endblock %} | OpenPrescribing</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous" />
-    <link href="{% static 'css/index.css' %}?q=1234567" rel="stylesheet">
+    <link href="{% static 'css/index.css' %}" rel="stylesheet">
 
-    <link rel="icon" href="{% static 'img/favicon.png?2' %}">
+    <link rel="icon" href="{% static 'img/favicon.png' %}">
     <!--[if IE]><link rel="shortcut icon" href="{% static 'img/favicon.ico' %}"><![endif]-->
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -55,8 +55,8 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous" />
     <link href="{% static 'css/index.css' %}?q=1234567" rel="stylesheet">
 
-    <link rel="icon" href="/static/img/favicon.png?2">
-    <!--[if IE]><link rel="shortcut icon" href="/static/img/favicon.ico"><![endif]-->
+    <link rel="icon" href="{% static 'img/favicon.png?2' %}">
+    <!--[if IE]><link rel="shortcut icon" href="{% static 'img/favicon.ico' %}"><![endif]-->
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -79,7 +79,7 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
             <span class="icon-bar"></span>
           </button>
           <a class="navbar-brand" href="{% url 'home' %}">
-          <img class="logo" src="/static/img/logo.svg" alt="OpenPrescribing logo" onerror="this.src='/static/img/logo.png';this.onerror=null;" />
+          <img class="logo" src="{% static 'img/logo.svg' %}" alt="OpenPrescribing logo" onerror="this.src='{% static "img/logo.png" %}';this.onerror=null;" />
           OpenPrescribing<span class="beta">beta</span>
           </a>
         </div>
@@ -156,12 +156,12 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
       <div class="container">
         <div class="row">
             <div class="col-md-12 col-sm-12 col-xs-12 sponsors">
-              <a href="http://www.health.org.uk/"><img src="/static/img/health_foundation_logo.png" alt="Health Foundation logo"/></a>
-              <a href="http://weahsn.net"><img src="/static/img/weahsn_logo_bw.png" alt="WEAHSN logo"/></a>
-              <a href="http://cebm.net"><img src="/static/img/cebm_logo.png" alt="Centre for Evidence-Based Medicine logo"/></a>
-              <a href="http://www.ox.ac.uk"><img src="/static/img/oxford_logo.png" alt="University of Oxford logo"/></a>
-              <a href="http://www.lshtm.ac.uk"><img src="/static/img/lshtm_logo.png" alt="LSHTM logo"/></a>
-              <a href="http://www.nihr.ac.uk/"><img src="/static/img/nihr_logo.png" alt="National Institute for Health Research logo"/></a>
+              <a href="http://www.health.org.uk/"><img src="{% static 'img/health_foundation_logo.png' %}" alt="Health Foundation logo"/></a>
+              <a href="http://weahsn.net"><img src="{% static 'img/weahsn_logo_bw.png' %}" alt="WEAHSN logo"/></a>
+              <a href="http://cebm.net"><img src="{% static 'img/cebm_logo.png' %}" alt="Centre for Evidence-Based Medicine logo"/></a>
+              <a href="http://www.ox.ac.uk"><img src="{% static 'img/oxford_logo.png' %}" alt="University of Oxford logo"/></a>
+              <a href="http://www.lshtm.ac.uk"><img src="{% static 'img/lshtm_logo.png' %}" alt="LSHTM logo"/></a>
+              <a href="http://www.nihr.ac.uk/"><img src="{% static 'img/nihr_logo.png' %}" alt="National Institute for Health Research logo"/></a>
             </div>
             <div class="col-md-9 col-sm-9 col-xs-12 attribution text-muted">
               <div>Designed and built by the <a href="http://ebmdatalab.net">EBM DataLab</a>, <a href="http://www.phc.ox.ac.uk/">Department of Primary Care Health Sciences</a>, University of Oxford. Funded by <a href="">WEAHSN</a> and <a href="http://www.health.org.uk/">The Health Foundation</a>.

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}Prescribing measures for {{ entity.name }}{% endblock %}

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -52,7 +52,7 @@
         <div class="col-md-12">
           <div id="top-measure-container" class="row">
             <div class="loading-wrapper loading">
-              <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+              <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
             </div>
           </div>
         </div>
@@ -70,7 +70,7 @@
         <div class="col-md-12">
           <div id="lpzomnibus-container" class="row">
             <div class="loading-wrapper loading">
-              <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+              <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
             </div>
           </div>
         </div>

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}FAQs{% endblock %}

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -204,7 +204,7 @@
 <ul>
   <li>To share the dashboard as a link for someone else to access, or to save for later, select <strong>Share</strong>. If you have made changes then "Current View" will be selected. Copy the link:<br>
 
-    <img src="/static/img/tableau_share.png" alt="Tableau share menu"/>
+    <img src="{% static 'img/tableau_share.png' %}" alt="Tableau share menu"/>
 
   </li>
   <li>To share the view as an image or PDF, select <strong>Download</strong> and select your preferred option.</li>

--- a/openprescribing/templates/how-to-use.html
+++ b/openprescribing/templates/how-to-use.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}How to use{% endblock %}

--- a/openprescribing/templates/how-to-use.html
+++ b/openprescribing/templates/how-to-use.html
@@ -17,6 +17,6 @@
 
 <br/>
 
-<p>See also our informal <a href="/static/downloads/walkthrough.pdf">walkthough</a> (PDF) for prescribing analysts and our notes on <a href="{% url 'faq' %}">understanding the data</a>.</p>
+<p>See also our informal <a href="{% static 'downloads/walkthrough.pdf' %}">walkthough</a> (PDF) for prescribing analysts and our notes on <a href="{% url 'faq' %}">understanding the data</a>.</p>
 
 {% endblock %}

--- a/openprescribing/templates/measure_for_all_ccgs.html
+++ b/openprescribing/templates/measure_for_all_ccgs.html
@@ -21,7 +21,7 @@
     <div id="charts" class="row">
       <div class="loading-wrapper col-xs-12">
         <hr/>
-        <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+        <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
         <br/>Fetching data...
         <br/><br/>
       </div>

--- a/openprescribing/templates/measure_for_all_ccgs.html
+++ b/openprescribing/templates/measure_for_all_ccgs.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %} {{ measure }} by all CCGs{% endblock %}

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -21,7 +21,7 @@
     <div id="charts" class="row">
       <div class="loading-wrapper col-xs-12">
         <hr/>
-        <img class="loading" src="/static/img/logo.svg" onerror="this.src='/static/img/ajax-loader.gif';this.onerror=null;" title="Loading icon">
+        <img class="loading" src="{% static 'img/logo.svg' %}" onerror="this.src='{% static "img/ajax-loader.gif" %}';this.onerror=null;" title="Loading icon">
         <br/>Fetching data...
         <br/><br/>
       </div>

--- a/openprescribing/templates/measure_for_practices_in_ccg.html
+++ b/openprescribing/templates/measure_for_practices_in_ccg.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}{{measure.name}} by practices in {{ ccg.name }}{% endblock %}

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -39,7 +39,7 @@
 <form method="post" class="form form-inline">
  {% csrf_token %}
  <p>
-   <img src="/static/img/bang.jpg" style="float: left; margin-right: 10px">
+   <img src="{% static 'img/bang.jpg' %}" style="float: left; margin-right: 10px">
    Get email updates (roughly weekly) for {{ entity_name }} when new price
    concession data is available.  You can also sign up for our monthly
    newsletter.

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 {% load humanize %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}{{ title }}{% endblock %}

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -7,7 +7,7 @@
 {% block active_class %}tariff{% endblock %}
 
 {% block extra_css %}
-<link href="/static/css/select2.min.css" rel="stylesheet">
+<link href="{% static 'css/select2.min.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load staticfiles %}
 {% load template_extras %}
 
 {% block title %}Drug tariff for {{ chart_title }}{% endblock %}


### PR DESCRIPTION
This patch introduces Django's [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#manifeststaticfilesstorage) backend which will create unique names for every version of our static files so we no longer have issues with stale files being cached.

This involves making sure that every reference to the URL of a static file uses the `{% static %}` tag so that the correct URL gets used in production.

Currently, this doesn't use the backend in test which is not ideal but is what the Django docs recommend. At some point we could start using WhiteNoise which would allow us to have an identical configuration in dev, test and production.

Closes #1491