### PR TITLE
Extract ENV from environment in gunicorn_start

### DIFF
--- a/ansible/test_playbook.sh
+++ b/ansible/test_playbook.sh
@@ -18,4 +18,4 @@ sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 SKIP_NPM_BUILD=1 /openprescribing/venv/bin/python /openprescribing/openprescribing/manage.py test frontend.tests.test_models.SearchBookmarkTestCase
 
 # Check that gunicorn can start
-CHECK_CONFIG=1 PORT=8000 /openprescribing/bin/gunicorn_start production
+CHECK_CONFIG=1 PORT=8000 /openprescribing/bin/gunicorn_start

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -6,12 +6,16 @@ db_password: sdkjasdalskdax
 db_name: openprescribing_dev
 secret_key: sdjfhasiufqpiasln
 repo_root: /openprescribing
+django_settings_module: openprescribing.settings.staging
 virtualenv_path: "{{ repo_root }}/venv"
 apps_root: "{{ repo_root }}/openprescribing"
 requirements_path: "{{ repo_root }}/requirements.txt"
 log_path: "{{ repo_root }}/logs"
 
 envvars:
+  - var: DJANGO_SETTINGS_MODULE
+    name: DJANGO_SETTINGS_MODULE
+    content: "{{ django_settings_module }}"
   - var: VIRTUALENV_PATH
     name: VIRTUALENV_PATH
     content: "{{ virtualenv_path }}"

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -6,7 +6,7 @@ db_password: sdkjasdalskdax
 db_name: openprescribing_dev
 secret_key: sdjfhasiufqpiasln
 repo_root: /openprescribing
-django_settings_module: openprescribing.settings.staging
+django_settings_module: openprescribing.settings.production
 virtualenv_path: "{{ repo_root }}/venv"
 apps_root: "{{ repo_root }}/openprescribing"
 requirements_path: "{{ repo_root }}/requirements.txt"

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -2,7 +2,13 @@
 
 set -eo pipefail
 
-ENV=$1
+# Export each variable in the environment file, ignoring comments. Sourcing the
+# file is insufficient as it sets the vars in the current environment but
+# doesn't flag them for export to child processes.
+export $(grep -v '^\s*#' "$REPO_ROOT/environment" | xargs)
+
+# Extract the environment name from the path to the settings file.
+ENV=$(echo $DJANGO_SETTINGS_MODULE | cut -d \. -f 3)
 
 if [[ $ENV != "production" && $ENV != "staging" ]]
 then
@@ -27,7 +33,6 @@ LOGFILE="$LOGDIR/gunicorn-error.log"
 ACCESS_LOGFILE="$LOGDIR/gunicorn-access.log"
 
 # Export environment variables that depend on $ENV
-export DJANGO_SETTINGS_MODULE="openprescribing.settings.$ENV"
 export PYTHONPATH=$APPS_ROOT:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$REPO_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENV
@@ -47,11 +52,6 @@ echo "ENV: $ENV"
 echo "REPO_ROOT: $REPO_ROOT"
 echo "APPS_ROOT: $APPS_ROOT"
 echo "PYTHONPATH: $PYTHONPATH"
-
-# Export each variable in the environment file, ignoring comments. Sourcing the
-# file is insufficient as it sets the vars in the current environment but
-# doesn't flag them for export to child processes.
-export $(grep -v '^\s*#' "$REPO_ROOT/environment" | xargs)
 
 # Activate the virtual environment
 source "$VIRTUALENV_PATH/bin/activate"

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# REPO_ROOT matches definitions in settings
+REPO_ROOT=$(dirname $(dirname $0))
+
 # Export each variable in the environment file, ignoring comments. Sourcing the
 # file is insufficient as it sets the vars in the current environment but
 # doesn't flag them for export to child processes.
@@ -18,10 +21,6 @@ fi
 
 NAME="openprescribing_$ENV"
 
-# REPO_ROOT and APPS_ROOT match definitions in settings
-REPO_ROOT=$(dirname $(dirname $0))
-APPS_ROOT="$REPO_ROOT/openprescribing"
-
 RUNDIR="$REPO_ROOT/run"
 LOGDIR="$REPO_ROOT/logs"
 
@@ -32,8 +31,8 @@ mkdir -p $LOGDIR
 LOGFILE="$LOGDIR/gunicorn-error.log"
 ACCESS_LOGFILE="$LOGDIR/gunicorn-access.log"
 
-# Export environment variables that depend on $ENV
-export PYTHONPATH=$APPS_ROOT:$PYTHONPATH
+# Export environment variables that depend on $ENV or $REPO_ROOT
+export PYTHONPATH=$REPO_ROOT/openprescribing:$PYTHONPATH
 export NEW_RELIC_CONFIG_FILE="$REPO_ROOT/newrelic.ini"
 export NEW_RELIC_ENVIRONMENT=$ENV
 
@@ -50,7 +49,6 @@ echo "Starting $NAME"
 echo "whoami: $(whoami)"
 echo "ENV: $ENV"
 echo "REPO_ROOT: $REPO_ROOT"
-echo "APPS_ROOT: $APPS_ROOT"
 echo "PYTHONPATH: $PYTHONPATH"
 
 # Activate the virtual environment

--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -12,7 +12,7 @@ ENV=$(echo $DJANGO_SETTINGS_MODULE | cut -d \. -f 3)
 
 if [[ $ENV != "production" && $ENV != "staging" ]]
 then
-  echo '$ENV must be "production" or "staging"'
+  echo "\$ENV must be 'production' or 'staging', got '$ENV'"
   exit 1
 fi
 

--- a/contrib/systemd/app.openprescribing_staging.web.service
+++ b/contrib/systemd/app.openprescribing_staging.web.service
@@ -23,8 +23,8 @@
 
 [Service]
 User=www-data
-ExecStart=/webapps/openprescribing/bin/gunicorn_start
-SyslogIdentifier=app.openprescribing.web
+ExecStart=/webapps/openprescribing_staging/bin/gunicorn_start
+SyslogIdentifier=app.openprescribing_staging.web
 Restart=always
 RestartSec=4
 

--- a/contrib/systemd/app.openprescribing_staging.web.socket
+++ b/contrib/systemd/app.openprescribing_staging.web.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=/webapps/openprescribing_staging/run/gunicorn.sock
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
It was passed as an argument by systemd, but the version of
app.openprescribing.web.service was incorrectly passing "staging" when
it should've passed "production".

Fixes #2026.