### PR TITLE
Fix dm+d links from tariff page

### DIFF
--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -619,6 +619,15 @@ class TestTariffView(TestCase):
             response,
             '<option value="0202010F0AAAAAA" selected>Chlortalidone 50mg tablets</option>'
         )
+        self.assertContains(
+            response,
+            '''
+            <ul>
+              <li><a href="/dmd/vmp/317935006/">Chlortalidone 50mg tablets</a></li>
+            </ul>
+            ''',
+            html=True
+        )
 
 class TestPPUViews(TestCase):
     fixtures = ['orgs', 'importlog', 'practices', 'prescriptions', 'presentations']

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -803,10 +803,12 @@ def tariff(request, code=None):
         presentations = Presentation.objects.filter(bnf_code__in=codes)
     else:
         presentations = []
+    selected_vmps = VMP.objects.filter(bnf_code__in=codes)
     context = {
         'bnf_codes': codes,
         'presentations': presentations,
         'vmps': vmps,
+        'selected_vmps': selected_vmps,
         'chart_title': 'Tariff prices for ' + ', '.join(
             [x.product_name for x in presentations])
     }

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -74,7 +74,7 @@
 <hr>
 <p>View dm+d data about:</p>
 <ul>
-  {% for vmp in vmps %}
+  {% for vmp in selected_vmps %}
   <li><a href="{% url 'dmd_obj' 'vmp' vmp.id %}">{{ vmp.nm }}</a></li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
We were showing links to every single VMP