### PR TITLE
Store costs in pence as ints, rather than pounds as floats

### DIFF
--- a/openprescribing/matrixstore/build/import_prescribing.py
+++ b/openprescribing/matrixstore/build/import_prescribing.py
@@ -110,10 +110,14 @@ def parse_prescribing_csv(input_stream):
             # We only need the YYYY-MM-DD part of the date
             row[date_col][:10],
             int(row[items_col]),
-            float(row[quantity_col]),
-            float(row[actual_cost_col]),
-            float(row[net_cost_col])
+            int(row[quantity_col]),
+            pounds_to_pence(row[actual_cost_col]),
+            pounds_to_pence(row[net_cost_col])
         )
+
+
+def pounds_to_pence(value):
+    return int(round(float(value) * 100))
 
 
 def build_matrices(prescriptions, practices, dates):
@@ -134,8 +138,8 @@ def build_matrices(prescriptions, practices, dates):
     for bnf_code, row_group in grouped_by_bnf_code:
         items_matrix = sparse_matrix(shape, integer=True)
         quantity_matrix = sparse_matrix(shape, integer=True)
-        actual_cost_matrix = sparse_matrix(shape)
-        net_cost_matrix = sparse_matrix(shape)
+        actual_cost_matrix = sparse_matrix(shape, integer=True)
+        net_cost_matrix = sparse_matrix(shape, integer=True)
         for _, practice, date, items, quantity, actual_cost, net_cost in row_group:
             practice_offset = practices[practice]
             date_offset = dates[date]

--- a/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
+++ b/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
@@ -168,7 +168,10 @@ class TestMatrixStoreBuild(SimpleTestCase):
         self.assertEqual(get_value.nonzero_values, expected_entries)
 
     def test_prescribing_values_are_correct(self):
-        for field in ('items', 'quantity', 'net_cost', 'actual_cost'):
+        for field in ['items', 'quantity', 'net_cost', 'actual_cost']:
+            # Cost figures are originally in pounds but we store them in pence
+            # as ints
+            multiplier = 100 if field.endswith('_cost') else 1
             get_value = MatrixValueFetcher(
                 self.connection, 'presentation', 'bnf_code', field
             )
@@ -176,7 +179,8 @@ class TestMatrixStoreBuild(SimpleTestCase):
             for entry in self._expected_prescribing_values():
                 expected_entries += 1
                 value = get_value(entry['bnf_code'], entry['practice'], entry['month'])
-                self.assertEqual(value, entry[field])
+                expected_value = round(entry[field] * multiplier)
+                self.assertEqual(value, expected_value)
             # Check there are no additional values that we weren't expecting
             self.assertEqual(get_value.nonzero_values, expected_entries)
 

--- a/openprescribing/matrixstore/tests/data_factory.py
+++ b/openprescribing/matrixstore/tests/data_factory.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import csv
 import itertools
 import json
@@ -116,8 +118,9 @@ class DataFactory(object):
             'bnf_name': presentation['name'],
             'items': self.random.randint(1, 100),
             'quantity': self.random.randint(1, 100),
-            'net_cost': self.random.random() * 100,
-            'actual_cost': self.random.random() * 100,
+            # Costs should be in pounds to two decimal places
+            'net_cost': self.random.randint(1, 10000) / 100,
+            'actual_cost': self.random.randint(1, 10000) / 100,
             'sha': None,
             'pct': None,
             'stp': None,


### PR DESCRIPTION
This is more efficient, both in terms of storage space and numpy
arithmetic.