### PR TITLE
Stop stripping trailing commas from measure SQL

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -844,14 +844,12 @@ class MeasureCalculation(object):
         assert num_or_denom in ["numerator", "denominator"]
         fieldname = "%s_columns" % num_or_denom
         val = getattr(self.measure, fieldname)
-        # Deal with possible inconsistencies in measure definition
-        # trailing commas
-        if val.strip()[-1] == ",":
-            val = re.sub(r",\s*$", "", val) + " "
         if self.measure.is_cost_based and self.measure.is_percentage:
             # Cost calculations for percentage measures require extra columns.
+            # (Include newline in case previous line ends in a comment)
             val += (
-                ", SUM(items) AS items, "
+                "\n    , "
+                "SUM(items) AS items, "
                 "SUM(actual_cost) AS cost, "
                 "SUM(quantity) AS quantity "
             )

--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -435,21 +435,21 @@ def build_num_or_denom_fields(measure, num_or_denom):
         bnf_codes_query = get_measure_attr("bnf_codes_query")
 
     elif type_ == "bnf_items":
-        columns = "SUM(items) AS {},".format(num_or_denom)
+        columns = "SUM(items) AS {}".format(num_or_denom)
         from_ = "{hscic}.normalised_prescribing_standard"
         where = get_measure_attr("where")
         is_list_of_bnf_codes = True
         bnf_codes_query = None
 
     elif type_ == "bnf_quantity":
-        columns = "SUM(quantity) AS {},".format(num_or_denom)
+        columns = "SUM(quantity) AS {}".format(num_or_denom)
         from_ = "{hscic}.normalised_prescribing_standard"
         where = get_measure_attr("where")
         is_list_of_bnf_codes = True
         bnf_codes_query = None
 
     elif type_ == "bnf_cost":
-        columns = "SUM(actual_cost) AS {},".format(num_or_denom)
+        columns = "SUM(actual_cost) AS {}".format(num_or_denom)
         from_ = "{hscic}.normalised_prescribing_standard"
         where = get_measure_attr("where")
         is_list_of_bnf_codes = True
@@ -457,7 +457,7 @@ def build_num_or_denom_fields(measure, num_or_denom):
 
     elif type_ == "list_size":
         assert num_or_denom == "denominator"
-        columns = "SUM(total_list_size / 1000.0) AS denominator,"
+        columns = "SUM(total_list_size / 1000.0) AS denominator"
         from_ = "{hscic}.practice_statistics"
         where = "1 = 1"
         is_list_of_bnf_codes = False

--- a/openprescribing/measure_definitions/aafpercent.json
+++ b/openprescribing/measure_definitions/aafpercent.json
@@ -25,7 +25,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(quantity) AS numerator, "
+    "SUM(quantity) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p LEFT JOIN {measures}.cmpa_products r ON p.bnf_code=r.bnf_code ",
   "numerator_where": [
@@ -33,7 +33,7 @@
   ],
   "denominator_type": "custom",
   "denominator_columns": [
-    "SUM(quantity) AS denominator, "
+    "SUM(quantity) AS denominator"
   ],
   "denominator_from": "{hscic}.normalised_prescribing_standard p LEFT JOIN {measures}.cmpa_products r ON p.bnf_code=r.bnf_code ",
   "denominator_where": [

--- a/openprescribing/measure_definitions/bdzadq.json
+++ b/openprescribing/measure_definitions/bdzadq.json
@@ -29,7 +29,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(p.quantity * r.percent_of_adq) AS numerator, "
+    "SUM(p.quantity * r.percent_of_adq) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p  LEFT JOIN {hscic}.bdz_adq r  ON concat(substr(p.bnf_code,0,9),substr(p.bnf_code,-2)) = concat(substr(r.bnf_code,0,9),substr(r.bnf_code,-2)) ",
   "numerator_where": [
@@ -42,7 +42,7 @@
   ],
   "denominator_type": "custom",
   "denominator_columns": [
-    "SUM(items) AS denominator, "
+    "SUM(items) AS denominator"
   ],
   "denominator_from": "{hscic}.normalised_prescribing_standard p ",
   "denominator_where": [

--- a/openprescribing/measure_definitions/bdzper1000.json
+++ b/openprescribing/measure_definitions/bdzper1000.json
@@ -28,7 +28,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(p.quantity * r.percent_of_adq) AS numerator, "
+    "SUM(p.quantity * r.percent_of_adq) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p  LEFT JOIN {hscic}.bdz_adq r  ON concat(substr(p.bnf_code,0,9),substr(p.bnf_code,-2)) = concat(substr(r.bnf_code,0,9),substr(r.bnf_code,-2)) ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/cmpaperpt.json
+++ b/openprescribing/measure_definitions/cmpaperpt.json
@@ -22,7 +22,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(actual_cost) AS numerator, "
+    "SUM(actual_cost) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p LEFT JOIN {measures}.cmpa_products r ON p.bnf_code=r.bnf_code ",
   "numerator_where": [
@@ -30,7 +30,7 @@
   ],
   "denominator_type": "custom",
   "denominator_columns": [
-    "SUM(male_0_4 + female_0_4) AS denominator, "
+    "SUM(male_0_4 + female_0_4) AS denominator"
   ],
   "denominator_from": "{hscic}.practice_statistics ",
   "denominator_where": [

--- a/openprescribing/measure_definitions/gabapentinoidsddd.json
+++ b/openprescribing/measure_definitions/gabapentinoidsddd.json
@@ -30,7 +30,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(gaba_ddd) AS numerator, "
+    "SUM(gaba_ddd) AS numerator"
   ],
   "numerator_from": "{measures}.gaba_total_ddd",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ghost_generic_measure.json
+++ b/openprescribing/measure_definitions/ghost_generic_measure.json
@@ -20,7 +20,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(possible_savings) AS numerator, "
+    "SUM(possible_savings) AS numerator"
   ],
   "numerator_from": "{measures}.vw__ghost_generic_measure p",
   "numerator_where": [
@@ -29,7 +29,7 @@
   "numerator_is_list_of_bnf_codes": false,
   "denominator_type": "custom",
   "denominator_columns": [
-    "SUM(net_cost) AS denominator, "
+    "SUM(net_cost) AS denominator"
   ],
   "denominator_from": "{measures}.vw__ghost_generic_measure p",
   "denominator_where": [

--- a/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
+++ b/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
@@ -32,7 +32,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(p.quantity * r.adq_per_quantity) AS numerator, "
+    "SUM(p.quantity * r.adq_per_quantity) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p  LEFT JOIN {hscic}.presentation r  ON p.bnf_code = r.bnf_code ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lpherbal.json
+++ b/openprescribing/measure_definitions/lpherbal.json
@@ -24,7 +24,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(actual_cost) AS numerator, "
+    "SUM(actual_cost) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p INNER JOIN (SELECT DISTINCT bnf_code FROM ebmdatalab.richard.herbal_list) r ON p.bnf_code = r.bnf_code",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lpneedles.json
+++ b/openprescribing/measure_definitions/lpneedles.json
@@ -25,7 +25,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(actual_cost) AS numerator, "
+    "SUM(actual_cost) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard p LEFT JOIN {measures}.vw__median_price_per_unit r ON p.month=r.date AND p.bnf_code=r.bnf_code ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lpzomnibus.json
+++ b/openprescribing/measure_definitions/lpzomnibus.json
@@ -26,7 +26,7 @@
   "include_in_alerts": false,
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(numerator) AS numerator, "
+    "SUM(numerator) AS numerator"
   ],
   "numerator_from": "{measures}.practice_data_all_low_priority ",
   "numerator_where": [
@@ -35,7 +35,7 @@
   "numerator_is_list_of_bnf_codes": false,
   "denominator_type": "custom",
   "denominator_columns": [
-    "SUM(denominator)/18 AS denominator, "
+    "SUM(denominator)/18 AS denominator"
   ],
   "denominator_from": "{measures}.practice_data_all_low_priority ",
   "denominator_where": [

--- a/openprescribing/measure_definitions/opioidome.json
+++ b/openprescribing/measure_definitions/opioidome.json
@@ -30,7 +30,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(total_ome) AS numerator, "
+    "SUM(total_ome) AS numerator"
   ],
   "numerator_from": "{measures}.opioid_total_ome ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/pregabalinmg.json
+++ b/openprescribing/measure_definitions/pregabalinmg.json
@@ -26,7 +26,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(lyrica_mg) AS numerator, "
+    "SUM(lyrica_mg) AS numerator"
   ],
   "numerator_from": "{measures}.pregabalin_total_mg ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/seven_day_prescribing.json
+++ b/openprescribing/measure_definitions/seven_day_prescribing.json
@@ -42,7 +42,7 @@
 	],
 	"numerator_type": "custom",
 	"numerator_columns": [
-		"SUM(total_quantity) AS numerator ,"
+		"SUM(total_quantity) AS numerator"
 	],
 	"numerator_from": "{hscic}.raw_prescribing_normalised",
 	"numerator_where": [
@@ -61,7 +61,7 @@
 	],
 	"denominator_type": "custom",
 	"denominator_columns": [
-		"SUM(total_quantity) AS denominator , "
+		"SUM(total_quantity) AS denominator"
 	],
 	"denominator_from": "{hscic}.raw_prescribing_normalised",
 	"denominator_where": [

--- a/openprescribing/measure_definitions/sildenafil.json
+++ b/openprescribing/measure_definitions/sildenafil.json
@@ -28,7 +28,7 @@
   ],
   "numerator_type": "custom",
   "numerator_columns": [
-    "SUM(items) AS numerator, "
+    "SUM(items) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard ",
   "numerator_where": [

--- a/openprescribing/measure_definitions/tamoxifen.json
+++ b/openprescribing/measure_definitions/tamoxifen.json
@@ -34,7 +34,7 @@
     "WHEN bnf_name LIKE '%Liq%' THEN 10 ",
     "WHEN RTRIM(bnf_name) LIKE '%10mg' THEN 2 ",
     "WHEN RTRIM(bnf_name) LIKE '%40mg' THEN 0.5 ",
-    "ELSE 1 END) AS numerator, "
+    "ELSE 1 END) AS numerator"
   ],
   "numerator_from": "{hscic}.normalised_prescribing_standard ",
   "numerator_where": [


### PR DESCRIPTION
Previously we attempted to automatically strip trailing commas from numerator/denominator column definitions. However this would break in the presence of a comment after the trailing comma which made things quite confusing.

This PR removes all trailing commas from existing measure definitions and then removes the code which attempts to strip them.