### PR TITLE
Fix `DataFactory.create_prescribing` to include every presentation

### DIFF
--- a/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
+++ b/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
@@ -40,7 +40,7 @@ class TestMatrixStoreBuild(SimpleTestCase):
 
     @classmethod
     def setUpClass(cls):
-        factory = DataFactory(seed=37)
+        factory = DataFactory()
         cls.months = factory.create_months("2019-01-01", 3)
         # This practice won't do any prescribing but it will have practice
         # statistics so it should still show up in our data

--- a/openprescribing/matrixstore/tests/data_factory.py
+++ b/openprescribing/matrixstore/tests/data_factory.py
@@ -127,17 +127,22 @@ class DataFactory(object):
 
     def create_prescribing(self, presentations, practices, months):
         prescribing = []
-        for practice in practices:
-            # Make sure each practice prescribes in at least one month, although
-            # probably not every month
-            n = self.random.randint(1, len(months))
-            selected_months = self.random.sample(months, n)
-            for month in selected_months:
-                # Make sure the practice prescribes at least one presentation,
-                # although probably not every one
-                n = self.random.randint(1, len(presentations))
-                selected_presentations = self.random.sample(presentations, n)
-                for presentation in selected_presentations:
+        for month in months:
+            practice_codes_used = set()
+            for presentation in presentations:
+                # For each presentation in each month, choose a random subset
+                # of practices to prescribe it
+                n = self.random.randint(1, len(practices))
+                selected_practices = self.random.sample(practices, n)
+                for practice in selected_practices:
+                    prescribing.append(
+                        self.create_prescription(presentation, practice, month)
+                    )
+                    practice_codes_used.add(practice["code"])
+            # Make sure each practice prescribes at least one thing each month
+            for practice in practices:
+                if practice["code"] not in practice_codes_used:
+                    presentation = self.random.choice(presentations)
                     prescribing.append(
                         self.create_prescription(presentation, practice, month)
                     )


### PR DESCRIPTION
Previously it was possible for a presentation not to be prescribed at
all, if the randomness fell out that way. This meant the tests only
passed when we provided a specific random seed.

Closes #2080