### PR TITLE
Don't include presentations without prescribing in MatrixStore

### DIFF
--- a/openprescribing/matrixstore/build/init_db.py
+++ b/openprescribing/matrixstore/build/init_db.py
@@ -138,11 +138,10 @@ def import_presentations(bq_conn, sqlite_conn):
     Query BigQuery for BNF codes and metadata on all presentations and insert
     into SQLite
     """
-    # Unlike with practices above, we make no attempt to determine which
-    # presentations have prescribing data during the period: it costs very
-    # little to have presentations in the database which are not prescribed
-    # against; and we don't actually know which codes are and aren't used until
-    # we apply the "BNF map" which translates old codes into new codes.
+    # We initially pull in metadata for all presentations. After we have
+    # imported prescribing data and applied the "BNF map" to apply any changed
+    # to codes we can delete entries for presentations that don't have
+    # associated prescribing.
     logger.info('Querying all presentation metadata')
     result = bq_conn.query(
         """

--- a/openprescribing/matrixstore/build/update_bnf_map.py
+++ b/openprescribing/matrixstore/build/update_bnf_map.py
@@ -26,6 +26,10 @@ def update_bnf_map(sqlite_path):
     bnf_map = get_old_to_new_bnf_codes(bigquery_connection)
     for old_code, new_code in bnf_map:
         move_values_from_old_code_to_new(cursor, old_code, new_code)
+    # Until we've completed the BNF code update we don't know which
+    # presentations actually have prescribing data, so we have to wait until
+    # now to do this cleanup
+    delete_presentations_with_no_prescribing(cursor)
     connection.commit()
     connection.close()
 
@@ -128,3 +132,7 @@ def format_values_for_sqlite(row):
         sqlite3.Binary(serialize_compressed(value))
         for value in row
     ]
+
+
+def delete_presentations_with_no_prescribing(cursor):
+    cursor.execute('DELETE FROM presentation WHERE items IS NULL')

--- a/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
+++ b/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
@@ -69,6 +69,9 @@ class TestMatrixStoreBuild(SimpleTestCase):
         cls.prescribing_with_new_code = factory.create_prescribing(
             [cls.updated_presentation], cls.active_practices, cls.months
         )
+        # Create a presenation without creating any prescribing for it so we can
+        # check it doesn't appear in the final file
+        cls.presentation_without_prescribing = factory.create_presentation()
         # We deliberately import data for fewer months than we've created so we
         # can test that only the right data is included
         cls.months_to_import = cls.months[1:]
@@ -143,6 +146,7 @@ class TestMatrixStoreBuild(SimpleTestCase):
         results = [dict(row) for row in results]
         self.assertEqual(results, expected)
         self.assertNotIn(self.presentation_to_update, results)
+        self.assertNotIn(self.presentation_without_prescribing, results)
 
     def test_practice_statistics_are_correct(self):
         get_value = MatrixValueFetcher(

--- a/openprescribing/matrixstore/tests/import_test_data_fast.py
+++ b/openprescribing/matrixstore/tests/import_test_data_fast.py
@@ -10,7 +10,7 @@ from matrixstore.build.import_prescribing import (
     write_prescribing, parse_prescribing_csv
 )
 from matrixstore.build.update_bnf_map import (
-    move_values_from_old_code_to_new
+    move_values_from_old_code_to_new, delete_presentations_with_no_prescribing
 )
 from matrixstore.build.precalculate_totals import (
     precalculate_totals_for_db
@@ -89,6 +89,7 @@ def update_bnf_map(sqlite_conn, data_factory):
             item['former_bnf_code'],
             item['current_bnf_code']
         )
+    delete_presentations_with_no_prescribing(cursor)
 
 
 def _get_active_practice_codes(data_factory, dates):


### PR DESCRIPTION
There doesn't seem to be any significant performance difference here,
but without this we have to add an irritating extra `IS NOT NULL` clause
to the end of every MatrixStore query.