### PR TITLE
Remove ZStandard and redundant NULL checks

### DIFF
--- a/openprescribing/api/views_measures.py
+++ b/openprescribing/api/views_measures.py
@@ -199,7 +199,7 @@ def _get_prescribing_for_bnf_codes(bnf_codes):
         FROM
           presentation
         WHERE
-          items IS NOT NULL AND bnf_code IN ({})
+          bnf_code IN ({})
         """.format(
             ",".join(["?"] * len(bnf_codes))
         ),

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -654,7 +654,7 @@ def _get_prescribing_for_codes(db, bnf_code_prefixes):
             FROM
                 presentation
             WHERE
-                items IS NOT NULL AND ({})
+                {}
             """.format(
             where_clause
         )

--- a/openprescribing/dmd2/views.py
+++ b/openprescribing/dmd2/views.py
@@ -121,7 +121,7 @@ def dmd_obj_view(request, obj_type, id):
         has_prescribing = get_db().query_one(
             """
             SELECT EXISTS(
-                SELECT 1 FROM presentation WHERE bnf_code=? AND items IS NOT NULL
+                SELECT 1 FROM presentation WHERE bnf_code=?
             )
             """,
             [obj.bnf_code],

--- a/openprescribing/frontend/views/spending_utils.py
+++ b/openprescribing/frontend/views/spending_utils.py
@@ -222,7 +222,7 @@ def _get_quantities_for_bnf_codes(db, bnf_codes):
         FROM
           presentation
         WHERE
-          quantity IS NOT NULL AND bnf_code IN ({})
+          bnf_code IN ({})
         """.format(
             ",".join(["?"] * len(bnf_codes))
         ),

--- a/openprescribing/matrixstore/README.md
+++ b/openprescribing/matrixstore/README.md
@@ -29,8 +29,8 @@ The [PyArrow](https://arrow.apache.org/docs/python/) library provides
 very fast serialization and deserialization of numpy objects. We use
 [SciPy sparse matrices](https://docs.scipy.org/doc/scipy/reference/sparse.html)
 to reduce storage requirements where data is sparse. And we use the
-[zstandard](https://github.com/indygreg/python-zstandard) compression
-library to further reduce space on disk.
+[LZ4](https://python-lz4.readthedocs.io/en/stable/intro.html)
+compression library to further reduce space on disk.
 
 
 ## How data is structured

--- a/openprescribing/matrixstore/README.md
+++ b/openprescribing/matrixstore/README.md
@@ -108,7 +108,7 @@ from matrixstore.serializer import deserialize
 
 conn = sqlite3.connect('matrixstore_file.sqlite')
 results = conn.execute(
-    'SELECT items FROM presentation WHERE items IS NOT NULL LIMIT 1'
+    'SELECT items FROM presentation LIMIT 1'
 )
 value = list(results)[0][0]
 matrix = deserialize(value)

--- a/openprescribing/matrixstore/serializer.py
+++ b/openprescribing/matrixstore/serializer.py
@@ -3,15 +3,11 @@ import struct
 import lz4.frame
 import pyarrow
 from scipy.sparse import csc_matrix
-import zstandard
 
 
-# The magic intial bytes which tell us whether a given binary chunk is
-# ZStandard or LZ4 compressed data
-ZSTD_MAGIC_NUMBER = struct.pack("<I", 0xFD2FB528)
+# The magic intial bytes which tell us that a given binary chunk is LZ4
+# compressed data
 LZ4_MAGIC_NUMBER = struct.pack("<I", 0x184D2204)
-
-zstd_decompressor = zstandard.ZstdDecompressor()
 
 context = pyarrow.SerializationContext()
 
@@ -76,6 +72,4 @@ def deserialize(data):
     magic_number = memoryview(data)[:4]
     if magic_number == LZ4_MAGIC_NUMBER:
         data = lz4.frame.decompress(data, return_bytearray=True)
-    elif magic_number == ZSTD_MAGIC_NUMBER:
-        data = zstd_decompressor.decompress(data)
     return context.deserialize(data)

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,6 @@ scipy==1.2.1
 titlecase==0.12.0
 tqdm==4.35.0
 xlrd==1.2.0
-zstandard==0.11.1
 
 # redis
 django-redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bcrypt==3.1.7             # via paramiko
 beautifulsoup4==4.8.0
 cachetools==3.1.1         # via google-auth, premailer
 certifi==2019.6.16        # via requests
-cffi==1.12.3              # via bcrypt, cryptography, pynacl, zstandard
+cffi==1.12.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 coverage==4.5.4
@@ -106,7 +106,6 @@ urllib3==1.25.3           # via requests, selenium
 watchdog==0.9.0           # via when-changed
 when-changed==0.3.0
 xlrd==1.2.0
-zstandard==0.11.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.2.0        # via google-api-core, pandas-gbq, protobuf, pydata-google-auth


### PR DESCRIPTION
We now use LZ4 compression for the MatrixStore and remove NULL rows at build time.

Closes #1956