### PR TITLE
Don't include alert signup template if no signup form

### DIFF
--- a/openprescribing/templates/_measures_heading.html
+++ b/openprescribing/templates/_measures_heading.html
@@ -35,7 +35,7 @@
     {% endif %}
 
     <div class="row">
-      {% if entity_type == 'practice' or entity_type == 'ccg' %}
+      {% if form %}
         <div class="col-md-6">
           {% include '_alert_signup_form.html' %}
         </div>


### PR DESCRIPTION
Previously, we checked the entity type but this fails for the
`measures_for_one_entity` pages which don't have the appropriate `form`
object in the template context. This means we display a "Subscribe"
button which doesn't do anything on the CCG and practice pages e.g.
https://openprescribing.net/ccg/99P/measures/

Possibly we can fix the view function to create the relevant form, but
we should fix this conditional anyway as checking a fixed list of entity
types is bound to be fragile.