### PR TITLE
Improve MatrixStore performance

### DIFF
--- a/openprescribing/matrixstore/connection.py
+++ b/openprescribing/matrixstore/connection.py
@@ -1,8 +1,8 @@
 import os.path
 import sqlite3
 
-from .matrix_ops import zeros_like
-from .serializer import serialize, deserialize
+from .serializer import deserialize
+from .sql_functions import MatrixSum
 
 
 class MatrixStore(object):
@@ -60,32 +60,3 @@ def convert_value(value):
         return deserialize(value)
     else:
         return value
-
-
-class MatrixSum(object):
-
-    accumulator = None
-
-    def step(self, value):
-        if value is None:
-            return
-        matrix = deserialize(value)
-        if self.accumulator is None:
-            self.accumulator = zeros_like(matrix)
-        self.accumulator += matrix
-
-    def finalize(self):
-        if self.accumulator is not None:
-            # Operations on SciPy sparse matrices sometimes return matrix
-            # objects rather than the standard 2-dimensional numpy array. See:
-            # https://github.com/scipy/scipy/issues/7510
-            # We always want array values (for one thing, pyarrow can't
-            # serialize matrix instances out of the box) and so we convert them
-            # here by grabbing the underlying array from the matrix object, if
-            # that's what we've got. (Note: this is the documented conversion
-            # method; we're not using a private API)
-            try:
-                value = self.accumulator.A
-            except AttributeError:
-                value = self.accumulator
-            return sqlite3.Binary(serialize(value))

--- a/openprescribing/matrixstore/connection.py
+++ b/openprescribing/matrixstore/connection.py
@@ -1,7 +1,7 @@
 import os.path
 import sqlite3
 
-from .matrix_ops import zero_like
+from .matrix_ops import zeros_like
 from .serializer import serialize, deserialize
 
 
@@ -71,7 +71,7 @@ class MatrixSum(object):
             return
         matrix = deserialize(value)
         if self.accumulator is None:
-            self.accumulator = zero_like(matrix)
+            self.accumulator = zeros_like(matrix)
         self.accumulator += matrix
 
     def finalize(self):

--- a/openprescribing/matrixstore/matrix_ops.py
+++ b/openprescribing/matrixstore/matrix_ops.py
@@ -38,15 +38,15 @@ def finalise_matrix(matrix):
     return matrix
 
 
-def zero_like(matrix):
+def zeros_like(matrix):
     """
     Return a zero-valued matrix of the same shape as `matrix` and with
     equivalent integer or floating point type
 
-    Note this differs from `numpy.zero_like` in that it always uses the largest
-    integer type (int_) even if the source matrix uses a smaller type (e.g.
-    uint8). This is so that we have sufficient headroom to sum many matrices
-    together.
+    Note this differs from `numpy.zeros_like` in that it always uses the
+    largest integer type (int_) even if the source matrix uses a smaller type
+    (e.g.  uint8). This is so that we have sufficient headroom to sum many
+    matrices together.
     """
     dtype = numpy.int_ if is_integer(matrix) else numpy.float_
     return numpy.zeros(matrix.shape, dtype=dtype)

--- a/openprescribing/matrixstore/matrix_ops.py
+++ b/openprescribing/matrixstore/matrix_ops.py
@@ -38,7 +38,7 @@ def finalise_matrix(matrix):
     return matrix
 
 
-def zeros_like(matrix):
+def zeros_like(matrix, order=None):
     """
     Return a zero-valued matrix of the same shape as `matrix` and with
     equivalent integer or floating point type
@@ -49,7 +49,7 @@ def zeros_like(matrix):
     matrices together.
     """
     dtype = numpy.int_ if is_integer(matrix) else numpy.float_
-    return numpy.zeros(matrix.shape, dtype=dtype)
+    return numpy.zeros(matrix.shape, dtype=dtype, order=order)
 
 
 def is_integer(matrix):

--- a/openprescribing/matrixstore/sql_functions.py
+++ b/openprescribing/matrixstore/sql_functions.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+from scipy.sparse import csc_matrix, _sparsetools
+
 from .matrix_ops import zeros_like
 from .serializer import serialize, deserialize
 
@@ -13,8 +15,13 @@ class MatrixSum(object):
             return
         matrix = deserialize(value)
         if self.accumulator is None:
-            self.accumulator = zeros_like(matrix)
-        self.accumulator += matrix
+            # We need this to be in Fortran (i.e. column-major) order for the
+            # fast addition path below to work
+            self.accumulator = zeros_like(matrix, order='F')
+        try:
+            fast_in_place_add(self.accumulator, matrix)
+        except FastInPlaceAddError:
+            self.accumulator += matrix
 
     def finalize(self):
         if self.accumulator is not None:
@@ -31,3 +38,35 @@ class MatrixSum(object):
             except AttributeError:
                 value = self.accumulator
             return sqlite3.Binary(serialize(value))
+
+
+class FastInPlaceAddError(Exception):
+    pass
+
+
+def fast_in_place_add(accumulator, matrix):
+    """
+    Attempt fast in-place addition of `matrix` (a sparse CSC matrix) to
+    `accumulator` (an ndarray of the same size)
+
+    Raises FastInPlaceAddError if the operation can't be performed and standard
+    addition should be used instead
+
+    This is based on the code found in:
+        scipy/sparse/compressed.py:_cs_matrix._add_dense
+    """
+    if not isinstance(matrix, csc_matrix):
+        raise FastInPlaceAddError()
+    if accumulator.shape != matrix.shape:
+        raise FastInPlaceAddError()
+    if not accumulator.flags.f_contiguous:
+        raise FastInPlaceAddError()
+    # In order to use Compressed Sparse Row (csr) operations with Compressed
+    # Sparse Column (csc) matrices we need to transpose the matrix
+    # we're adding into. This is a fast operation which just returns a new view
+    # on the underlying data.
+    transposed = accumulator.transpose()
+    rows, columns = transposed.shape
+    _sparsetools.csr_todense(
+        rows, columns, matrix.indptr, matrix.indices, matrix.data, transposed
+    )

--- a/openprescribing/matrixstore/sql_functions.py
+++ b/openprescribing/matrixstore/sql_functions.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+from .matrix_ops import zeros_like
+from .serializer import serialize, deserialize
+
+
+class MatrixSum(object):
+
+    accumulator = None
+
+    def step(self, value):
+        if value is None:
+            return
+        matrix = deserialize(value)
+        if self.accumulator is None:
+            self.accumulator = zeros_like(matrix)
+        self.accumulator += matrix
+
+    def finalize(self):
+        if self.accumulator is not None:
+            # Operations on SciPy sparse matrices sometimes return matrix
+            # objects rather than the standard 2-dimensional numpy array. See:
+            # https://github.com/scipy/scipy/issues/7510
+            # We always want array values (for one thing, pyarrow can't
+            # serialize matrix instances out of the box) and so we convert them
+            # here by grabbing the underlying array from the matrix object, if
+            # that's what we've got. (Note: this is the documented conversion
+            # method; we're not using a private API)
+            try:
+                value = self.accumulator.A
+            except AttributeError:
+                value = self.accumulator
+            return sqlite3.Binary(serialize(value))

--- a/openprescribing/matrixstore/tests/test_sql_functions.py
+++ b/openprescribing/matrixstore/tests/test_sql_functions.py
@@ -1,0 +1,37 @@
+from django.test import SimpleTestCase
+
+import numpy
+import scipy.sparse
+
+from matrixstore.sql_functions import fast_in_place_add
+
+
+class TestFastInPlaceAdd(SimpleTestCase):
+
+    def test_fast_in_place_add(self):
+        matrix_a = [
+            [1, 0, 2],
+            [0, 0, 0],
+            [0, 4, 5],
+            [2, 3, 2],
+        ]
+        matrix_b = [
+            [0, 0, 0],
+            [0, 0, 4],
+            [1, 1, 1],
+            [3, 2, 0],
+        ]
+        sparse_matrix_a = scipy.sparse.csc_matrix(numpy.array(matrix_a))
+        sparse_matrix_b = scipy.sparse.csc_matrix(numpy.array(matrix_b))
+        accumulator = numpy.zeros((4, 3), order='F')
+        fast_in_place_add(accumulator, sparse_matrix_a)
+        fast_in_place_add(accumulator, sparse_matrix_b)
+        self.assertEqual(
+            accumulator.tolist(),
+            [
+                [1, 0, 2],
+                [0, 0, 4],
+                [1, 5, 6],
+                [5, 5, 2],
+            ]
+        )


### PR DESCRIPTION
This patch improves the performance of summing a selection of matrices by a factor of around 3 to 4 through a combination of:
 * using in-place matrix addition rather than constructing a new matrix each time;
 * skipping some unnecessary checks whether deserialising matrices.

The majority of the time is now spent in the zstandard decompression function so changing the compression settings, or using a different library like LZ4 which prioritises decompression speed, is an obvious next place to look.