### PR TITLE
Fix flaky import_measures test

### DIFF
--- a/openprescribing/frontend/tests/commands/test_import_measures_new.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures_new.py
@@ -179,7 +179,7 @@ class ImportMeasuresTests(TestCase):
 
         df['items'] = numerators.groupby(org_column)['items'].sum()
         df['thousand_patients'] = (
-            denominators.groupby(org_column)['total_list_size'].sum() / 1000
+            denominators.groupby(org_column)['thousand_patients'].sum()
         )
         df['ratio'] = df['items'] / df['thousand_patients']
         df['items'] = df['items'].fillna(0)
@@ -203,7 +203,7 @@ class ImportMeasuresTests(TestCase):
 
         df['cost'] = numerators.groupby(org_column)['actual_cost'].sum()
         df['thousand_patients'] = (
-            denominators.groupby(org_column)['total_list_size'].sum() / 1000
+            denominators.groupby(org_column)['thousand_patients'].sum()
         )
         df['ratio'] = df['cost'] / df['thousand_patients']
         df['cost'] = df['cost'].fillna(0)
@@ -584,7 +584,7 @@ def upload_practice_statistics():
                     'ccg_id': practice.ccg_id,
                     'stp_id': practice.ccg.stp_id,
                     'regional_team_id': practice.ccg.regional_team_id,
-                    'total_list_size': total_list_size,
+                    'thousand_patients': total_list_size / 1000.0,
                 },
                 ignore_index=True,
             )


### PR DESCRIPTION
This fixes a failure that occurs in a test that calculates measure
ratios and percentiles using two different implementations (BQ and
Python) and then checks that the implementations give the same result.

The problem occurs when two ratios in the same month are identical, but
where one implementation loses some accuracy thanks to floating point
rounding.  When this happens, the implementation that has lost accuracy
thinks that the two ratios are different, and so assigns them to
different percentiles, while the other implementation assigns them to
the same percentile.

The fix is to change they Python implementation to more closely match
the BQ one, which means that if the BQ implementation loses accuracy,
the Python one will too.

That is, rather than calculating the denominator for a CCG by summing
the list sizes of all practices in the CCG and then dividing by 1000, we
now divide a practice's list size by 1000 and sum this.

This is a bit of a shame, in that one of the nice things about this kind
of test is that the more different the two implementations are, the more
confidence we can have that we haven't got the same bug in both!

And I know this only looks like a small change but it's taken all day to
hunt down!

Fixes #1678.