### PR TITLE
Report how many alerts have been sent

### DIFF
--- a/openprescribing/frontend/management/commands/send_ncso_concessions_alerts.py
+++ b/openprescribing/frontend/management/commands/send_ncso_concessions_alerts.py
@@ -39,6 +39,8 @@ def send_alerts(date):
                 date
             )
 
+    print('Sent {} alerts'.format(bookmarks.count()))
+
 
 def get_unsent_bookmarks(date):
     '''Find unsent bookmarks for given date.


### PR DESCRIPTION
This will get reported to Slack if alerts are sent via `op ncso send alerts`.