### PR TITLE
Test sending All England alerts as part of monthly alerts

### DIFF
--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -200,6 +200,7 @@ class Command(BaseCommand):
             "settings",
             "no_color",
             "max_errors",
+            "skip_checks",
         ]:
             set_options.pop(key, None)
         # We do understand this one, so keep a record of its value

--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import logging
 
@@ -206,14 +207,16 @@ class Command(BaseCommand):
         # We do understand this one, so keep a record of its value
         recipient_email = set_options.pop("recipient_email", None)
         if not set_options:
-            logger.info("Sending All England alerts")
+            message = "Sending All England alerts"
+            logger.info(message)
+            print (message)
             send_all_england_alerts(recipient_email)
         else:
-            logger.info(
-                "Not sending All England alerts as found unhandled option: {}".format(
-                    ", ".join(set_options.keys())
-                )
+            message = "Not sending All England alerts as found unhandled option: {}".format(
+                ", ".join(set_options.keys())
             )
+            logger.info(message)
+            print (message)
 
     def handle(self, *args, **options):
         self.validate_options(**options)

--- a/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
@@ -15,6 +15,8 @@ from frontend.models import Measure
 from frontend.management.commands.send_monthly_alerts import Command
 from frontend.views.bookmark_utils import BadAlertImageError
 from frontend.tests.test_bookmark_utils import _makeContext
+from frontend.tests.data_factory import DataFactory
+from frontend.tests.test_api_spending import ApiTestBase
 
 
 CMD_NAME = "send_monthly_alerts"
@@ -451,6 +453,21 @@ class SearchEmailTestCase(TestCase):
         self.assertIn("**Hello!**", text)
         self.assertIn("/bookmarks/dummykey", text)
         self.assertRegexpMatches(text, "http://localhost/analyse/.*#%s" % "something")
+
+
+class AllEnglandAlertTestCase(ApiTestBase):
+
+    fixtures = ApiTestBase.fixtures + ["ppusavings", "functional-measures"]
+
+    def test_all_england_alerts_sent(self):
+        factory = DataFactory()
+
+        # Create an All England bookmark, send alerts, and make sure one email
+        # is sent to correct user
+        bookmark = factory.create_org_bookmark(None)
+        call_command(CMD_NAME)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [bookmark.user.email])
 
 
 def call_mocked_command(context, mock_finder, **opts):

--- a/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
+++ b/openprescribing/frontend/tests/fixtures/bookmark_alerts.json
@@ -121,17 +121,6 @@
   }
 },
 {
-  "model": "frontend.orgbookmark",
-  "pk": 5,
-  "fields": {
-    "user": 1,
-    "pct": null,
-    "practice": null,
-    "approved": true,
-    "created_at": "2000-01-01T12:01:00Z"
-  }
-},
-{
   "model": "frontend.searchbookmark",
   "pk": 1,
   "fields": {


### PR DESCRIPTION
Despite what I thought earlier, this was actually done correctly in #1927. The reason the alerts didn't send was due to the early exit caused by #2058 (now fixed).

However, attempting to add tests for this revealed several tedious issues with the test set up. Also, although the command logged what it was doing with respect to All England alerts it's not clear where these logs go (certainly not to the console) so we now print them as well so they should hopefully be seen by whoever's running the command.