### PR TITLE
Improve dm+d search

### DIFF
--- a/openprescribing/dmd2/fixtures/README
+++ b/openprescribing/dmd2/fixtures/README
@@ -1,0 +1,12 @@
+This directory contains the following fixtures:
+
+dmd-search-fixtures.json
+------------------------
+
+Generated with:
+
+    ./manage.py generate_dmd_fixture --include-reverse-relations 318412000
+
+Contains all objects in dm+d family for VMP 318412000 (Acebutolol 100mg
+capsules), which includes several AMPs which are not available, are invalid,
+and/or have no BNF code.

--- a/openprescribing/dmd2/fixtures/dmd-search-fixtures.json
+++ b/openprescribing/dmd2/fixtures/dmd-search-fixtures.json
@@ -1,0 +1,479 @@
+[
+{
+  "model": "dmd2.vmp",
+  "pk": 318412000,
+  "fields": {
+    "vpiddt": null,
+    "vpidprev": null,
+    "vtm": 68088000,
+    "invalid": false,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "basis": 1,
+    "nmdt": null,
+    "nmprev": null,
+    "basis_prev": null,
+    "nmchange": null,
+    "combprod": null,
+    "pres_stat": 1,
+    "sug_f": false,
+    "glu_f": false,
+    "pres_f": false,
+    "cfc_f": false,
+    "non_avail": null,
+    "non_availdt": null,
+    "df_ind": 1,
+    "udfs": "1.000",
+    "udfs_uom": 428641000,
+    "unit_dose_uom": 428641000,
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 9703211000001108,
+  "fields": {
+    "invalid": true,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (A A H Pharmaceuticals Ltd)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 3144701000001104,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 10347111000001100,
+  "fields": {
+    "invalid": false,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (Alliance Healthcare (Distribution) Ltd)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 2089901000001107,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 4814811000001108,
+  "fields": {
+    "invalid": false,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (Kent Pharmaceuticals Ltd)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 2073701000001100,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 17747811000001100,
+  "fields": {
+    "invalid": true,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (Phoenix Healthcare Distribution Ltd)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 17845311000001104,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 15057611000001104,
+  "fields": {
+    "invalid": true,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (Sigma Pharmaceuticals Plc)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 2087601000001106,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 21735411000001105,
+  "fields": {
+    "invalid": true,
+    "vmp": 318412000,
+    "nm": "Acebutolol 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Acebutolol 100mg capsules (Waymade Healthcare Plc)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 2091401000001103,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 9,
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.amp",
+  "pk": 632811000001105,
+  "fields": {
+    "invalid": false,
+    "vmp": 318412000,
+    "nm": "Sectral 100mg capsules",
+    "abbrevnm": null,
+    "descr": "Sectral 100mg capsules (Sanofi)",
+    "nmdt": null,
+    "nm_prev": null,
+    "supp": 9190711000001101,
+    "lic_auth": 1,
+    "lic_auth_prev": null,
+    "lic_authchange": null,
+    "lic_authchangedt": null,
+    "combprod": null,
+    "flavour": null,
+    "ema": false,
+    "parallel_import": false,
+    "avail_restrict": 1,
+    "bnf_code": "0204000C0BBAAAA"
+  }
+},
+{
+  "model": "dmd2.vmpp",
+  "pk": 1098611000001105,
+  "fields": {
+    "invalid": false,
+    "nm": "Acebutolol 100mg capsules 84 capsule",
+    "vmp": 318412000,
+    "qtyval": "84.00",
+    "qty_uom": 428641000,
+    "combpack": null,
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.vtm",
+  "pk": 68088000,
+  "fields": {
+    "invalid": false,
+    "nm": "Acebutolol",
+    "abbrevnm": null,
+    "vtmidprev": null,
+    "vtmiddt": null
+  }
+},
+{
+  "model": "dmd2.basisofname",
+  "pk": 1,
+  "fields": {
+    "descr": "rINN - Recommended International Non-proprietary"
+  }
+},
+{
+  "model": "dmd2.virtualproductpresstatus",
+  "pk": 1,
+  "fields": {
+    "descr": "Valid as a prescribable product"
+  }
+},
+{
+  "model": "dmd2.dfindicator",
+  "pk": 1,
+  "fields": {
+    "descr": "Discrete"
+  }
+},
+{
+  "model": "dmd2.unitofmeasure",
+  "pk": 428641000,
+  "fields": {
+    "cddt": "2008-11-01",
+    "cdprev": 3316911000001105,
+    "descr": "capsule"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 9703311000001100,
+  "fields": {
+    "invalid": true,
+    "nm": "Acebutolol 100mg capsules (A A H Pharmaceuticals Ltd) 84 capsule",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 9703211000001108,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": null,
+    "disc": 1,
+    "discdt": "2017-08-08",
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 3144701000001104,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "A A H Pharmaceuticals Ltd"
+  }
+},
+{
+  "model": "dmd2.licensingauthority",
+  "pk": 1,
+  "fields": {
+    "descr": "Medicines - MHRA/EMA"
+  }
+},
+{
+  "model": "dmd2.availabilityrestriction",
+  "pk": 9,
+  "fields": {
+    "descr": "Not available"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 10347211000001106,
+  "fields": {
+    "invalid": false,
+    "nm": "Acebutolol 100mg capsules (Alliance Healthcare (Distribution) Ltd) 84 capsule",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 10347111000001100,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": null,
+    "disc": 1,
+    "discdt": "2010-05-25",
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 2089901000001107,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Alliance Healthcare (Distribution) Ltd"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 4814911000001103,
+  "fields": {
+    "invalid": false,
+    "nm": "Acebutolol 100mg capsules (Kent Pharmaceuticals Ltd) 84 capsule 6 x 14 capsules",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 4814811000001108,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": "6 x 14 capsules",
+    "disc": 1,
+    "discdt": "2007-03-27",
+    "bnf_code": "0204000C0AAAAAA"
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 2073701000001100,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Kent Pharmaceuticals Ltd"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 17747911000001105,
+  "fields": {
+    "invalid": true,
+    "nm": "Acebutolol 100mg capsules (Phoenix Healthcare Distribution Ltd) 84 capsule",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 17747811000001100,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": null,
+    "disc": 1,
+    "discdt": "2018-10-01",
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 17845311000001104,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Phoenix Healthcare Distribution Ltd"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 15057711000001108,
+  "fields": {
+    "invalid": true,
+    "nm": "Acebutolol 100mg capsules (Sigma Pharmaceuticals Plc) 84 capsule",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 15057611000001104,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": null,
+    "disc": 1,
+    "discdt": "2018-10-02",
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 2087601000001106,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Sigma Pharmaceuticals Plc"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 21735511000001109,
+  "fields": {
+    "invalid": true,
+    "nm": "Acebutolol 100mg capsules (Waymade Healthcare Plc) 84 capsule",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 21735411000001105,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": null,
+    "disc": 1,
+    "discdt": "2018-10-05",
+    "bnf_code": null
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 2091401000001103,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Waymade Healthcare Plc"
+  }
+},
+{
+  "model": "dmd2.ampp",
+  "pk": 1389011000001108,
+  "fields": {
+    "invalid": false,
+    "nm": "Sectral 100mg capsules (Sanofi) 84 capsule 6 x 14 capsules",
+    "abbrevnm": null,
+    "vmpp": 1098611000001105,
+    "amp": 632811000001105,
+    "combpack": null,
+    "legal_cat": 3,
+    "subp": "6 x 14 capsules",
+    "disc": null,
+    "discdt": null,
+    "bnf_code": "0204000C0BBAAAA"
+  }
+},
+{
+  "model": "dmd2.supplier",
+  "pk": 9190711000001101,
+  "fields": {
+    "cddt": null,
+    "cdprev": null,
+    "invalid": false,
+    "descr": "Sanofi"
+  }
+},
+{
+  "model": "dmd2.availabilityrestriction",
+  "pk": 1,
+  "fields": {
+    "descr": "None"
+  }
+},
+{
+  "model": "dmd2.legalcategory",
+  "pk": 3,
+  "fields": {
+    "descr": "POM"
+  }
+},
+{
+  "model": "dmd2.discontinuedind",
+  "pk": 1,
+  "fields": {
+    "descr": "Discontinued Flag"
+  }
+}
+]
+

--- a/openprescribing/dmd2/forms.py
+++ b/openprescribing/dmd2/forms.py
@@ -1,0 +1,56 @@
+from django import forms
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Field, ButtonHolder, Submit
+from crispy_forms.bootstrap import InlineCheckboxes
+
+
+obj_types_choices = [
+    ('vtm', 'VTMs'),
+    ('vmp', 'VMPs'),
+    ('amp', 'AMPs'),
+    ('vmpp', 'VMPPs'),
+    ('ampp', 'AMPPs'),
+]
+
+include_choices = [
+    ('unavailable', 'Unavailable items'),
+    ('invalid', 'Invalid items'),
+    ('no_bnf_code', 'Items with no BNF code'),
+]
+
+class SearchForm(forms.Form):
+    q = forms.CharField(
+        label='Query or SNOMED code',
+        min_length=3,
+    )
+    obj_types = forms.MultipleChoiceField(
+        label='Search...',
+        choices=obj_types_choices,
+        required=False,
+        initial=[tpl[0] for tpl in obj_types_choices],
+    )
+    include = forms.MultipleChoiceField(
+        label='Include...',
+        choices=include_choices,
+        required=False,
+    )
+
+    # This is only used in tests
+    max_results_per_obj_type = forms.IntegerField(
+        required=False,
+        widget=forms.HiddenInput(),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(SearchForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_method = 'GET'
+        self.helper.layout = Layout(
+            Field('q'),
+            InlineCheckboxes('obj_types'),
+            InlineCheckboxes('include'),
+            ButtonHolder(
+                Submit('submit', 'Search'),
+            )
+        )

--- a/openprescribing/dmd2/forms.py
+++ b/openprescribing/dmd2/forms.py
@@ -34,6 +34,7 @@ class SearchForm(forms.Form):
         label='Include...',
         choices=include_choices,
         required=False,
+        help_text='Unavailable items are not available to be prescribed and/or have been discontinued.',
     )
 
     # This is only used in tests

--- a/openprescribing/dmd2/management/commands/generate_dmd_fixture.py
+++ b/openprescribing/dmd2/management/commands/generate_dmd_fixture.py
@@ -10,6 +10,7 @@ have foreign keys to, such as UnitOfMeasure or VTM.
 from django.core import serializers
 from django.core.management import BaseCommand
 from django.db.models.fields.related import ForeignKey
+from django.db.models.fields.reverse_related import ManyToOneRel, OneToOneRel
 
 from dmd2.models import VMP, VMPP, AMP, AMPP
 
@@ -19,20 +20,31 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('ids', nargs='+')
+        parser.add_argument('--include-reverse-relations', action='store_true')
 
     def handle(self, *args, **kwargs):
+        classes_we_care_about = (VMP, VMPP, AMP, AMPP)
         ids = kwargs['ids']
         objs = []
-        objs.extend(VMP.objects.filter(id__in=ids))
-        objs.extend(VMPP.objects.filter(id__in=ids))
-        objs.extend(AMP.objects.filter(id__in=ids))
-        objs.extend(AMPP.objects.filter(id__in=ids))
+        for cls in classes_we_care_about:
+            objs.extend(cls.objects.filter(id__in=ids))
 
         for obj in objs:
-            for f in obj._meta.fields:
+            for f in obj._meta.get_fields():
                 if isinstance(f, ForeignKey):
                     related_obj = getattr(obj, f.name)
                     if related_obj is not None and related_obj not in objs:
                         objs.append(related_obj)
+
+                if (
+                        kwargs['include_reverse_relations']
+                        and isinstance(obj, classes_we_care_about)
+                        and isinstance(f, ManyToOneRel)
+                        and f.related_model in classes_we_care_about
+                    ):
+                    related_objs = getattr(obj, f.get_accessor_name()).all()
+                    for related_obj in related_objs:
+                        if related_obj not in objs:
+                            objs.append(related_obj)
 
         print(serializers.serialize('json', objs, indent=2))

--- a/openprescribing/dmd2/managers.py
+++ b/openprescribing/dmd2/managers.py
@@ -9,16 +9,23 @@ class DMDObjectQuerySet(models.QuerySet):
     def valid(self):
         return self.exclude(invalid=True)
 
+    def available(self):
+        raise NotImplementedError
+
+    def with_bnf_code(self):
+        return self.filter(bnf_code__isnull=False)
+
     def valid_and_available(self):
         return self.valid().available()
-
-    def available(self, q):
-        raise NotImplementedError
 
 
 class VTMQuerySet(DMDObjectQuerySet):
     def available(self):
         # There are no fields on VTM relating to availability
+        return self
+
+    def with_bnf_code(self):
+        # We can't match BNF codes against VTMs
         return self
 
 

--- a/openprescribing/dmd2/models.py
+++ b/openprescribing/dmd2/models.py
@@ -46,6 +46,12 @@ class VTM(models.Model):
     def title(self):
         return self.nm
 
+    def status(self):
+        if self.invalid:
+            return 'invalid'
+        else:
+            return None
+
 
 class VMP(models.Model):
     class Meta:
@@ -191,6 +197,18 @@ class VMP(models.Model):
 
     def title(self):
         return self.nm
+
+    def status(self):
+        tokens = []
+
+        if self.invalid:
+            tokens.append('invalid')
+        if not self.bnf_code:
+            tokens.append('no BNF code')
+        if self.non_avail_id == 1:
+            tokens.append('not available')
+
+        return ', '.join(tokens) or None
 
 
 class VPI(models.Model):
@@ -445,6 +463,18 @@ class AMP(models.Model):
     def title(self):
         return self.descr
 
+    def status(self):
+        tokens = []
+
+        if self.invalid:
+            tokens.append('invalid')
+        if not self.bnf_code:
+            tokens.append('no BNF code')
+        if self.avail_restrict_id == 9:
+            tokens.append('not available')
+
+        return ', '.join(tokens) or None
+
 
 class ApIng(models.Model):
     class Meta:
@@ -582,6 +612,16 @@ class VMPP(models.Model):
     def title(self):
         return self.nm
 
+    def status(self):
+        tokens = []
+
+        if self.invalid:
+            tokens.append('invalid')
+        if not self.bnf_code:
+            tokens.append('no BNF code')
+
+        return ', '.join(tokens) or None
+
 
 class Dtinfo(models.Model):
     class Meta:
@@ -688,6 +728,18 @@ class AMPP(models.Model):
 
     def title(self):
         return self.nm
+
+    def status(self):
+        tokens = []
+
+        if self.invalid:
+            tokens.append('invalid')
+        if not self.bnf_code:
+            tokens.append('no BNF code')
+        if self.disc_id == 1:
+            tokens.append('not available')
+
+        return ', '.join(tokens) or None
 
 
 class PackInfo(models.Model):

--- a/openprescribing/dmd2/search.py
+++ b/openprescribing/dmd2/search.py
@@ -1,37 +1,54 @@
-from collections import OrderedDict
-
 from .models import VTM, VMP, VMPP, AMP, AMPP
 
 
-def search(q):
+NUM_RESULTS_PER_OBJ_TYPE = 10
+
+
+def search(q, obj_types, include):
     try:
         int(q)
     except ValueError:
-        return search_by_term(q)
+        return search_by_term(q, obj_types, include)
 
     return search_by_snomed_code(q)
 
 
-def search_by_term(q):
-    results = OrderedDict()
+def search_by_term(q, obj_types, include):
+    results = []
 
     for cls in [VTM, VMP, VMPP, AMP, AMPP]:
-        objs = list(cls.objects.valid_and_available().search(q))
+        if cls.obj_type not in obj_types:
+            continue
+
+        qs = cls.objects
+        if 'invalid' not in include:
+            qs = qs.valid()
+        if 'unavailable' not in include:
+            qs = qs.available()
+        if 'no_bnf_code' not in include:
+            qs = qs.with_bnf_code()
+        qs = qs.search(q)
+
+        objs = list(qs)
         if objs:
-            results[cls._meta.verbose_name_plural] = objs
+            results.append({
+                'cls': cls,
+                'objs': objs,
+            })
 
     return results
 
 
 def search_by_snomed_code(q):
-    results = OrderedDict()
-
     for cls in [VTM, VMP, VMPP, AMP, AMPP]:
         try:
             obj = cls.objects.get(pk=q)
         except cls.DoesNotExist:
             continue
 
-        results[cls._meta.verbose_name_plural] = [obj]
+        return [{
+            'cls': cls,
+            'objs': [obj],
+        }]
 
-    return results
+    return []

--- a/openprescribing/dmd2/templates/dmd/search.html
+++ b/openprescribing/dmd2/templates/dmd/search.html
@@ -1,25 +1,32 @@
 {% extends "base.html" %}
+
+{% load crispy_forms_tags %}
+
 {% block content %}
 <h1>dm+d browser</h1>
+<hr />
 
-<form class="form-inline">
-  <div class="form-group">
-    <label class="sr-only" for="search-query">Query</label>
-    <input name="q" value="{{ q|default_if_none:'' }}" type="text" class="form-control" id="search-query" placeholder="Query or SNOMED code">
-  </div>
-  <button type="submit" class="btn btn-default">Search</button>
-</form>
+{% crispy form %}
 
-{% if q %}
-{% for verbose_name_plural, objs in results.items %}
-<h2>{{ verbose_name_plural }}</h2>
-<ul>
-{% for obj in objs %}
-<li><a href="{% url 'dmd_obj' obj.obj_type obj.id %}">{{ obj.title }}</a></li>
-{% endfor %}
-</ul>
-{% empty %}
-<p>No results found.</p>
-{% endfor %}
+{% if results != None %}
+  <hr />
+
+  {% for result in results %}
+    <h2>{{ result.obj_type_human_plural }} ({{ result.num_hits }})</h2>
+    <ul>
+      {% for obj in result.objs %}
+        <li>
+          <a href="{% url 'dmd_obj' obj.obj_type obj.id %}">{{ obj.title }}</a>
+          {% if obj.status %}({{ obj.status }}){% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+
+    {% if result.link_to_more %}
+    <a href="{{ result.link_to_more }}">Show all {{ result.obj_type_human_plural }}</a>
+    {% endif %}
+  {% empty %}
+    <p>No results found.</p>
+  {% endfor %}
 {% endif %}
 {% endblock %}

--- a/openprescribing/dmd2/tests/test_search.py
+++ b/openprescribing/dmd2/tests/test_search.py
@@ -1,0 +1,99 @@
+from django.test import TestCase
+
+from dmd2.models import AMP, AMPP, VMP, VMPP
+from dmd2.search import search
+
+
+class TestSearch(TestCase):
+    fixtures = ['dmd-search-fixtures']
+
+    def test_by_snomed_code(self):
+        self.assertSearchResults(
+            {'q': '318412000'},
+            {VMP: [318412000]}
+        )
+
+    def test_by_term(self):
+        self.assertSearchResults(
+            {'q': 'sanofi'},
+            {AMP: [632811000001105], AMPP: [1389011000001108]}
+        )
+
+    def test_with_obj_types(self):
+        self.assertSearchResults(
+            {'q': 'acebutolol', 'obj_types': ['vmp']},
+            {VMP: [318412000]}
+        )
+
+    def test_include_invalid(self):
+        # In our test data, all invalid AMPs are also unavailable and have no
+        # BNF code, so we need to include those objects here.
+        self.assertSearchResults(
+            {
+                'q': 'phoenix',
+                'obj_types': ['amp'],
+                'include': ['unavailable', 'no_bnf_code', 'invalid'],
+            },
+            {AMP: [17747811000001100]}
+        )
+        self.assertSearchResults(
+            {
+                'q': 'phoenix',
+                'obj_types': ['amp'],
+                'include': ['unavailable', 'no_bnf_code'],
+            },
+            {}
+        )
+
+    def test_include_unavailable(self):
+        self.assertSearchResults(
+            {
+                'q': 'kent',
+                'obj_types': ['amp'],
+                'include': ['unavailable'],
+            },
+            {AMP: [4814811000001108]}
+        )
+        self.assertSearchResults(
+            {
+                'q': 'kent',
+                'obj_types': ['amp'],
+                'include': [],
+            },
+            {}
+        )
+
+    def test_include_no_bnf_codes(self):
+        # In our test data, all AMPs without a BNF code are also unavailable
+        # and invalid, so we need to include those objects here.
+        self.assertSearchResults(
+            {
+                'q': 'phoenix',
+                'obj_types': ['amp'],
+                'include': ['unavailable', 'invalid', 'no_bnf_code'],
+            },
+            {AMP: [17747811000001100]}
+        )
+        self.assertSearchResults(
+            {
+                'q': 'phoenix',
+                'obj_types': ['amp'],
+                'include': ['unavailable', 'invalid'],
+            },
+            {}
+        )
+
+    def assertSearchResults(self, search_params, exp_result_ids):
+        kwargs = {
+            'q': '',
+            'obj_types': ['vmp', 'vmpp', 'amp', 'ampp'],
+            'include': [],
+        }
+        kwargs.update(search_params)
+        results = search(**kwargs)
+        result_ids = {
+            result['cls']: [obj.pk for obj in result['objs']]
+            for result in results
+        }
+
+        self.assertEqual(result_ids, exp_result_ids)

--- a/openprescribing/dmd2/tests/test_views.py
+++ b/openprescribing/dmd2/tests/test_views.py
@@ -1,0 +1,102 @@
+from django.test import TestCase
+
+
+class TestSearchView(TestCase):
+    fixtures = ['dmd-search-fixtures']
+
+    def test_search_returning_no_results(self):
+        rsp = self._get('bananas')
+
+        # We expect to see "No results found".
+        self.assertContains(rsp, 'No results found.')
+
+    def test_search_by_returning_one_result(self):
+        rsp = self._get('acebutolol', obj_types=['vmp'])
+
+        # We expect to be redirected to the page for the one matching object.
+        self.assertRedirects(rsp, '/dmd/vmp/318412000/')
+
+    def test_search_returning_many_results(self):
+        rsp = self._get('acebutolol')
+
+        # We expect to see lists of the matching objects.
+        self.assertContains(rsp, 'Virtual Medicinal Products (1)')
+        self.assertContains(rsp, 'Acebutolol 100mg capsules')
+        self.assertContains(rsp, 'Virtual Medicinal Product Packs (1)')
+        self.assertContains(rsp, 'Acebutolol 100mg capsules 84 capsule')
+
+    def test_search_for_all_obj_types_shows_limited_results(self):
+        rsp = self._get(
+            'acebutolol', 
+            include=['invalid', 'unavailable', 'no_bnf_code'],
+            max_results_per_obj_type=5,
+        )
+
+        # We expect to see 5 out of 6 of the AMPPs, and a link to show all of them.
+        self.assertContains(rsp, 'Actual Medicinal Product Packs (6)')
+        for supplier in [
+            'A A H Pharmaceuticals Ltd',
+            'Alliance Healthcare (Distribution) Ltd',
+            'Kent Pharmaceuticals Ltd',
+            'Phoenix Healthcare Distribution Ltd',
+            'Sigma Pharmaceuticals Plc',
+        ]:
+            self.assertContains(rsp, supplier)
+        self.assertNotContains(rsp, 'Waymade Healthcare Plc')
+        self.assertContains(rsp, 'Show all Actual Medicinal Product Packs')
+
+        # We don't expect to see a link to show all VMPPs, since there aren't
+        # more than 5.
+        self.assertNotContains(rsp, 'Show all Virtual Medicinal Product Packs')
+
+    def test_search_for_one_obj_type_shows_all_results(self):
+        rsp = self._get(
+            'acebutolol', 
+            obj_types=['ampp'],
+            include=['invalid', 'unavailable', 'no_bnf_code'],
+            max_results_per_obj_type=5,
+        )
+
+        # We expect to see all 6 AMPPs, and no link to show all of them.
+        for supplier in [
+            'A A H Pharmaceuticals Ltd',
+            'Alliance Healthcare (Distribution) Ltd',
+            'Kent Pharmaceuticals Ltd',
+            'Phoenix Healthcare Distribution Ltd',
+            'Sigma Pharmaceuticals Plc',
+            'Waymade Healthcare Plc',
+        ]:
+            self.assertContains(rsp, supplier)
+
+        self.assertNotContains(rsp, 'Show all Actual Medicinal Product Packs')
+
+    def test_search_by_snomed_code_returning_one_result(self):
+        rsp = self._get('318412000')
+
+        # We expect to be redirected to the page for the one matching object.
+        self.assertRedirects(rsp, '/dmd/vmp/318412000/')
+
+    def test_search_by_snomed_code_returning_no_results(self):
+        rsp = self._get('12345')
+
+        # We expect to see "No results found".
+        self.assertContains(rsp, 'No results found.')
+
+    def test_with_invalid_form(self):
+        rsp = self._get('aa')
+
+        # We expect to see an error message because the search string was too short.
+        self.assertContains(rsp, 'Ensure this value has at least')
+
+        # We don't expect to see that a search has happened.
+        self.assertNotContains(rsp, 'No results found.')
+
+
+    def _get(self, q, **extra_params):
+        params = {
+            'q': q,
+            'obj_types': ['vtm', 'vmp', 'amp', 'vmpp', 'ampp'],
+            'include': [],
+        }
+        params.update(extra_params)
+        return self.client.get('/dmd/', params)

--- a/openprescribing/dmd2/urls.py
+++ b/openprescribing/dmd2/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^$', views.search_view, name="search"),
+    url(r'^$', views.search_view, name="dmd_search"),
     url(r'^(?P<obj_type>\w+)/(?P<id>\d+)/$', views.dmd_obj_view, name="dmd_obj"),
     url(r'^vmp/(?P<vmp_id>\d+)/relationships/$', views.vmp_relationships_view, name="vmp_relationships"),
     url(r'^bnf/(?P<bnf_code>\w+)/relationships/$', views.bnf_code_relationships_view, name="bnf_code_relationships"),


### PR DESCRIPTION
* Allow searching by object type
* Allow excluding invalid/unavailble/missing BNF code
* Only show 10 results per object type if multiple object types returned
* Show invalid/unavailable/missing BNF code in results
* Add minimum length for search string