### PR TITLE
Select newsletter group on signup form

### DIFF
--- a/openprescribing/templates/_mailchimp_signup.html
+++ b/openprescribing/templates/_mailchimp_signup.html
@@ -37,6 +37,13 @@
     </label>
     <input type="text" name="MMERGE4" class="form-control" id="mce-MMERGE4" />
   </div>
+  
+  <div class="form-group input-group" style="display:none">
+    <strong>Please send me email updates about... </strong>
+    <ul><li><input type="checkbox" value="1" name="group[6431][1]" id="mce-group[6431]-6431-0" checked><label for="mce-group[6431]-6431-0">OpenPrescribing.net</label></li>
+  <li><input type="checkbox" value="2" name="group[6431][2]" id="mce-group[6431]-6431-1"><label for="mce-group[6431]-6431-1">OpenPathology.net</label></li>
+  </ul>
+  </div>
 
   <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
   <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_e88ddd909a00ef5c60300273b_b2b7873a73" tabindex="-1" value=""></div>

--- a/openprescribing/templates/_newsletter_signup_form.html
+++ b/openprescribing/templates/_newsletter_signup_form.html
@@ -18,5 +18,11 @@
     <label for="job_title">Job title</label>
     <input type="text" class="form-control" id="job_title" name="job_title">
   </div>
+  <div class="form-group input-group" style="display:none">
+    <strong>Please send me email updates about... </strong>
+    <ul><li><input type="checkbox" value="1" name="group[6431][1]" id="mce-group[6431]-6431-0" checked><label for="mce-group[6431]-6431-0">OpenPrescribing.net</label></li>
+    <li><input type="checkbox" value="2" name="group[6431][2]" id="mce-group[6431]-6431-1"><label for="mce-group[6431]-6431-1">OpenPathology.net</label></li>
+  </ul>
+  </div>
   <button type="submit" class="btn btn-default">Continue</button>
 </form>


### PR DESCRIPTION
Added lines from mailchimp to incorporate new group options (OpenPrescribing or OpenPathology) to the signup form  - the group selection is hidden (`style="display:none"`) to avoid confusion, and so OpenPrescribing is automatically selected (`checked`). (Users can amend their preferences later to opt in to OpenPathology)