### PR TITLE
Only clear Cloudflare cache in production

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -273,7 +273,8 @@ def setup_env_from_environment(environment):
 
 @task
 def clear_cloudflare():
-    setup_env_from_environment("production")
+    if env.environment != "production":
+        return
 
     with cd(env.path):
         with prefix("source .venv/bin/activate"):


### PR DESCRIPTION
This fixes the problem that setup_env_from_environment changes the env
global, meaning that anything that happens after clear_cloudflare() runs
in the production environment, even on staging.

Rather than reorder the commands in deploy(), we may as well only clear
the Cloudflare cache in production.