### PR TITLE
Fix triple counting of All England measure numbers

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1328,7 +1328,13 @@ def all_england_ppu_savings(entity_type, date):
 def all_england_measure_savings(entity_type, date):
     return (
         MeasureValue.objects
-        .filter(month=date, practice_id__isnull=(entity_type == 'CCG'))
+        .filter(
+            month=date,
+            practice_id__isnull=(entity_type == 'CCG'),
+            # Practice level data also has `pct_id` set, but we want to exclude
+            # STP/RegionalTeam data
+            pct_id__isnull=False
+        )
         .exclude(measure_id='lpzomnibus')
         .aggregate_cost_savings()
     )
@@ -1344,7 +1350,10 @@ def all_england_low_priority_savings(entity_type, date):
         MeasureValue.objects.filter(
             month=date,
             measure_id='lpzomnibus',
-            practice_id__isnull=(entity_type == 'CCG')
+            practice_id__isnull=(entity_type == 'CCG'),
+            # Practice level data also has `pct_id` set, but we want to exclude
+            # STP/RegionalTeam data
+            pct_id__isnull=False
         )
         .calculate_cost_savings(target_costs)
     )
@@ -1355,7 +1364,10 @@ def all_england_low_priority_total(entity_type, date):
         MeasureValue.objects.filter(
             month=date,
             measure_id='lpzomnibus',
-            practice_id__isnull=(entity_type == 'CCG')
+            practice_id__isnull=(entity_type == 'CCG'),
+            # Practice level data also has `pct_id` set, but we want to exclude
+            # STP/RegionalTeam data
+            pct_id__isnull=False
         )
         .aggregate(total=Sum('numerator'))
     )


### PR DESCRIPTION
Some of the All England totals are generated by aggregating CCG level data from
the MeasureValues table. It's not possible to select CCG level data by
selecting only rows where `pct_id` is not NULL because practice level
data also has the `pct_id` set. So we have to instead select where
`practice_id` is NULL.

Previously, including the extra condition that `pct_id` be not NULL was
redundant as this was true for all rows. However with the inclusion of
STP and Regional Team data this stopped being true and our query was now
returning CCG, STP and Regional Team data which resulting in a triple
counting of some of the All England numbers.