### PR TITLE
Fix N+1 query problem when rolling up MeasureValues

### DIFF
--- a/openprescribing/api/views_measures.py
+++ b/openprescribing/api/views_measures.py
@@ -250,6 +250,12 @@ def _measure_by_org(request, org_type):
         tags,
     )
 
+    # Because we access the `name` of the related org for each MeasureValue
+    # during the roll-up process below we need to prefetch them to avoid doing
+    # N+1 db queries
+    org_field = org_type if org_type != 'ccg' else 'pct'
+    measure_values = measure_values.prefetch_related(org_field)
+
     if aggregate:
         measure_values = measure_values.aggregate_by_measure_and_month()
 


### PR DESCRIPTION
Previously, each loop iteration in `_roll_up_measure_values` would
access the `name` field on the related organisation, triggering a
database query to load it.

We use `prefetch_related` in preference to `select_related` because the
same organisation will be referenced by multiple MeasureValues (60, to
be precise: one for each month over 5 years) and so it's more efficient
to load these once in a separate query than to do the JOIN.

By way of comparison, here are timings for the measure API requests
executed on the following pages (note, these were run locally with the
staging database tunnelled over SSH so are slower than we'd expect in
production):

https://openprescribing.net/measure/ace/
Currently: 8.1 minutes
With select_related: 33.5 seconds
With prefetch_related: 11.8 seconds

https://openprescribing.com/ccg/99P/ace/
Currently: 4.8 minutes
With select_related: 59.6 seconds
With prefetch_related: 48.7 seconds

Closes #1528, replaces #1529