### PR TITLE
Allow Analyse charts to handle duplicated practice names

### DIFF
--- a/openprescribing/media/js/src/analyse-bar-chart.js
+++ b/openprescribing/media/js/src/analyse-bar-chart.js
@@ -63,12 +63,12 @@ var barChart = {
       barOptions.yAxis.max = globalOptions.maxRatioItems;
     }
     barOptions.series = utils.createChartSeries(dataForMonth);
-    barOptions.xAxis.categories = this._getCategoriesFromSeries(barOptions.series[0]);
+    barOptions.xAxis.categories = this._getCategoriesFromData(dataForMonth);
     return new Highcharts.Chart(barOptions);
   },
 
-  _getCategoriesFromSeries: function (series) {
-    return series.data.map(function(d) { return d.name; });
+  _getCategoriesFromData: function (data) {
+    return data.map(function(d) { return d.name; });
   },
 
   update: function(chart, month, ratio, title, formatter, playing, yAxisMax) {
@@ -84,17 +84,14 @@ var barChart = {
       chart.animation = false;
     }
     chart.yAxis[0].update(newYAxisOptions, false);
-    if (month in this.barData) {
-      chart.series[0].setData(this.barData[month][ratio], false);
-    } else {
-      chart.series[0].setData([], false);
-    }
+    var data = (month in this.barData) ? this.barData[month][ratio] : [];
+    chart.series[0].setData(data, false);
     chart.yAxis[0].setExtremes(null, yAxisMax);
-    chart.xAxis[0].setCategories(this._getCategoriesFromSeries(chart.series[0]), false);
+    chart.xAxis[0].setCategories(this._getCategoriesFromData(data), false);
     try {
       chart.redraw();
     } catch (err) {
-      chart.series[0].setData(this.barData[month][ratio], true);
+      chart.series[0].setData(data, true);
     }
   },
 

--- a/openprescribing/media/js/src/analyse-bar-chart.js
+++ b/openprescribing/media/js/src/analyse-bar-chart.js
@@ -133,14 +133,22 @@ var barChart = {
           maxRatioActualCost = d.y;
         }
       });
-      newData[month].ratio_items = _.sortBy(newData[month].ratio_items, 'y');
-      newData[month].ratio_actual_cost = _.sortBy(newData[month].ratio_actual_cost, 'y');
+      newData[month].ratio_items = this._sortAndIndex(newData[month].ratio_items);
+      newData[month].ratio_actual_cost = this._sortAndIndex(newData[month].ratio_actual_cost);
     }
     return {
       barData: newData,
       maxRatioItems: maxRatioItems,
       maxRatioActualCost: maxRatioActualCost};
   },
+
+  _sortAndIndex: function(data) {
+    var sortedData = _.sortBy(data, 'y');
+    for (var index = 0; index < sortedData.length; index++) {
+      sortedData[index].x = index;
+    }
+    return sortedData;
+  }
 };
 
 module.exports = barChart;

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -427,8 +427,8 @@ var analyseChart = {
     } else {
       yAxisMax = _this.globalOptions.maxRatioItems;
     }
-    console.log('ratio: ' + _this.globalOptions.chartValues.ratio);
-    console.log(_this.globalOptions);
+    // console.log('ratio: ' + _this.globalOptions.chartValues.ratio);
+    // console.log(_this.globalOptions);
     barChart.update(_this.globalOptions.barChart,
                     _this.globalOptions.activeMonth,
                     _this.globalOptions.chartValues.ratio,

--- a/openprescribing/media/js/src/highcharts-options.js
+++ b/openprescribing/media/js/src/highcharts-options.js
@@ -179,6 +179,15 @@ barOptions.xAxis.type = 'category';
 barOptions.legend.enabled = false;
 barOptions.xAxis.labels = {
   formatter: function() {
+    // When animating chart transitions we can sometimes end up in a state
+    // where Highcharts want to format a label for an x-value for which we have
+    // no corresponding category e.g if we're transitioning to a chart with
+    // fewer practices then, during the transition, a portion of the x-axis
+    // will not correspond to any practice. In this case, we want an empty
+    // label rather than an error
+    if ( ! this.value.length) {
+      return '';
+    }
     var str = this.value.substring(0, 17);
     str += (this.value.length > 17) ? '...' : '';
     return str;


### PR DESCRIPTION
Closes #1119 

From some brief testing it's possible that this will also solve #1368, although that will need some testing on staging as it's not 100% obvious what counts as "working" for this feature.

Sadly it doesn't help with #1732