### PR TITLE
Make functional tests required again in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,6 @@ matrix:
       script:
         - docker run -v ${TRAVIS_BUILD_DIR}:/openprescribing/ dockette/jessie /bin/bash -c "cd /openprescribing/ansible && bash test_playbook.sh"
       env: LANG=en_US.UTF-8
-  allow_failures:
-    # The SauceLabs browser tests are very flaky such that we get frequent
-    # failures which disappear if the tests are re-run. At present, we're not
-    # touching the frontend code much at all and so these failures are just
-    # useless noise and promote the bad habit of ignoring CI results. As a
-    # quick improvement on this situation we now ignore failures in the browser
-    # tests when determining the overall test status, but we still run them so
-    # that the results can be checked manually if you're making frontend
-    # changes.
-    - env: TEST_SUITE=functional BROWSER="internet explorer:11.0:Windows 7"
 cache:
   directories:
     docker


### PR DESCRIPTION
Out of the previous 20 green test runs only one has included a
functional test failure, which seems like a low enough rate to try
making a pass required again.

If they prove too flaky we can always revisit.