### PR TITLE
Fix styling and JS on measure_for_one_entity pages

### DIFF
--- a/openprescribing/templates/_measure_breakdown_table.html
+++ b/openprescribing/templates/_measure_breakdown_table.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs-3.3.7/dt-1.10.15/datatables.min.css"/>
-<script type="text/javascript" src="https://cdn.datatables.net/v/bs-3.3.7/dt-1.10.15/datatables.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.15/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.15/datatables.min.js"></script>
 <script type="text/javascript">
   $('#numerator_breakdown').DataTable(
     {


### PR DESCRIPTION
This broke due to an annoyingly subtle bit of behviour from the
datatables CDN: we include "bs" in the URLs to indicate that we want the
Bootstrap compatible versions of the JS and CSS, but if you include a
version number as well (e.g. "bs-3.3.7") then it includes a copy of that
version of Bootstrap in the response. It's this second copy that causes
the breakage.

Fixes #1544