### PR TITLE
Exclude neutral measures from dashboard

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1092,6 +1092,7 @@ def _home_page_context_for_entity(request, entity):
         MeasureValue.objects
         .filter(**mv_filter)
         .exclude(measure_id='lpzomnibus')
+        .exclude(measure__low_is_good__isnull=True)
         .values('measure_id')
         .annotate(average_percentile=Avg('percentile'))
         .order_by('-average_percentile')


### PR DESCRIPTION
A neutral measure is one where there is disagreement about whether a
higher or lower value is better.  That is, it is one where low_is_good
is null.

Fixes #1177.