### PR TITLE
exclude NaCL bottles for inconsistent qty

### DIFF
--- a/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
+++ b/openprescribing/frontend/management/commands/measure_sql/vw__ghost_generic_measure.sql
@@ -65,5 +65,10 @@ AND
 -- These are sometimes recorded by dose, and sometimes by pack (of 8) see #937
 AND
   rx.bnf_code <> '0407020A0AABPBP' -- Fentanyl 400micrograms/dose nasal spray
+-- These are sometimes recorded as bottles, sometimes in litres
+AND
+  rx.bnf_code <> '0902021S0AAAXAX' -- Sodium chloride 0.9% infusion 1litre polyethylene bottles
+
+
 
 -- trivial savings / costs are discounted in the measure definition


### PR DESCRIPTION
Quantity of `Sodium chloride 0.9% infusion 1litre polyethylene bottles` is sometimes recorded in bottles, sometimes in litres.