### PR TITLE
Fix incorrect aggregation SQL

### DIFF
--- a/openprescribing/frontend/managers.py
+++ b/openprescribing/frontend/managers.py
@@ -119,13 +119,15 @@ class MeasureValueQuerySet(models.QuerySet):
             .annotate(
                 numerator=Sum("numerator"),
                 denominator=Sum("denominator"),
-                calc_value=_divide("numerator", "denominator"),
                 cost_savings=_aggregate_over_json(
                     field="cost_savings",
                     aggregate_function=_sum_positive_values,
                     keys=CENTILES,
                 ),
             )
+            # Note, this needs to be in its own `annotate` call so it's
+            # processed after the definitions of `numerator` and `denominator`
+            .annotate(calc_value=_divide("numerator", "denominator"))
         )
         return (self.model(**row) for row in aggregate_queryset)
 


### PR DESCRIPTION
In order to generate the correct SQL it's necessary that the definition
of `calc_value` come *after* the definition of `numerator` and
`denominator`. Previously, by luck of the order in which the keyword
arguments were processed, it worked to have all the definitions in one
`annotate` call. But the upgrade to Python 3 exposed the error here, so
now we use two `annotate` calls.