### PR TITLE
Link to All England numerator breakdown page

### DIFF
--- a/openprescribing/templates/measure_for_all_entities.html
+++ b/openprescribing/templates/measure_for_all_entities.html
@@ -22,7 +22,7 @@
     NHS in England.
   </p>
   <p>
-    <a href="{% url 'all_england' %}#{{ measure.id }}" class="btn btn-default">
+    <a href="{% url 'measure_for_all_england' measure.id %}" class="btn btn-default">
       View measure for NHS England combined &rarr;
     </a>
   </p>


### PR DESCRIPTION
This is instead of linking to the dashboard with a `#<measure_id>` URL
fragment, which gave a slower-loading and more confusing user
experience.