### PR TITLE
Email alerts for All England

### DIFF
--- a/openprescribing/frontend/management/commands/load_development_data.py
+++ b/openprescribing/frontend/management/commands/load_development_data.py
@@ -1,7 +1,8 @@
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
-from frontend.tests.test_api_spending import TestAPISpendingViewsPPUTable
+from frontend.models import ImportLog, PPUSaving
+from frontend.tests.test_api_spending import ApiTestBase, TestAPISpendingViewsPPUTable
 
 
 class Command(BaseCommand):
@@ -13,3 +14,6 @@ class Command(BaseCommand):
         # API tests
         fixtures = TestAPISpendingViewsPPUTable.fixtures
         call_command('loaddata', *fixtures)
+        ApiTestBase.setUpTestData()
+        max_ppu_date = PPUSaving.objects.order_by('-date')[0].date
+        ImportLog.objects.create(current_at=max_ppu_date, category='ppu')

--- a/openprescribing/frontend/management/commands/send_all_england_alerts.py
+++ b/openprescribing/frontend/management/commands/send_all_england_alerts.py
@@ -1,0 +1,93 @@
+'''
+Send alerts about all of NHS England
+'''
+
+from __future__ import print_function
+
+import logging
+
+from django.core.management import BaseCommand
+
+from common.alert_utils import EmailErrorDeferrer
+from frontend.models import EmailMessage, OrgBookmark, User, Profile, ImportLog
+from frontend.views import bookmark_utils
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--recipient-email',
+            help='Send example email to this address'
+        )
+
+    def handle(self, recipient_email=None, **options):
+        send_alerts(recipient_email=recipient_email)
+
+
+def send_alerts(recipient_email=None):
+    '''Send unsent alerts for the current month'''
+
+    date = (
+        ImportLog.objects
+        .latest_in_category('prescribing')
+        .current_at
+        .strftime('%Y-%m-%d')
+        .lower()
+    )
+
+    if recipient_email is None:
+        bookmarks = get_unsent_bookmarks(date)
+    else:
+        bookmarks = [make_dummy_bookmark(recipient_email)]
+
+    for bookmark in bookmarks:
+        with EmailErrorDeferrer() as error_deferrer:
+            error_deferrer.try_email(
+                send_alert,
+                bookmark,
+                date
+            )
+
+    print('Sent {} alerts'.format(len(bookmarks)))
+
+
+def make_dummy_bookmark(email_address):
+    '''Make a dummy bookmark with this email address for testing purposes'''
+    dummy_user = User(email=email_address, id='dummyid')
+    dummy_user.profile = Profile(key='dummykey')
+    return OrgBookmark(
+        user=dummy_user,
+        pct_id=None,
+        practice_id=None
+    )
+
+
+def get_unsent_bookmarks(date):
+    '''Find unsent bookmarks for given date.
+
+    Alerts should only be sent to active users who have an approved bookmark.
+    '''
+
+    return OrgBookmark.objects.filter(
+        practice__isnull=True,
+        pct__isnull=True,
+        approved=True,
+        user__is_active=True
+    ).exclude(
+        user__emailmessage__tags__contains=['all_england', date]
+    )
+
+
+def send_alert(bookmark, date):
+    '''Send alert for bookmark for given date.'''
+    try:
+        message = bookmark_utils.make_all_england_email(bookmark, tag=date)
+        email_message = EmailMessage.objects.create_from_message(message)
+        email_message.send()
+        logger.info('Sent alert to %s about %s', email_message.to, bookmark.name)
+    except bookmark_utils.BadAlertImageError as e:
+        logger.exception(e)

--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -69,7 +69,11 @@ class Command(BaseCommand):
         """
         query = (
             Q(approved=True, user__is_active=True) &
-            ~Q(user__emailmessage__tags__contains=['measures', now_month]))
+            ~Q(user__emailmessage__tags__contains=['measures', now_month]) &
+            # Only include bookmarks for either a practice or pct: when both
+            # are NULL this indicates an All England bookmark
+            (Q(practice__isnull=False) | Q(pct__isnull=False))
+        )
         if options['recipient_email'] and (
                 options['ccg'] or options['practice']):
             dummy_user = User(email=options['recipient_email'], id='dummyid')

--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -1,7 +1,6 @@
 import cPickle
 import json
 import os.path
-import re
 import uuid
 
 from django.contrib.gis.db import models
@@ -18,7 +17,6 @@ from dmd2.models import (
     VMP,
     AMP,
     VMPP,
-    AMPP,
     DtPaymentCategory,
     AvailabilityRestriction,
     VirtualProductPresStatus,

--- a/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
@@ -1,0 +1,40 @@
+from django.core import mail
+from django.core.management import call_command
+
+from frontend.models import PPUSaving, ImportLog
+from frontend.tests.test_api_spending import ApiTestBase
+from frontend.tests.data_factory import DataFactory
+
+
+class CommandTestCase(ApiTestBase):
+
+    fixtures = ApiTestBase.fixtures + ['ppusavings', 'functional-measures']
+
+    @classmethod
+    def setUpTestData(cls):
+        super(CommandTestCase, cls).setUpTestData()
+        max_ppu_date = PPUSaving.objects.order_by('-date')[0].date
+        ImportLog.objects.create(current_at=max_ppu_date, category='ppu')
+
+    def test_send_alerts(self):
+        factory = DataFactory()
+
+        # Create a bookmark, send alerts, and make sure one email is sent to
+        # correct user
+        bookmark = factory.create_org_bookmark(None)
+        call_command('send_all_england_alerts')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [bookmark.user.email])
+
+        # Create another bookmark, send alerts again and make sure email is
+        # only sent to new user
+        mail.outbox = []
+        bookmark2 = factory.create_org_bookmark(None)
+        call_command('send_all_england_alerts')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [bookmark2.user.email])
+
+        # Try sending alerts again and make sure no emails are sent
+        mail.outbox = []
+        call_command('send_all_england_alerts')
+        self.assertEqual(len(mail.outbox), 0)

--- a/openprescribing/frontend/tests/data_factory.py
+++ b/openprescribing/frontend/tests/data_factory.py
@@ -8,7 +8,8 @@ from dateutil.relativedelta import relativedelta
 from dateutil.parser import parse as parse_date
 
 from frontend.models import (
-    ImportLog, Practice, PCT, Prescription, Presentation, NCSOConcessionBookmark
+    ImportLog, Practice, PCT, Prescription, Presentation,
+    NCSOConcessionBookmark, OrgBookmark
 )
 from dmd.models import (
     DMDProduct, DMDVmpp, NCSOConcession, TariffPrice, TariffCategory
@@ -160,3 +161,21 @@ class DataFactory(object):
             assert False
 
         return NCSOConcessionBookmark.objects.create(**kwargs)
+
+    def create_org_bookmark(self, org, user=None):
+        kwargs = {
+            'user': user or self.create_user(),
+            'approved': True,
+        }
+
+        if org is None:
+            # All England
+            pass
+        elif isinstance(org, PCT):
+            kwargs['pct'] = org
+        elif isinstance(org, Practice):
+            kwargs['practice'] = org
+        else:
+            assert False
+
+        return OrgBookmark.objects.create(**kwargs)

--- a/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
+++ b/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
@@ -121,6 +121,17 @@
   }
 },
 {
+  "model": "frontend.orgbookmark",
+  "pk": 5,
+  "fields": {
+    "user": 1,
+    "pct": null,
+    "practice": null,
+    "approved": true,
+    "created_at": "2000-01-01T12:01:00Z"
+  }
+},
+{
   "model": "frontend.searchbookmark",
   "pk": 1,
   "fields": {

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -35,7 +35,9 @@ class TestAlertViews(TestCase):
         if alert:
             newsletter_types.append('alerts')
         form_data['newsletters'] = newsletter_types
-        if len(entity_id) == 3:
+        if entity_id == "all_england":
+            url = '/all-england/'
+        elif len(entity_id) == 3:
             url = "/ccg/%s/" % entity_id
             form_data['pct'] = entity_id
         else:
@@ -309,6 +311,15 @@ class TestAlertViews(TestCase):
             response, "subscribed to alerts about "
             "<em>prescribing in 1/ST Andrews")
         self.assertTrue(response.context['user'].is_active)
+
+    def test_all_england_bookmark_created(self):
+        self.assertEqual(OrgBookmark.objects.count(), 0)
+        self._post_org_signup('all_england')
+        self.assertEqual(OrgBookmark.objects.count(), 1)
+        bookmark = OrgBookmark.objects.last()
+        self.assertEqual(bookmark.practice, None)
+        self.assertEqual(bookmark.pct, None)
+        self.assertEqual(bookmark.org_type(), 'all_england')
 
 
 class TestFrontendHomepageViews(TestCase):

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -15,7 +15,7 @@ from frontend.models import (
     EmailMessage, OrgBookmark, SearchBookmark, ImportLog, PCT, Practice,
     MeasureValue, Measure
 )
-from frontend.views.views import BadRequestError, _get_measure_tag_filter, _cache
+from frontend.views.views import BadRequestError, _get_measure_tag_filter, cached
 
 from allauth.account.models import EmailAddress
 
@@ -728,25 +728,25 @@ class TestCacheWrapper(SimpleTestCase):
             side_effect=lambda s: 'foo%s' % s,
             __name__='test_func'
         )
-        result = _cache(test_func, 'bar')
+        result = cached(test_func, 'bar')
         self.assertEqual(result, 'foobar')
-        result2 = _cache(test_func, 'bar')
+        result2 = cached(test_func, 'bar')
         self.assertEqual(result2, result)
         test_func.assert_called_once_with('bar')
 
     def test_source_commit_id_used_in_cache_key(self):
         test_func = Mock(__name__='test_func', return_value='foo')
-        _cache(test_func)
-        _cache(test_func)
+        cached(test_func)
+        cached(test_func)
         self.assertEqual(test_func.call_count, 1)
         with override_settings(SOURCE_COMMIT_ID='def456'):
-            _cache(test_func)
-            _cache(test_func)
+            cached(test_func)
+            cached(test_func)
         self.assertEqual(test_func.call_count, 2)
 
     def test_no_caching_if_not_enabled(self):
         test_func = Mock(__name__='test_func', return_value='foo')
         with override_settings(ENABLE_CACHING=False):
-            _cache(test_func)
-            _cache(test_func)
+            cached(test_func)
+            cached(test_func)
         self.assertEqual(test_func.call_count, 2)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -871,6 +871,10 @@ def make_all_england_email(bookmark, tag=None):
     msg.subject = 'Your monthly update on prescribing across NHS England'
 
     date = ImportLog.objects.latest_in_category('ppu').current_at
+
+    # This allows us to switch between calculating savings at the practice or
+    # CCG level. We use CCG at present for performance reasons but we may want
+    # to switch in future.
     entity_type = 'CCG'
     ppu_savings = _cache(_all_england_ppu_savings, entity_type, date)
     measure_savings = _cache(_all_england_measure_savings, entity_type, date)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -835,6 +835,7 @@ def make_ncso_concession_email(bookmark, tag=None):
         'additional_cost': monthly_totals[0]['additional_cost'],
         'breakdown': breakdown,
         'concessions_url': concessions_url,
+        'dashboard_url': dashboard_url,
         'chart_image_cid': chart_image_cid,
         'unsubscribe_link': unsubscribe_link,
     }

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -32,9 +32,9 @@ from frontend.views.spending_utils import (
     ncso_spending_for_entity, ncso_spending_breakdown_for_entity,
 )
 from frontend.views.views import (
-    _cache, _first_or_none, _all_england_low_priority_total,
-    _all_england_low_priority_savings, _all_england_measure_savings,
-    _all_england_ppu_savings
+    cached, first_or_none, all_england_low_priority_total,
+    all_england_low_priority_savings, all_england_measure_savings,
+    all_england_ppu_savings
 )
 
 GRAB_CMD = ('/usr/local/bin/phantomjs ' +
@@ -876,11 +876,11 @@ def make_all_england_email(bookmark, tag=None):
     # CCG level. We use CCG at present for performance reasons but we may want
     # to switch in future.
     entity_type = 'CCG'
-    ppu_savings = _cache(_all_england_ppu_savings, entity_type, date)
-    measure_savings = _cache(_all_england_measure_savings, entity_type, date)
-    low_priority_savings = _cache(_all_england_low_priority_savings, entity_type, date)
-    low_priority_total = _cache(_all_england_low_priority_total, entity_type, date)
-    ncso_spending = _first_or_none(
+    ppu_savings = cached(all_england_ppu_savings, entity_type, date)
+    measure_savings = cached(all_england_measure_savings, entity_type, date)
+    low_priority_savings = cached(all_england_low_priority_savings, entity_type, date)
+    low_priority_total = cached(all_england_low_priority_total, entity_type, date)
+    ncso_spending = first_or_none(
         ncso_spending_for_entity(None, 'all_england', num_months=1)
     )
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -610,7 +610,6 @@ def all_england_price_per_unit(request):
 def price_per_unit_by_presentation(request, entity_code, bnf_code):
     date = _specified_or_last_date(request, 'ppu')
     presentation = get_object_or_404(Presentation, pk=bnf_code)
-    product = presentation.dmd_product
     if len(entity_code) == 3:
         entity = get_object_or_404(PCT, code=entity_code)
     elif len(entity_code) == 6:
@@ -648,7 +647,6 @@ def price_per_unit_by_presentation(request, entity_code, bnf_code):
 def all_england_price_per_unit_by_presentation(request, bnf_code):
     date = _specified_or_last_date(request, 'ppu')
     presentation = get_object_or_404(Presentation, pk=bnf_code)
-    product = presentation.dmd_product
 
     params = {
         'format': 'json',
@@ -1067,24 +1065,20 @@ def _home_page_context_for_entity(request, entity):
     if isinstance(entity, Practice):
         mv_filter['practice_id'] = entity.code
         entity_type = 'practice'
-        parent_org = entity.ccg_id
     elif isinstance(entity, PCT):
         mv_filter['pct_id'] = entity.code
         mv_filter['practice_id'] = None
         entity_type = 'ccg'
-        parent_org = None
     elif isinstance(entity, STP):
         mv_filter['stp_id'] = entity.code
         mv_filter['pct_id'] = None
         mv_filter['practice_id'] = None
         entity_type = 'stp'
-        parent_org = None
     elif isinstance(entity, RegionalTeam):
         mv_filter['regional_team_id'] = entity.code
         mv_filter['pct_id'] = None
         mv_filter['practice_id'] = None
         entity_type = 'regional_team'
-        parent_org = None
     else:
         raise RuntimeError("Can't handle type: {!r}".format(entity))
     # find the core measurevalue that is most outlierish

--- a/openprescribing/matrixstore/build/import_prescribing.py
+++ b/openprescribing/matrixstore/build/import_prescribing.py
@@ -91,7 +91,7 @@ def read_gzipped_prescribing_csv(filename):
 
 def parse_prescribing_csv(input_stream):
     """
-    Accepts a stream of CSV and yields prescibing data as tuples of the form:
+    Accepts a stream of CSV and yields prescribing data as tuples of the form:
 
         bnf_code, practice_code, date, items, quantity, actual_cost, net_cost
     """

--- a/openprescribing/templates/_alert_signup_form.html
+++ b/openprescribing/templates/_alert_signup_form.html
@@ -8,6 +8,9 @@
      <input type="hidden" name="name" value="">
      Get monthly alert emails with the latest version of this chart.
      You can also sign up for our monthly newsletter.
+   {% elif alert_type == 'all_england' %}
+     Get monthly alert emails highlighting changes affecting all of NHS England.
+     You can also sign up for our monthly newsletter.
    {% else %}
      Get monthly alerts highlighting where you are an outlier, or have
      suddenly changed (<a href="{% url 'alert_example' %}">example</a>).

--- a/openprescribing/templates/_measure_filters.html
+++ b/openprescribing/templates/_measure_filters.html
@@ -1,6 +1,5 @@
 <form class="form" action="">
   <div class="form-group">
-    <span class="label label-warning pull-right">New!</span>
     <label>Show measures categorised as:</label>
     <select name="tags" class="form-control js-submit-on-change">
       {% for tag in tag_filter.all_tags %}

--- a/openprescribing/templates/all_england.html
+++ b/openprescribing/templates/all_england.html
@@ -29,13 +29,15 @@
     <h2>Prescribing measures</h2>
     <p>
       The charts below show the distribution of prescribing behaviour across
-      {{entity_type}}s in NHS England on various measures
+      {{entity_type}}s in NHS England on various measures covering safety,
+      efficacy and cost-effectiveness
       (<a href="{% url 'faq' %}#measureinterpret">read more about these</a>).
     </p>
     <p>
       If all {{ entity_type}}s across England had prescribed at least as well
-      as the median {{ entity_type}} the monthly cost saving in
-      <strong>{{ date|date:"F Y" }}</strong> would have been:<br>
+      as the median {{ entity_type}} on the cost-saving measures the monthly
+      cost saving in <strong>{{ date|date:"F Y" }}</strong> would have
+      been:<br>
       <span style="font-size: 200%">£{{ measure_savings.50|sigfigs:4|intcomma }}</span>
     </p>
     <p>

--- a/openprescribing/templates/all_england.html
+++ b/openprescribing/templates/all_england.html
@@ -140,6 +140,10 @@
   {% endif %}
 
   <div class="col-md-6">
+    {% include '_alert_signup_form.html' with alert_type='all_england' %}
+  </div>
+
+  <div class="col-md-6">
     {% include '_measure_filters.html' %}
   </div>
 

--- a/openprescribing/templates/all_england.html
+++ b/openprescribing/templates/all_england.html
@@ -100,7 +100,7 @@
     <h2>Impact of price concessions</h2>
     <p>
       We have estimated the additional spending due to price concessions on
-      out-of-stock products by taking the latest available prescibing data from
+      out-of-stock products by taking the latest available prescribing data from
       <strong>{{ ncso_spending.last_prescribing_date|date:"F Y" }}</strong>
       and projecting forwards.
       In <strong>{{ ncso_spending.month|date:"F Y" }}</strong> this amounts to:<br>

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -1,0 +1,111 @@
+{% extends 'bookmarks/email_base.html' %}
+{% load template_extras %}
+{% load humanize %}
+{% block title %}Your monthly update on prescribing across NHS England{% endblock %}
+
+{% block content %}
+
+<h2>OpenPrescribing National Prescribing Dashboard: monthly update</h2>
+
+<p>
+  <em>
+    This is an experimental new service and we are keen for feedback: just reply
+    to this email.
+  </em>
+</p>
+
+<p>
+  Each month the OpenPrescribing team process data on primary care prescribing
+  across NHS England and produce a
+  <a href="{{ HOST }}{% url 'all_england' %}">national prescribing dashboard</a>
+  (as well as dashboards for every individual practice, CCG, STP and regional
+  team).
+</p>
+
+<p>Below are some of this month's key numbers.</p>
+
+
+<h3>Prescribing measures</h3>
+<p>
+  We track the distribution of prescribing behaviour across
+  {{entity_type}}s in NHS England on various measures
+  (<a href="{{ HOST }}{% url 'faq' %}#measureinterpret">read more about these</a>).
+</p>
+<p>
+  If all {{ entity_type}}s across England had prescribed at least as well
+  as the median {{ entity_type}} the monthly cost saving in
+  <strong>{{ date|date:"F Y" }}</strong> would have been:<br>
+  <span style="font-size: 150%">£{{ measure_savings.50|sigfigs:4|intcomma }}</span>
+</p>
+<p>
+  If they had prescribed as well as the best decile the saving would have been:<br>
+  <span style="font-size: 150%">£{{ measure_savings.10|sigfigs:4|intcomma }}</span>
+</p>
+<p>
+  <a href="{{ HOST }}{% url 'all_england' %}#perfsummary">
+    View prescribing measures &rarr;
+  </a>
+</p>
+
+
+<h3>Low priority prescribing</h3>
+<p>
+  NHS England produce a <a
+    href="https://www.england.nhs.uk/medicines/items-which-should-not-be-routinely-prescribed/">list
+    of products</a> considered low priority for funding by the NHS.
+  The total monthly spend on such products in {{ date|date:"F Y" }} was:
+  <strong>£{{ low_priority_total|sigfigs:4|intcomma }}</strong>
+</p>
+<p>
+  If every {{ entity_type }} had prescribed low priority products at least
+  as sparingly as the median {{ entity_type }} the monthly cost saving in
+  <strong>{{ date|date:"F Y" }}</strong> would have been:<br>
+  <span style="font-size: 150%">£{{ low_priority_savings.50|sigfigs:4|intcomma }}</span>
+</p>
+<p>
+  If they had prescribed at the level achieved by the best decile the saving
+  would have been:<br>
+  <span style="font-size: 150%">£{{ low_priority_savings.10|sigfigs:4|intcomma }}</span>
+</p>
+<p>
+  <a href="{{ HOST }}{% url 'all_england' %}#measure_lpzomnibus">
+    View distribution of low priority prescribing &rarr;
+  </a>
+</p>
+
+<h3>PPU cost savings</h3>
+<p>
+  There is wide variation in the unit cost of a number of medicines
+  prescribed across England, due to the way the reimbursement system is
+  structured.
+</p>
+<p>
+  We have calculated the potential monthly cost saving if every {{ entity_type }}
+  achieved the unit cost obtained by the best 10%.
+  In <strong>{{ date|date:"F Y" }}</strong> this was:<br>
+  <span style="font-size: 150%">£{{ ppu_savings|sigfigs:4|intcomma }}</span>
+</p>
+<p>
+  <a href="{{ HOST }}{% url 'all_england_price_per_unit' %}">
+    View cost savings breakdown &rarr;
+  </a>
+</p>
+
+<h3>Impact of price concessions</h3>
+<p>
+  We have estimated the additional spending due to price concessions on
+  out-of-stock products by taking the latest available prescribing data from
+  <strong>{{ ncso_spending.last_prescribing_date|date:"F Y" }}</strong>
+  and projecting forwards.
+  In <strong>{{ ncso_spending.month|date:"F Y" }}</strong> this amounts to:<br>
+  <span style="font-size: 150%">
+    £{{ ncso_spending.additional_cost|sigfigs:4|intcomma }}
+  </span>
+</p>
+<p>
+  <a href="{{ HOST }}{% url 'spending_for_all_england' %}">
+    View price concessions breakdown &rarr;
+  </a>
+</p>
+
+{% endblock %}

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -9,8 +9,9 @@
 
 <p>
   <em>
-    This is an experimental new service and we are keen for feedback: just reply
-    to this email.
+    This is the first iteration of our new experimental service and we are keen
+    for feedback. Please respond to this e-mail with thoughts and ideas for
+    features you would like to see.
   </em>
 </p>
 

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -27,14 +27,15 @@
 
 <h3>Prescribing measures</h3>
 <p>
-  We track the distribution of prescribing behaviour across
-  {{entity_type}}s in NHS England on various measures
+  We track the distribution of prescribing behaviour across {{entity_type}}s in
+  NHS England on various measures covering safety, efficacy and
+  cost-effectiveness
   (<a href="{{ HOST }}{% url 'faq' %}#measureinterpret">read more about these</a>).
 </p>
 <p>
-  If all {{ entity_type}}s across England had prescribed at least as well
-  as the median {{ entity_type}} the monthly cost saving in
-  <strong>{{ date|date:"F Y" }}</strong> would have been:<br>
+  If all {{ entity_type}}s across England had prescribed at least as well as
+  the median {{ entity_type}} on the cost-saving measures the monthly cost
+  saving in <strong>{{ date|date:"F Y" }}</strong> would have been:<br>
   <span style="font-size: 150%">£{{ measure_savings.50|sigfigs:4|intcomma }}</span>
 </p>
 <p>

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h2>OpenPrescribing National Prescribing Dashboard: monthly update</h2>
+<h2>OpenPrescribing All England Prescribing Dashboard: Monthly Update</h2>
 
 <p>
   <em>


### PR DESCRIPTION
This PR adds a sign-up form on the All England dashboard, plus a new management command `send_all_england_alerts` which does just that.

The emails themselves will no doubt be subject to many changes (they're currently just a copy of what's already on the dashboard) but they're not quite "user facing" until the point we actually decide to send them out so it might be acceptable to merge and start collecting signups before iterating on the email content.

Relates to #1553 and closes #1503 

Example alert email:
![localhost_8080_](https://user-images.githubusercontent.com/19630/58895358-a084b900-86eb-11e9-9add-af8b2ec3e375.png)
