### PR TITLE
Ensure insert_rows_from_pg always uses correct schema 

### DIFF
--- a/openprescribing/frontend/management/commands/generate_measure_fixtures.py
+++ b/openprescribing/frontend/management/commands/generate_measure_fixtures.py
@@ -261,7 +261,7 @@ class Command(BaseCommand):
             for row in prescribing_rows:
                 writer.writerow(row)
             f.seek(0)
-            table.insert_rows_from_csv(f.name)
+            table.insert_rows_from_csv(f.name, schemas.PRESCRIBING_SCHEMA)
 
         # Do the work.
         call_command('import_measures', measure='core_0,core_1,lp_2,lp_3,lpzomnibus')

--- a/openprescribing/frontend/management/commands/generate_measure_fixtures.py
+++ b/openprescribing/frontend/management/commands/generate_measure_fixtures.py
@@ -122,11 +122,13 @@ class Command(BaseCommand):
         Client('measures').create_dataset()
         client = Client('hscic')
         table = client.get_or_create_table('ccgs', schemas.CCG_SCHEMA)
-        columns = [field.name for field in schemas.CCG_SCHEMA]
-        table.insert_rows_from_pg(PCT, columns, schemas.ccgs_transform)
+        table.insert_rows_from_pg(
+            PCT,
+            schemas.CCG_SCHEMA,
+            transformer=schemas.ccgs_transform
+        )
         table = client.get_or_create_table('practices', schemas.PRACTICE_SCHEMA)
-        columns = [field.name for field in schemas.PRACTICE_SCHEMA]
-        table.insert_rows_from_pg(Practice, columns)
+        table.insert_rows_from_pg(Practice, schemas.PRACTICE_SCHEMA)
 
         # Create measures definitions and record the BNF codes used
         measure_definitions_path = os.path.join(

--- a/openprescribing/frontend/management/commands/generate_presentation_replacements.py
+++ b/openprescribing/frontend/management/commands/generate_presentation_replacements.py
@@ -179,7 +179,7 @@ def create_bigquery_table():
         csv_file.seek(0)
         client = Client('hscic')
         table = client.get_or_create_table('bnf_map', schemas.BNF_MAP_SCHEMA)
-        table.insert_rows_from_csv(csv_file.name)
+        table.insert_rows_from_csv(csv_file.name, schemas.BNF_MAP_SCHEMA)
 
 
 def write_zero_prescribing_codes_table(level):

--- a/openprescribing/frontend/management/commands/import_ppu_savings.py
+++ b/openprescribing/frontend/management/commands/import_ppu_savings.py
@@ -242,9 +242,8 @@ class Command(BaseCommand):
 
         client = Client('hscic')
         table = client.get_or_create_table('ppu_savings', PPU_SAVING_SCHEMA)
-        columns = [field.name for field in PPU_SAVING_SCHEMA]
         table.insert_rows_from_pg(
             PPUSaving,
-            columns,
-            ppu_savings_transform
+            PPU_SAVING_SCHEMA,
+            transformer=ppu_savings_transform
         )

--- a/openprescribing/frontend/tests/commands/test_create_views.py
+++ b/openprescribing/frontend/tests/commands/test_create_views.py
@@ -47,12 +47,10 @@ class CommandsTestCase(SimpleTestCase):
             table.insert_rows_from_csv(prescribing_fixture_path)
 
             table = client.get_or_create_table('ccgs', CCG_SCHEMA)
-            columns = [field.name for field in CCG_SCHEMA]
-            table.insert_rows_from_pg(PCT, columns, ccgs_transform)
+            table.insert_rows_from_pg(PCT, CCG_SCHEMA, transformer=ccgs_transform)
 
             table = client.get_or_create_table('practices', PRACTICE_SCHEMA)
-            columns = [field.name for field in PRACTICE_SCHEMA]
-            table.insert_rows_from_pg(Practice, columns)
+            table.insert_rows_from_pg(Practice, PRACTICE_SCHEMA)
 
             table = client.get_or_create_table(
                 'practice_statistics',
@@ -63,8 +61,9 @@ class CommandsTestCase(SimpleTestCase):
             columns[-1] = 'practice_id'
             table.insert_rows_from_pg(
                 PracticeStatistics,
-                columns,
-                statistics_transform
+                PRACTICE_STATISTICS_SCHEMA,
+                columns=columns,
+                transformer=statistics_transform
             )
 
             sql = """

--- a/openprescribing/frontend/tests/commands/test_create_views.py
+++ b/openprescribing/frontend/tests/commands/test_create_views.py
@@ -44,7 +44,7 @@ class CommandsTestCase(SimpleTestCase):
                 'frontend', 'tests', 'fixtures', 'commands',
                 'prescribing_bigquery_views_fixture.csv'
             )
-            table.insert_rows_from_csv(prescribing_fixture_path)
+            table.insert_rows_from_csv(prescribing_fixture_path, PRESCRIBING_SCHEMA)
 
             table = client.get_or_create_table('ccgs', CCG_SCHEMA)
             table.insert_rows_from_pg(PCT, CCG_SCHEMA, transformer=ccgs_transform)

--- a/openprescribing/frontend/tests/commands/test_import_adqs.py
+++ b/openprescribing/frontend/tests/commands/test_import_adqs.py
@@ -53,7 +53,11 @@ class CommandsFunctionalTestCase(TestCase):
         self.client = Client('tmp_eu')
         t1 = self.client.get_or_create_table(
             self.table_name, RAW_PRESCRIBING_SCHEMA)
-        t1.insert_rows_from_csv(raw_data_path, skip_leading_rows=1)
+        t1.insert_rows_from_csv(
+            raw_data_path,
+            RAW_PRESCRIBING_SCHEMA,
+            skip_leading_rows=1
+        )
 
         call_command('import_adqs')
 

--- a/openprescribing/frontend/tests/commands/test_import_measures.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures.py
@@ -224,7 +224,7 @@ class BigqueryFunctionalTests(TestCase):
                 'normalised_prescribing_legacy',
                 PRESCRIBING_SCHEMA
             )
-            table.insert_rows_from_csv(prescribing_fixture_path)
+            table.insert_rows_from_csv(prescribing_fixture_path, PRESCRIBING_SCHEMA)
 
             practices_fixture_path = os.path.join(
                 fixtures_path,
@@ -232,14 +232,14 @@ class BigqueryFunctionalTests(TestCase):
             )
             client = Client('hscic')
             table = client.get_or_create_table('practices', PRACTICE_SCHEMA)
-            table.insert_rows_from_csv(practices_fixture_path)
+            table.insert_rows_from_csv(practices_fixture_path, PRACTICE_SCHEMA)
 
             ccgs_fixture_path = os.path.join(
                 fixtures_path,
                 'ccgs.csv'
             )
             table = client.get_or_create_table('ccgs', CCG_SCHEMA)
-            table.insert_rows_from_csv(ccgs_fixture_path)
+            table.insert_rows_from_csv(ccgs_fixture_path, CCG_SCHEMA)
 
         opts = {
             'month': '2015-09-01',

--- a/openprescribing/frontend/tests/commands/test_import_measures_new.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures_new.py
@@ -510,7 +510,7 @@ def upload_prescribing(randint):
         for row in prescribing_rows:
             writer.writerow(row)
         f.seek(0)
-        table.insert_rows_from_csv(f.name)
+        table.insert_rows_from_csv(f.name, schemas.PRESCRIBING_SCHEMA)
 
         headers = [
             'sha',
@@ -611,6 +611,6 @@ def upload_practice_statistics(randint):
         for row in practice_statistics_rows:
             writer.writerow(row)
         f.seek(0)
-        table.insert_rows_from_csv(f.name)
+        table.insert_rows_from_csv(f.name, schemas.PRACTICE_STATISTICS_SCHEMA)
 
     return practice_stats

--- a/openprescribing/frontend/tests/commands/test_import_measures_new.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures_new.py
@@ -387,11 +387,13 @@ def upload_ccgs_and_practices():
     '''Upload CCGs and Practices to BQ.'''
 
     table = Client('hscic').get_table('ccgs')
-    columns = [field.name for field in schemas.CCG_SCHEMA]
-    table.insert_rows_from_pg(PCT, columns, schemas.ccgs_transform)
+    table.insert_rows_from_pg(
+        PCT,
+        schemas.CCG_SCHEMA,
+        transformer=schemas.ccgs_transform
+    )
     table = Client('hscic').get_table('practices')
-    columns = [field.name for field in schemas.PRACTICE_SCHEMA]
-    table.insert_rows_from_pg(Practice, columns)
+    table.insert_rows_from_pg(Practice, schemas.PRACTICE_SCHEMA)
 
 
 def upload_prescribing(randint):

--- a/openprescribing/frontend/tests/commands/test_import_ppu_savings.py
+++ b/openprescribing/frontend/tests/commands/test_import_ppu_savings.py
@@ -65,7 +65,10 @@ class BigqueryFunctionalTests(TestCase):
             'normalised_prescribing_standard',
             bq_schemas.PRESCRIBING_SCHEMA
         )
-        table.insert_rows_from_csv(prescribing_fixture_path)
+        table.insert_rows_from_csv(
+            prescribing_fixture_path,
+            bq_schemas.PRESCRIBING_SCHEMA
+        )
 
         practices_fixture_path = os.path.join(
             fixtures_base_path,
@@ -75,18 +78,18 @@ class BigqueryFunctionalTests(TestCase):
             'practices',
             bq_schemas.PRACTICE_SCHEMA
         )
-        table.insert_rows_from_csv(practices_fixture_path)
+        table.insert_rows_from_csv(practices_fixture_path, bq_schemas.PRACTICE_SCHEMA)
 
         tariff_path = os.path.join(fixtures_base_path, 'tariff_fixture.csv')
         table = client.get_or_create_table('tariff', bq_schemas.TARIFF_SCHEMA)
-        table.insert_rows_from_csv(tariff_path)
+        table.insert_rows_from_csv(tariff_path, bq_schemas.TARIFF_SCHEMA)
 
         bnf_path = os.path.join(
             fixtures_base_path,
             'bnf_codes_for_ppu_savings.csv'
         )
         table = client.get_or_create_table('bnf', bq_schemas.BNF_SCHEMA)
-        table.insert_rows_from_csv(bnf_path)
+        table.insert_rows_from_csv(bnf_path, bq_schemas.BNF_SCHEMA)
 
         month = date(2015, 9, 1)
         dummy_substitutions = pd.read_csv(

--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -274,7 +274,7 @@ class Client(object):
                 record[ix] = record[ix] + ' 00:00:00'
             return record
 
-        table.insert_rows_from_pg(model, columns, transformer)
+        table.insert_rows_from_pg(model, schema, columns, transformer)
 
 
 class Table(object):
@@ -362,13 +362,15 @@ class Table(object):
             self.run_job('load_table_from_file', args, options,
                          default_options)
 
-    def insert_rows_from_pg(self, model, columns, transformer=None):
+    def insert_rows_from_pg(self, model, schema, columns=None, transformer=None):
+        if columns is None:
+            columns = [field.name for field in schema]
         table_dumper = TableDumper(model, columns, transformer)
 
         with tempfile.NamedTemporaryFile() as f:
             table_dumper.dump_to_file(f)
             f.seek(0)
-            self.insert_rows_from_csv(f.name, foo='bar')
+            self.insert_rows_from_csv(f.name, schema=schema)
 
     def insert_rows_from_storage(self, gcs_path, **options):
         default_options = {

--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -5,6 +5,7 @@ import string
 import subprocess
 import sys
 import tempfile
+import warnings
 
 from google.cloud import bigquery as gcbq
 from google.cloud.exceptions import Conflict, NotFound
@@ -65,9 +66,15 @@ class Client(object):
 
         # If this raises a DefaultCredentialsError:
         #  * on a developer's machine, run `gcloud auth application-default login`
+        #   to use OAuth
         #  * elsewhere, ensure that GOOGLE_APPLICATION_CREDENTIALS is set and
         #    points to a valid set of credentials for a service account
-        self.gcbq_client = gcbq.Client(project=self.project)
+        #
+        # A warning is raised when authenticating with OAuth, recommending that
+        # server applications use a service account.  We can ignore this.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            self.gcbq_client = gcbq.Client(project=self.project)
 
         self.dataset_key = dataset_key
 

--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -351,6 +351,12 @@ class Table(object):
             'write_disposition': 'WRITE_TRUNCATE',
         }
 
+        if 'schema' in options:
+            # When we send a schema with a load_table_from_file job, our copy
+            # of the table metadata doesn't get updated, so we need to do this
+            # ourselves.
+            self.gcbq_table.schema = options['schema']
+
         with open(csv_path, 'rb') as f:
             args = [f, self.gcbq_table_ref]
             self.run_job('load_table_from_file', args, options,

--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -240,7 +240,6 @@ class Client(object):
         sql = interpolate_sql(sql)
         kwargs = {
             'project_id': self.project,
-            'verbose': False,
             'dialect': 'legacy' if legacy else 'standard',
         }
         with exception_sql_printer(sql):

--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -345,17 +345,17 @@ class Table(object):
                 self.client.create_dataset()
                 self.run_job('query', args, options, default_options)
 
-    def insert_rows_from_csv(self, csv_path, **options):
+    def insert_rows_from_csv(self, csv_path, schema, **options):
         default_options = {
             'source_format': 'text/csv',
             'write_disposition': 'WRITE_TRUNCATE',
+            'schema': schema,
         }
 
-        if 'schema' in options:
-            # When we send a schema with a load_table_from_file job, our copy
-            # of the table metadata doesn't get updated, so we need to do this
-            # ourselves.
-            self.gcbq_table.schema = options['schema']
+        # When we send a schema with a load_table_from_file job, our copy
+        # of the table metadata doesn't get updated, so we need to do this
+        # ourselves.
+        self.gcbq_table.schema = schema
 
         with open(csv_path, 'rb') as f:
             args = [f, self.gcbq_table_ref]
@@ -370,7 +370,7 @@ class Table(object):
         with tempfile.NamedTemporaryFile() as f:
             table_dumper.dump_to_file(f)
             f.seek(0)
-            self.insert_rows_from_csv(f.name, schema=schema)
+            self.insert_rows_from_csv(f.name, schema)
 
     def insert_rows_from_storage(self, gcs_path, **options):
         default_options = {

--- a/openprescribing/gcutils/tests/test_bigquery.py
+++ b/openprescribing/gcutils/tests/test_bigquery.py
@@ -60,7 +60,7 @@ class BQClientTest(TestCase):
         t1_qname = t1.qualified_name
 
         # Test Table.insert_rows_from_csv
-        t1.insert_rows_from_csv('gcutils/tests/test_table.csv', schema=schema)
+        t1.insert_rows_from_csv('gcutils/tests/test_table.csv', schema)
 
         self.assertEqual(sorted(t1.get_rows()), rows)
 

--- a/openprescribing/gcutils/tests/test_bigquery.py
+++ b/openprescribing/gcutils/tests/test_bigquery.py
@@ -164,7 +164,11 @@ class BQClientTest(TestCase):
 
         def transformer(row):
             return [ord(row[0][0]), row[1]]
-        t1.insert_rows_from_pg(PCT, ['code', 'name'], transformer)
+        t1.insert_rows_from_pg(
+            PCT,
+            build_schema(('code', 'INTEGER'), ('name', 'STRING')),
+            transformer=transformer
+        )
 
         self.assertEqual(sorted(t1.get_rows()), [(65, 'CCG 1'), (88, 'CCG 2')])
 

--- a/openprescribing/gcutils/tests/test_bigquery.py
+++ b/openprescribing/gcutils/tests/test_bigquery.py
@@ -39,6 +39,11 @@ class BQClientTest(TestCase):
         client = Client('test')
         archive_client = Client('archive')
 
+        orig_schema = build_schema(
+            ('a', 'STRING'),
+            ('b', 'INTEGER'),
+        )
+
         schema = build_schema(
             ('a', 'INTEGER'),
             ('b', 'STRING'),
@@ -51,11 +56,11 @@ class BQClientTest(TestCase):
             (3, 'coconut'),
         ]
 
-        t1 = client.get_or_create_table('t1', schema)
+        t1 = client.get_or_create_table('t1', orig_schema)
         t1_qname = t1.qualified_name
 
         # Test Table.insert_rows_from_csv
-        t1.insert_rows_from_csv('gcutils/tests/test_table.csv')
+        t1.insert_rows_from_csv('gcutils/tests/test_table.csv', schema=schema)
 
         self.assertEqual(sorted(t1.get_rows()), rows)
 

--- a/openprescribing/matrixstore/tests/import_test_data_full.py
+++ b/openprescribing/matrixstore/tests/import_test_data_full.py
@@ -74,7 +74,7 @@ def create_and_populate_bq_table(client, name, schema, table_data):
         for item in table_data:
             writer.writerow(dict_to_row(item, schema))
         f.seek(0)
-        table.insert_rows_from_csv(f.name)
+        table.insert_rows_from_csv(f.name, schema)
 
 
 def dict_to_row(dictionary, schema):

--- a/openprescribing/pipeline/management/commands/bigquery_upload.py
+++ b/openprescribing/pipeline/management/commands/bigquery_upload.py
@@ -33,15 +33,13 @@ class Command(BaseCommand):
         client = BQClient('hscic')
 
         table = client.get_table('practices')
-        columns = [field.name for field in schemas.PRACTICE_SCHEMA]
-        table.insert_rows_from_pg(models.Practice, columns)
+        table.insert_rows_from_pg(models.Practice, schemas.PRACTICE_SCHEMA)
 
         table = client.get_table('presentation')
-        columns = [field.name for field in schemas.PRESENTATION_SCHEMA]
         table.insert_rows_from_pg(
             models.Presentation,
-            columns,
-            schemas.presentation_transform
+            schemas.PRESENTATION_SCHEMA,
+            transformer=schemas.presentation_transform
         )
 
         table = client.get_table('practice_statistics')
@@ -50,8 +48,9 @@ class Command(BaseCommand):
         columns[-1] = 'practice_id'
         table.insert_rows_from_pg(
             models.PracticeStatistics,
-            columns,
-            schemas.statistics_transform
+            schema=schema.PRACTICE_STATISTICS_SCHEMA,
+            columns=columns,
+            transformer=schemas.statistics_transform
         )
 
         sql = 'SELECT MAX(month) FROM {hscic}.practice_statistics_all_years'
@@ -73,11 +72,10 @@ class Command(BaseCommand):
         )
 
         table = client.get_table('ccgs')
-        columns = [field.name for field in schemas.CCG_SCHEMA]
         table.insert_rows_from_pg(
             models.PCT,
-            columns,
-            schemas.ccgs_transform
+            schemas.CCG_SCHEMA,
+            transformer=schemas.ccgs_transform
         )
 
         table = client.get_table('prescribing_' + date.strftime('%Y_%m'))


### PR DESCRIPTION
This is an improvement over what we have now, and should mean that we avoid problems like #1889 in future.  Longer term, we should aim for BQ and PG tables to match exactly.

Closes #1889.