### PR TITLE
Create raw_prescribing table in create_bq_measure_views

### DIFF
--- a/openprescribing/pipeline/management/commands/create_bq_measure_views.py
+++ b/openprescribing/pipeline/management/commands/create_bq_measure_views.py
@@ -3,6 +3,7 @@ import os
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from frontend.bq_schemas import RAW_PRESCRIBING_SCHEMA
 from gcutils.bigquery import Client, build_schema
 from google.cloud.exceptions import Conflict
 
@@ -14,6 +15,15 @@ class Command(BaseCommand):
         base_path = os.path.join(
             settings.APPS_ROOT, "frontend", "management", "commands", "measure_sql"
         )
+
+        try:
+            Client("hscic").create_storage_backed_table(
+                "raw_prescribing",
+                RAW_PRESCRIBING_SCHEMA,
+                "gs://ebmdatalabtest/hscic/prescribing/20*Detailed_Prescribing_Information.csv",
+            )
+        except Conflict:
+            pass
 
         client = Client("measures")
 

--- a/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
+++ b/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
@@ -76,11 +76,6 @@ def run_end_to_end():
     client.create_table("presentation", schemas.PRESENTATION_SCHEMA)
     client.create_table("tariff", schemas.TARIFF_SCHEMA)
     client.create_table("bdz_adq", schemas.BDZ_ADQ_SCHEMA)
-    client.create_storage_backed_table(
-        "raw_prescribing",
-        schemas.RAW_PRESCRIBING_SCHEMA,
-        "gs://ebmdatalabtest/hscic/prescribing/20*Detailed_Prescribing_Information.csv",
-    )
 
     client = BQClient("measures")
     # This is enough of a schema to allow the practice_data_all_low_priority


### PR DESCRIPTION
It needs to be created after import_hscic_prescribing has been run, and
before raw_prescribing_normalised is created.