### PR TITLE
Fix n+1 query in measure_by_xxx endpoints

### DIFF
--- a/openprescribing/frontend/managers.py
+++ b/openprescribing/frontend/managers.py
@@ -89,6 +89,9 @@ class MeasureValueQuerySet(models.QuerySet):
 
         if parent_org_type == 'ccg':
             parent_org_type = 'pct'
+            qs = qs.select_related('pct')
+        else:
+            qs = qs.select_related(org_type)
 
         return qs.for_orgs(parent_org_type, org_ids) \
             .for_measures(measure_ids) \


### PR DESCRIPTION
Closes #1528.

The extra queries were caused by looking up eg measure_value.pct.name in
_roll_up_measure_values.  The pct/ccg ugliness is not worth solving as
we expect to replace much of this code when the MatrixStore arrives.