### PR TITLE
Fix filtering of PCN pages from numbers checker

### DIFF
--- a/openprescribing/pipeline/management/commands/check_numbers.py
+++ b/openprescribing/pipeline/management/commands/check_numbers.py
@@ -121,9 +121,8 @@ def paths_to_scrape():
             continue
 
         # We don't have any PCN data yet, but when we do... TODO remove this
-        if "pcn_code" in keys:
+        if re.search(r"(^|/)pcn/", pattern):
             continue
-
         path = build_path(pattern, keys)
         yield name, path
 


### PR DESCRIPTION
At present we have no PCN data, so we want to exclude those pages from
the numbers checker. The previous method didn't work correctly because
it doesn't catch the PCN URLs which use `entity_code` rather than
`pcn_code`.

I spotted this because the numbers checker threw a TimeoutError on the
page `/measure/ace/pcn/0205051R0BBAIAN/` (which is substituting a BNF
code for a PCN code). I couldn't work out what had changed which made
this work before and fail now, but I think the answer is - nothing: the
server was under high load at the time and it was pure chance that it
timed out on this particular page. Ordinarily the page gives a 404,
which consistently has no numbers on it so the numbers checker is quite
happy. (Selenium doesn't give you the status code of pages: as long as
it gets some HTML it's happy.)