### PR TITLE
Add caching for expensive All England numbers

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -34,6 +34,8 @@ export PYTHONPATH=$APPS_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$REPO_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENV
 
+export SOURCE_COMMIT_ID="$(git rev-parse HEAD)"
+
 echo "Starting $NAME"
 echo "whoami: $(whoami)"
 echo "ENV: $ENV"

--- a/environment-sample
+++ b/environment-sample
@@ -27,8 +27,11 @@ MAILCHIMP_API_KEY=mailchimp_api_key
 # Platform services (eg BigQuery, Cloud Storage).
 GOOGLE_APPLICATION_CREDENTIALS=
 
-# URL of Redis instance to use for caching. The application will run fine
-# without this, it just won't be able to cache anything.
+# If this is set to True then both REDIS_URL below must also be defined or the
+# application won't start
+ENABLE_CACHING=False
+
+# URL of Redis instance to use for caching
 # Accepts any format handled by redis-py:
 # # https://redis-py.readthedocs.io/en/latest/#redis.Redis.from_url
 REDIS_URL=

--- a/environment-sample
+++ b/environment-sample
@@ -27,6 +27,11 @@ MAILCHIMP_API_KEY=mailchimp_api_key
 # Platform services (eg BigQuery, Cloud Storage).
 GOOGLE_APPLICATION_CREDENTIALS=
 
+# URL of Redis instance to use for caching. The application will run fine
+# without this, it just won't be able to cache anything.
+# Accepts any format handled by redis-py:
+# # https://redis-py.readthedocs.io/en/latest/#redis.Redis.from_url
+REDIS_URL=
 
 # Only required on the server
 GUNICORN_TIMEOUT=60

--- a/openprescribing/common/utils.py
+++ b/openprescribing/common/utils.py
@@ -63,6 +63,27 @@ def get_env_setting(setting, default=None):
             raise ImproperlyConfigured(error_msg)
 
 
+def get_env_setting_bool(setting, default=None):
+    """ Get the environment setting as a boolean
+
+    Return the default, or raise an exception if none supplied
+    """
+    value = get_env_setting(setting, default=default)
+    if value is default:
+        return value
+    normalised = value.lower().strip()
+    if normalised == 'true':
+        return True
+    elif normalised == 'false':
+        return False
+    else:
+        raise ImproperlyConfigured(
+            'Value for env variable {} is not a valid boolean: {}'.format(
+                setting, value
+            )
+        )
+
+
 def under_test():
     return db.connections.databases['default']['NAME'].startswith("test_")
 

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -703,12 +703,13 @@ class TestFeedbackView(TestCase):
         self.assertEqual(len(mail.outbox), 2)
 
 
-LOCAL_MEMORY_CACHE = {
-    'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
-}
-
-
-@override_settings(CACHES=LOCAL_MEMORY_CACHE, SOURCE_COMMIT_ID='abc123')
+@override_settings(
+    ENABLE_CACHING=True,
+    CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+    },
+    SOURCE_COMMIT_ID='abc123'
+)
 class TestCacheWrapper(SimpleTestCase):
 
     def test_function_calls_are_cached(self):
@@ -732,9 +733,9 @@ class TestCacheWrapper(SimpleTestCase):
             _cache(test_func)
         self.assertEqual(test_func.call_count, 2)
 
-    def test_no_caching_if_no_source_commit_id(self):
+    def test_no_caching_if_not_enabled(self):
         test_func = Mock(__name__='test_func', return_value='foo')
-        with override_settings(SOURCE_COMMIT_ID=''):
+        with override_settings(ENABLE_CACHING=False):
             _cache(test_func)
             _cache(test_func)
         self.assertEqual(test_func.call_count, 2)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -285,13 +285,9 @@ def _cache(function, *args):
     the code is used as part of the cache key so any new deployment will
     automatically invalidate the cache.
     """
-    # If we don't have a git sha for the currently executing code which we can
-    # use to cache against then we do the safe thing which is not to cache at
-    # all
-    commit_id = settings.SOURCE_COMMIT_ID
-    if not commit_id:
+    if not settings.ENABLE_CACHING:
         return function(*args)
-    key_parts = [commit_id, __name__, function.__name__]
+    key_parts = [settings.SOURCE_COMMIT_ID, __name__, function.__name__]
     key_parts.extend(map(str, args))
     key = ':'.join(key_parts)
     result = cache.get(key)

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -401,7 +401,7 @@ if redis_url:
     }
 else:
     # The dummy cache backend implements all the usual methods but never
-    # actually does any caching so it's perfect for developemt when you always
+    # actually does any caching so it's perfect for development when you always
     # want fresh values
     CACHES = {
         'default': {

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -383,3 +383,33 @@ MAILCHIMP_LIST_ID = 'b2b7873a73'
 sentry_raven_dsn = utils.get_env_setting('SENTRY_RAVEN_DSN', default='')
 if sentry_raven_dsn and not SHELL:
     RAVEN_CONFIG = {'dsn': sentry_raven_dsn}
+
+
+redis_url = utils.get_env_setting('REDIS_URL', default='')
+
+if redis_url:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": redis_url,
+            "OPTIONS": {
+                # This C-based parser is much faster than the default pure
+                # Python one
+                "PARSER_CLASS": "redis.connection.HiredisParser",
+            }
+        }
+    }
+else:
+    # The dummy cache backend implements all the usual methods but never
+    # actually does any caching so it's perfect for developemt when you always
+    # want fresh values
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+
+
+# The git sha of the currently running version of the code (will be empty in
+# development)
+SOURCE_COMMIT_ID = utils.get_env_setting('SOURCE_COMMIT_ID', default='')

--- a/openprescribing/openprescribing/settings/local.py
+++ b/openprescribing/openprescribing/settings/local.py
@@ -38,16 +38,6 @@ DATABASES = {
 }
 # END DATABASE CONFIGURATION
 
-
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
 INSTALLED_APPS += ('django_extensions',)
 
 # TOOLBAR CONFIGURATION

--- a/openprescribing/openprescribing/settings/production.py
+++ b/openprescribing/openprescribing/settings/production.py
@@ -41,15 +41,6 @@ DATABASES = {
 # END DATABASE CONFIGURATION
 
 
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
 GOOGLE_TRACKING_ID = 'UA-62480003-1'
 GOOGLE_OPTIMIZE_CONTAINER_ID = 'GTM-5PX77GZ'
 

--- a/openprescribing/openprescribing/settings/staging.py
+++ b/openprescribing/openprescribing/settings/staging.py
@@ -31,15 +31,6 @@ DATABASES = {
 # END DATABASE CONFIGURATION
 
 
-# CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-# END CACHE CONFIGURATION
-
 ANYMAIL["MAILGUN_SENDER_DOMAIN"] = "staging.openprescribing.net"
 SUPPORT_FROM_EMAIL = 'feedback@staging.openprescribing.net'
 DEFAULT_FROM_EMAIL = 'OpenPrescribing <{}>'.format(SUPPORT_FROM_EMAIL)

--- a/openprescribing/openprescribing/settings/test.py
+++ b/openprescribing/openprescribing/settings/test.py
@@ -15,11 +15,6 @@ DATABASES = {
         'HOST': utils.get_env_setting('DB_HOST', '127.0.0.1')
     }
 }
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
 INTERNAL_IPS = ('127.0.0.1',)
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'

--- a/requirements.in
+++ b/requirements.in
@@ -48,6 +48,10 @@ tqdm==4.32.1
 xlrd==1.2.0
 zstandard==0.11.1
 
+# redis
+django-redis
+hiredis
+
 # test requirements
 coverage
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ django-debug-toolbar==1.11
 django-dotenv==1.4.2
 django-extensions==2.1.7
 django-import-export==1.2.0
+django-redis==4.10.0
 django==1.11.20
 djangorestframework-csv==2.1.0
 djangorestframework==3.9.4
@@ -51,6 +52,7 @@ google-resumable-media==0.3.1  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.5.3  # via google-api-core
 graphviz==0.10.1
 gunicorn==19.9.0
+hiredis==1.0.0
 html2text==2018.1.9
 httplib2==0.10.3          # via google-api-python-client, google-auth-httplib2
 idna==2.6                 # via cryptography, requests
@@ -88,6 +90,7 @@ pytz==2019.1
 pyvirtualdisplay==0.2.1
 pyyaml==5.1               # via tablib, watchdog
 raven==6.10.0
+redis==3.2.1              # via django-redis
 requests-futures==0.9.9
 requests-oauthlib==0.8.0  # via django-allauth, google-auth-oauthlib
 requests[security]==2.22.0


### PR DESCRIPTION
At present the All England page contains no user-specific content and so
gets cached by Cloudflare. When we add an alert signup form it will stop
being cacheable, but it takes some expensive db queries to generate and
so it will become quite slow to load.

This patch adds application-level caching for a few of these expensive
queries which can be safely cached. Data is a cached in Redis with the
connection configured via a REDIS_URL environment variable. If no such
variable is present then the application will still work, it just won't
do any caching.

The application also looks for a SOURCE_COMMIT_ID environment variable
which is uses as part of the cache keys. This has the effect that every
deployment automatically invalidates the cache. Again, if this variable
isn't present then the application falls back to doing no caching.