### PR TITLE
Create raw_prescribing table correctly

### DIFF
--- a/openprescribing/gcutils/bigquery.py
+++ b/openprescribing/gcutils/bigquery.py
@@ -161,11 +161,6 @@ class Client(object):
         return table
 
     def create_storage_backed_table(self, table_id, schema, gcs_path):
-        gcs_client = StorageClient()
-        bucket = gcs_client.bucket()
-        if bucket.get_blob(gcs_path) is None:
-            raise RuntimeError("Could not find blob at {}".format(gcs_path))
-
         gcs_uri = "gs://{}/{}".format(self.project, gcs_path)
         schema_as_dict = [
             {"name": s.name, "type": s.field_type.lower()} for s in schema

--- a/openprescribing/pipeline/management/commands/create_bq_measure_views.py
+++ b/openprescribing/pipeline/management/commands/create_bq_measure_views.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             Client("hscic").create_storage_backed_table(
                 "raw_prescribing",
                 RAW_PRESCRIBING_SCHEMA,
-                "gs://ebmdatalabtest/hscic/prescribing/20*Detailed_Prescribing_Information.csv",
+                "hscic/prescribing/20*Detailed_Prescribing_Information.csv",
             )
         except Conflict:
             pass


### PR DESCRIPTION
We have to lose the check that the blob exists, because we're using a
wildcard.  In any case, it's not a very useful check.