### PR TITLE
Update requirements.txt to match requirements.in

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 argh==0.26.2              # via watchdog
 asn1crypto==0.23.0        # via cryptography
 backports.csv==1.0.5
+backports.functools-lru-cache==1.5  # via soupsieve
 bcrypt==3.1.4             # via paramiko
 beautifulsoup4==4.7.1
 cachetools==2.0.1         # via google-auth, premailer
@@ -14,12 +15,13 @@ certifi==2017.7.27.1      # via requests
 cffi==1.12.2              # via bcrypt, cryptography, pynacl, zstandard
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
+configparser==3.7.3       # via entrypoints, flake8
+contextlib2==0.5.5        # via raven
 coverage==4.5.2
 cryptography==2.3.1       # via paramiko, pyopenssl, requests
 cssselect==1.0.1          # via premailer, pyquery
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via networkx
-defusedxml==0.5.0         # via python3-openid
 diff-match-patch==20121119  # via django-import-export
 django-allauth==0.39.1
 django-anymail[mailgun]==6.0
@@ -39,6 +41,9 @@ enum34==1.1.6
 et-xmlfile==1.0.1         # via openpyxl
 fabric==1.14.1
 flake8==3.7.7
+funcsigs==1.0.2           # via mock
+functools32==3.2.3.post2  # via flake8
+futures==3.2.0            # via google-api-core, pyarrow, requests-futures
 google-api-core==0.1.4    # via google-cloud-bigquery, google-cloud-core, google-cloud-storage
 google-api-python-client==1.7.8
 google-auth-httplib2==0.0.3  # via google-api-python-client
@@ -54,6 +59,7 @@ gunicorn==19.9.0
 html2text==2018.1.9
 httplib2==0.10.3          # via google-api-python-client, google-auth-httplib2
 idna==2.6                 # via cryptography, requests
+ipaddress==1.0.22         # via cryptography
 jdcal==1.3                # via openpyxl
 lxml==4.3.2
 mailchimp3==3.0.6
@@ -84,7 +90,7 @@ pynacl==1.2.1             # via paramiko
 pyopenssl==19.0.0         # via requests
 pyquery==1.4.0
 python-dateutil==2.8.0
-python3-openid==3.1.0     # via django-allauth
+python-openid==2.2.5      # via django-allauth
 pytz==2018.9
 pyvirtualdisplay==0.2.1
 pyyaml==3.13              # via tablib, watchdog
@@ -101,6 +107,7 @@ sqlparse==0.2.4           # via django-debug-toolbar
 tablib==0.12.1            # via django-import-export
 titlecase==0.12.0
 tqdm==4.31.1
+typing==3.6.6             # via django-extensions, flake8
 unicodecsv==0.14.1        # via djangorestframework-csv, tablib
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.24.1           # via requests, selenium


### PR DESCRIPTION
This patch is the result of running:

    pip-compile --output-file requirements.txt requirements.in

I'm not 100% sure why this results in a diff, but I suspect it's
something to do with dependabot updating versions in
requirements.txt and requirements.in but not updating transitive
dependencies.