### PR TITLE
Handle pack_size with non-ascii character

### DIFF
--- a/openprescribing/dmd/management/commands/reconcile_ncso_concessions.py
+++ b/openprescribing/dmd/management/commands/reconcile_ncso_concessions.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         self.stdout.write('~' * 10)
         self.stdout.write('Unreconciled concession:')
         self.stdout.write(u'   drug: {}'.format(concession.drug))
-        self.stdout.write('   pack size: {}'.format(concession.pack_size))
+        self.stdout.write(u'   pack size: {}'.format(concession.pack_size))
 
         while True:
             self.stdout.write('')


### PR DESCRIPTION
We've seen a pack_size containing \x0a