### PR TITLE
Remove reference to email confirmation link

### DIFF
--- a/openprescribing/templates/account/email/email_confirmation_signup_message.html
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.html
@@ -3,8 +3,6 @@
 
 <p>You've been subscribed to alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
 
-<p>Please confirm your email address by following <a href="{{ activate_url }}">this link</a>.</p>
-
 <p>You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.</p>
 
 <p>Thanks,</p>

--- a/openprescribing/templates/account/email/email_confirmation_signup_message.txt
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.txt
@@ -2,8 +2,6 @@
 
 You've been subscribed to alerts about {{ user.profile.most_recent_bookmark.topic }}.
 
-Please confirm your email address by visiting {{ activate_url }}
-
 You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.
 
 {% endautoescape %}


### PR DESCRIPTION
Since #1397 was merged we no longer require confirmation of email
addresses, but we still send verification emails for the tedious reasons
outlined in that PR. However these emails still contain a line about
confirming your address by clicking the link which is confusing, so this
PR removes it.

Closes #1815