### PR TITLE
Make API work in the presence of basic auth parameters

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -299,7 +299,12 @@ REST_FRAMEWORK = {
         'rest_framework_csv.renderers.CSVRenderer',
     ),
     'DEFAULT_CONTENT_NEGOTIATION_CLASS':
-    'frontend.negotiation.IgnoreAcceptsContentNegotiation',
+        'frontend.negotiation.IgnoreAcceptsContentNegotiation',
+    # This removes HTTP BasicAuthentication, which DRF includes by default, as that
+    # clashes with the BasicAuth we use to protect staging from bots
+     'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+    ),
 }
 
 CORS_URLS_REGEX = r'^/api/.*$'


### PR DESCRIPTION
This patch removes the DRF BasicAuthentication class from the
default authenticators config. We're now using basic auth to prevent
staging from being accidentally crawled and DRF was picking up the
credentials and trying to do its own authentication with them which was
breaking.