### PR TITLE
Use `ons_code` for ID of rows in `public.stp` table

### DIFF
--- a/openprescribing/bq_public_tables/stp.sql
+++ b/openprescribing/bq_public_tables/stp.sql
@@ -1,4 +1,4 @@
 SELECT
-    code AS id,
+    ons_code AS id,
     name
 FROM {hscic}.stps


### PR DESCRIPTION
* `hscic.stps` doesn't have a `code` column yet.
* The `public.ccg` table has a foreign key called `stp_id` which
  contains an ONS code.
* Once we have ODS codes for STPs, we can update both `public.stp` and
  `public.ccg`.
* That this will change is already reflected in the draft documentation.