### PR TITLE
Use the MatrixStore to power NCSO calculations

### DIFF
--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -71,10 +71,10 @@ class TestSpendingViews(TestCase):
                 current_month=parse_date(self.months[-1]).date()
             )
             self.validate_ncso_spending_breakdown_for_entity(
-                entity, entity_type, self.months[0]
+                entity, entity_type, parse_date(self.months[0]).date()
             )
             self.validate_ncso_spending_breakdown_for_entity(
-                entity, entity_type, self.months[-1]
+                entity, entity_type, parse_date(self.months[-1]).date()
             )
 
     def validate_ncso_spending_for_entity(self, *args, **kwargs):

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -109,7 +109,7 @@ class TestSpendingViews(TestCase):
 
     def test_alert_signup(self):
         factory = DataFactory()
-        user = factory.create_user(email='alice@example.com')
+        factory.create_user(email='alice@example.com')
         factory.create_ncso_concessions_bookmark(None)
 
         self.assertEqual(NCSOConcessionBookmark.objects.count(), 1)
@@ -132,7 +132,7 @@ class TestSpendingViews(TestCase):
 
     def test_all_england_alert_signup(self):
         factory = DataFactory()
-        user = factory.create_user(email='alice@example.com')
+        factory.create_user(email='alice@example.com')
         factory.create_ncso_concessions_bookmark(self.practice)
 
         self.assertEqual(NCSOConcessionBookmark.objects.count(), 1)

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -15,6 +15,9 @@ from frontend.views.spending_utils import (
     ncso_spending_breakdown_for_entity
 )
 from frontend.tests.data_factory import DataFactory
+from matrixstore.tests.matrixstore_factory import (
+    matrixstore_from_postgres, patch_global_matrixstore
+)
 
 
 class TestSpendingViews(TestCase):
@@ -54,6 +57,19 @@ class TestSpendingViews(TestCase):
         # Pull out an individual practice and CCG to use in our tests
         cls.practice = cls.practices[0]
         cls.ccg = cls.ccgs[0]
+        # Copy all test data from the database into a MatrixStore instance.
+        # This allows us to reuse the existing test setup with
+        # matrixstore-powered functions.
+        matrixstore = matrixstore_from_postgres()
+        stop_patching = patch_global_matrixstore(matrixstore)
+        # Have to wrap this in a staticmethod decorator otherwise Python thinks
+        # we're trying to create a new class method
+        cls._stop_patching = staticmethod(stop_patching)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stop_patching()
+        super(TestSpendingViews, cls).tearDownClass()
 
     def test_ncso_spending_methods(self):
         entities = [

--- a/openprescribing/frontend/views/spending_utils.py
+++ b/openprescribing/frontend/views/spending_utils.py
@@ -39,7 +39,7 @@ def ncso_spending_for_entity(entity, entity_type, num_months, current_month=None
     # need to handle the empty case in testing
     if not end_date:
         return []
-    start_date = end_date + relativedelta(months=-(num_months-1))
+    start_date = end_date - relativedelta(months=num_months - 1)
     last_prescribing_date = parse_date(get_db().dates[-1]).date()
     costs = _get_concession_cost_matrices(
         start_date, end_date, org_type, org_id
@@ -119,7 +119,7 @@ def _get_names_for_bnf_codes(bnf_codes):
 def _get_concession_cost_matrices(min_date, max_date, org_type, org_id):
     """
     Given a date range (inclusive) and an organisation return a set of matrices
-    detailing all spending affected by price concessons during the period.
+    detailing all spending affected by price concessions during the period.
 
     Returns a ConcessionCostMatrices object with the following attributes:
 
@@ -292,8 +292,9 @@ def _get_concession_price_matrices(min_date, max_date):
         if price_increase > price_increases[index]:
             price_increases[index] = price_increase
             tariff_prices[index] = tariff_price
-    # Convert prices from pence to pounds and apply the national average
-    # discount to get a better approximation of the actual price paid
+    # Apply the national average discount to get a better approximation of the
+    # actual price paid, and while we're at it convert from pence to pounds to
+    # make later calcuations easier
     discount_factor = (100 - NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE) / (100*100)
     tariff_prices *= discount_factor
     price_increases *= discount_factor

--- a/openprescribing/frontend/views/spending_utils.py
+++ b/openprescribing/frontend/views/spending_utils.py
@@ -40,8 +40,7 @@ def ncso_spending_for_entity(entity, entity_type, num_months, current_month=None
     if not end_date:
         return []
     start_date = end_date + relativedelta(months=-(num_months-1))
-    max_prescribing_date_str = max(get_db().date_offsets.keys())
-    last_prescribing_date = parse_date(max_prescribing_date_str).date()
+    last_prescribing_date = parse_date(get_db().dates[-1]).date()
     costs = _get_concession_cost_matrices(
         start_date, end_date, org_type, org_id
     )

--- a/openprescribing/matrixstore/connection.py
+++ b/openprescribing/matrixstore/connection.py
@@ -19,6 +19,8 @@ class MatrixStore(object):
         self.practice_offsets = dict(
             self.connection.execute('SELECT code, offset FROM practice')
         )
+        self.dates = sorted_keys(self.date_offsets)
+        self.practices = sorted_keys(self.practice_offsets)
         self.connection.create_aggregate('MATRIX_SUM', 1, MatrixSum)
 
     @classmethod
@@ -49,6 +51,14 @@ class MatrixStore(object):
 
     def close(self):
         self.connection.close()
+
+
+def sorted_keys(dictionary):
+    sorted_items = sorted(
+        dictionary.items(),
+        key=lambda (key, value): value
+    )
+    return [key for (key, value) in sorted_items]
 
 
 def convert_row_types(row):

--- a/openprescribing/matrixstore/db.py
+++ b/openprescribing/matrixstore/db.py
@@ -108,6 +108,6 @@ def _all_practices_map():
     return {
         code: None
         for code in Practice.objects
-        .filter(ccg_id__isnull=False)
+        .filter(ccg__org_type='CCG')
         .values_list('code', flat=True)
     }

--- a/openprescribing/matrixstore/row_grouper.py
+++ b/openprescribing/matrixstore/row_grouper.py
@@ -100,6 +100,23 @@ class RowGrouper(object):
             numpy.sum(row_group, axis=0, out=output_view[group_offset])
         return grouped_output
 
+    def sum_one_group(self, matrix, group_id):
+        """
+        Sum the rows of matrix (column-wise) which belong to the specified
+        group
+
+        Returns a 1-dimensional array of size: columns_in_original_matrix
+        """
+        row_selector = self._group_selectors[self.offsets[group_id]]
+        row_group = matrix[row_selector]
+        group_sum = numpy.sum(row_group, axis=0)
+        # As above, there's complexity around whether our input value is a
+        # `numpy.matrix` or `numpy.ndarray`
+        if has_type_matrix(group_sum):
+            return group_sum.A[0]
+        else:
+            return group_sum
+
 
 def has_type_matrix(value):
     """

--- a/openprescribing/matrixstore/row_grouper.py
+++ b/openprescribing/matrixstore/row_grouper.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 import numpy
+import scipy.sparse
 
 
 class RowGrouper(object):
@@ -76,10 +77,34 @@ class RowGrouper(object):
         # Fast path for the "each group contains only one row" case
         if self._single_row_groups_selector is not None:
             return matrix[self._single_row_groups_selector]
+        # Initialise an array to contain the output
         rows = len(self._group_selectors)
         columns = matrix.shape[1]
-        grouped = numpy.empty((rows, columns), dtype=matrix.dtype)
+        grouped_output = numpy.empty((rows, columns), dtype=matrix.dtype)
+        # There's some complexity here depending on whether `matrix` is an
+        # ndarray (which it usually will be as the result of `MATRIX_SUM()` is
+        # always an ndarry) or the older-style matrix class (which it will be
+        # if we call this function directly with a sparse matrix). If our input
+        # is a matrix, then we can only write sum results into a matrix so we
+        # use the `asmatrix` method below to create a compatible view onto the
+        # underlying output array.  In either case, our return value is always
+        # an ndarray.
+        if has_type_matrix(matrix):
+            output_view = numpy.asmatrix(grouped_output)
+        else:
+            output_view = grouped_output
         for group_offset, rows_selector in enumerate(self._group_selectors):
+            # Get the rows to be summed
             row_group = matrix[rows_selector]
-            grouped[group_offset] = numpy.sum(row_group, axis=0)
-        return grouped
+            # Sum them and write the result into the output array
+            numpy.sum(row_group, axis=0, out=output_view[group_offset])
+        return grouped_output
+
+
+def has_type_matrix(value):
+    """
+    Return whether `value` is a numpy array or a numpy matrix
+    """
+    # This is harder than it ought to be because `numpy.matrix` inherits from
+    # `numpy.ndarray`, but the scipy sparse type doesn't inherit from either
+    return isinstance(value, (numpy.matrix, scipy.sparse.compressed._cs_matrix))

--- a/openprescribing/matrixstore/tests/test_connection.py
+++ b/openprescribing/matrixstore/tests/test_connection.py
@@ -30,6 +30,14 @@ class TestMatrixStoreConnection(SimpleTestCase):
         expected_offsets = dict(zip(dates, range(len(dates))))
         self.assertEqual(self.matrixstore.date_offsets, expected_offsets)
 
+    def test_practices(self):
+        expected_practices = sorted(p['code'] for p in self.factory.practices)
+        self.assertEqual(self.matrixstore.practices, expected_practices)
+
+    def test_dates(self):
+        expected_dates = sorted(m[:10] for m in self.factory.months)
+        self.assertEqual(self.matrixstore.dates, expected_dates)
+
     def test_query(self):
         excluded_code = self.factory.presentations[0]['bnf_code']
         results = self.matrixstore.query(

--- a/openprescribing/matrixstore/tests/test_row_grouper.py
+++ b/openprescribing/matrixstore/tests/test_row_grouper.py
@@ -80,9 +80,10 @@ class TestGrouper(SimpleTestCase):
         value = to_list_of_lists(grouped_matrix)
         self.assertEqual(value, [])
 
-    def test_all_group_and_matrix_type_combinations(self):
+    def test_sum_with_all_group_and_matrix_type_combinations(self):
         """
-        Tests every combination of group type and matrix type
+        Tests the `sum` method with every combination of group type and matrix
+        type
         """
         test_cases = product(self.get_group_definitions(), self.get_matrices())
         for (group_name, group_definition), (matrix_name, matrix) in test_cases:
@@ -98,13 +99,28 @@ class TestGrouper(SimpleTestCase):
             self.assertEqual(
                 round_floats(values), round_floats(expected_values)
             )
-            # Test summing a single group (we pick the first as that's easiest)
-            group_id = row_grouper.ids[0]
-            expected_value = expected_values[0]
-            value = row_grouper.sum_one_group(matrix, group_id)
-            self.assertEqual(
-                round_floats(value.tolist()), round_floats(expected_value)
-            )
+
+    def test_sum_one_group_with_all_group_and_matrix_type_combinations(self):
+        """
+        Tests the `sum_one_group` method with every combination of group type
+        and matrix type
+        """
+        test_cases = product(self.get_group_definitions(), self.get_matrices())
+        for (group_name, group_definition), (matrix_name, matrix) in test_cases:
+            # Use `subTest` when we upgrade to Python 3
+            # with self.subTest(matrix=matrix_name, group=group_name):
+            row_grouper = RowGrouper(group_definition)
+            # Calculate sums for all groups the boring way using pure Python
+            expected_values = self.sum_rows_by_group(group_definition, matrix)
+            # Check the `sum_one_group` gives the expected answer for all groups
+            for offset, group_id in enumerate(row_grouper.ids):
+                expected_value = expected_values[offset]
+                value = row_grouper.sum_one_group(matrix, group_id)
+                # We need to round floats to account for differences between
+                # numpy and Python float rounding
+                self.assertEqual(
+                    round_floats(value.tolist()), round_floats(expected_value)
+                )
 
     def sum_rows_by_group(self, group_definition, matrix):
         """

--- a/openprescribing/matrixstore/tests/test_row_grouper.py
+++ b/openprescribing/matrixstore/tests/test_row_grouper.py
@@ -46,6 +46,23 @@ class TestGrouper(SimpleTestCase):
         self.assertEqual(row_grouper.ids, ['even', 'odd'])
         self.assertEqual(row_grouper.offsets, {'even': 0, 'odd': 1})
 
+    def test_basic_sum_one_group(self):
+        """
+        Test summing for a single group on a matrix which is small enough to
+        verify the results by hand
+        """
+        group_definition = [(0, 'even'), (1, 'odd'), (2, 'even'), (3, 'odd')]
+        rows = [
+          [1, 2, 3, 4],
+          [2, 3, 4, 5],
+          [3, 4, 5, 6],
+          [4, 5, 6, 7],
+        ]
+        matrix = numpy.array(rows)
+        row_grouper = RowGrouper(group_definition)
+        group_sum = row_grouper.sum_one_group(matrix, 'even')
+        self.assertEqual(group_sum.tolist(), [4, 6, 8, 10])
+
     def test_empty_group_produces_empty_matrix(self):
         """
         Test the empty group edge case
@@ -80,6 +97,13 @@ class TestGrouper(SimpleTestCase):
             # numpy and Python float rounding
             self.assertEqual(
                 round_floats(values), round_floats(expected_values)
+            )
+            # Test summing a single group (we pick the first as that's easiest)
+            group_id = row_grouper.ids[0]
+            expected_value = expected_values[0]
+            value = row_grouper.sum_one_group(matrix, group_id)
+            self.assertEqual(
+                round_floats(value.tolist()), round_floats(expected_value)
             )
 
     def sum_rows_by_group(self, group_definition, matrix):


### PR DESCRIPTION
A few things to note:

1. There are some obvious improvements we can make off the back of this, like adding PCN pages and showing a longer history of concessions, but I'm leaving those to a separate PR.

2. I'm still not entirely happy with the clarity/simplicity of the code (I'd recommend reviewing the whole file here, rather than the diff). I've got a few ideas regarding a slightly better matrix class which I think might improve MatrixStore code more generally, but that still needs more thought.

3. Given that the query we make against Postgres is identical for every organisation there's obvious scope for caching here, but I've punted on this for now as it's extra complexity and even without caching the new code seems faster than the old.

Closes #1827 and #1763