### PR TITLE
Add manager method for filtering "active" regional teams

### DIFF
--- a/openprescribing/api/views_org_codes.py
+++ b/openprescribing/api/views_org_codes.py
@@ -117,7 +117,7 @@ def _get_stps_like_code(q, is_exact=False):
 
 
 def _get_regional_teams_like_code(q, is_exact=False):
-    orgs = RegionalTeam.objects.filter(close_date__isnull=True)
+    orgs = RegionalTeam.objects.active()
     if is_exact:
         orgs = orgs.filter(
             Q(code=q) | Q(name=q)

--- a/openprescribing/api/views_org_location.py
+++ b/openprescribing/api/views_org_location.py
@@ -57,7 +57,7 @@ def _get_stps(org_codes, centroids):
 
 
 def _get_regional_teams(org_codes, centroids):
-    results = RegionalTeam.objects.filter(close_date__isnull=True)
+    results = RegionalTeam.objects.active()
     if org_codes:
         results = results.filter(code__in=org_codes)
     return results.values(

--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -67,6 +67,12 @@ class Section(models.Model):
         ordering = ["bnf_id"]
 
 
+class RegionalTeamManager(models.Manager):
+
+    def active(self):
+        return self.exclude(close_date__isnull=False).exclude(pct=None)
+
+
 class RegionalTeam(models.Model):
     code = models.CharField(max_length=3, primary_key=True)
     name = models.CharField(max_length=200, null=True, blank=True)
@@ -74,6 +80,8 @@ class RegionalTeam(models.Model):
     close_date = models.DateField(null=True, blank=True)
     address = models.CharField(max_length=400, null=True, blank=True)
     postcode = models.CharField(max_length=10, null=True, blank=True)
+
+    objects = RegionalTeamManager()
 
     def __str__(self):
         return self.name

--- a/openprescribing/frontend/tests/fixtures/orgs.json
+++ b/openprescribing/frontend/tests/fixtures/orgs.json
@@ -22,6 +22,17 @@
   }
 },
 {
+  "model": "frontend.regionalteam",
+  "pk": "Y60",
+  "fields": {
+    "name": "MIDLANDS COMMISSIONING REGION",
+    "open_date": "2019-04-01",
+    "close_date": null,
+    "address": "2-4 VICTORIA HOUSE, CAPITAL PARK, FULBOURN, CAMBRIDGE",
+    "postcode": "CB21 5XB"
+  }
+},
+{
   "model": "frontend.stp",
   "pk": "E54000006",
   "fields": {

--- a/openprescribing/frontend/tests/test_models.py
+++ b/openprescribing/frontend/tests/test_models.py
@@ -7,6 +7,7 @@ from frontend.models import MailLog
 from frontend.models import PCT
 from frontend.models import Practice
 from frontend.models import Presentation
+from frontend.models import RegionalTeam
 from frontend.models import SearchBookmark
 from frontend.models import Section
 from frontend.models import User
@@ -240,3 +241,19 @@ class TestPresentationDMDLinks(TestCase):
         # exercised.
         for p in Presentation.objects.all():
             p.dmd_info()
+
+
+class RegionalTeamTest(TestCase):
+
+    fixtures = ['orgs']
+
+    def test_regional_team_with_no_pcts_excluded(self):
+        all_teams = RegionalTeam.objects.all()
+        empty_team = RegionalTeam.objects.get(pk='Y60')
+        self.assertEqual(empty_team.close_date, None)
+        active_teams = RegionalTeam.objects.active()
+        # This length check is not redundant: there are ways of attempting to
+        # exclude empty teams which produce a join that returns multiple
+        # instances of each team and we want to ensure that this doesn't happen
+        self.assertEqual(len(active_teams), len(all_teams) - 1)
+        self.assertNotIn(empty_team, active_teams)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.urlresolvers import get_resolver
 from django.db import connection
-from django.db.models import Avg, Count, Sum
+from django.db.models import Avg, Sum
 from django.http import Http404
 from django.http import HttpResponse
 from django.http.response import HttpResponseRedirect
@@ -250,9 +250,7 @@ def stp_home_page(request, stp_code):
 def all_regional_teams(request):
     # NHS reorganisations sometimes include regions before CCGs have
     # been assigned, hence the filter on an aggregation here:
-    regional_teams = RegionalTeam.objects.annotate(
-        num_ccgs=Count('pct')).filter(
-            close_date__isnull=True, num_ccgs__gt=0).order_by('name')
+    regional_teams = RegionalTeam.objects.active().order_by('name')
     context = {
         'regional_teams': regional_teams
     }


### PR DESCRIPTION
We have some regional teams imported which don't (or don't yet) have any
PCTs belonging to them. These are naturally excluded from prescribing
and practice stats endpoints due to the fact that they can't have any
prescribing data associated with them but they can show up in other
endpoints which makes for confusion.

Here we define a manager method we can use everywhere to exclude these
teams.

Fixes #1750