### PR TITLE
Only enable caching for web process

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -34,6 +34,13 @@ export PYTHONPATH=$APPS_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$REPO_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENV
 
+# This is set here rather than with the rest of the config as we only want
+# caching enabled for the web process not e.g. cron jobs or ad-hoc management
+# commands. This is because if we're going to enable caching we also need to
+# set SOURCE_COMMIT_ID and this can't be done in the static config file. The
+# proper fix here is a single entry point script which all invocations of the
+# app go through, but this avoids the problem for now.
+export ENABLE_CACHING=True
 export SOURCE_COMMIT_ID="$(git --git-dir="$REPO_ROOT/.git" rev-parse HEAD)"
 
 echo "Starting $NAME"


### PR DESCRIPTION
Currently, any attempt to run the application other than via
gunicorn_start blows up because ENABLE_CACHING is set in the config file
but SOURCE_COMMIT_ID is not set (it is determined dynamically via the
gunicorn_start script).

The quick fix here is to move ENABLE_CACHING out of the config file and
into gunicorn_start. The longer term fix is to have a common entry-point
script (not gunicorn specfic) which does all the necessary environment
setup and which everything can use.