### PR TITLE
Fix git sha detection in gunicorn_start

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -34,7 +34,7 @@ export PYTHONPATH=$APPS_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$REPO_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENV
 
-export SOURCE_COMMIT_ID="$(git rev-parse HEAD)"
+export SOURCE_COMMIT_ID="$(git --git-dir="$REPO_ROOT/.git" rev-parse HEAD)"
 
 echo "Starting $NAME"
 echo "whoami: $(whoami)"


### PR DESCRIPTION
This script doesn't run within the git directory so we need to specify
the git path.