### PR TITLE
Don't build changed measures on deploy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -296,7 +296,7 @@ def deploy(environment, force_build=False, branch="master"):
         npm_build_css(force_build)
         deploy_static()
         run_migrations()
-        build_changed_measures()
+        # build_changed_measures()
         graceful_reload()
         clear_cloudflare()
         setup_cron()


### PR DESCRIPTION
This matches the version of the fabfile that ebmbot has

We should revisit this, and either:

* work out why it wasn't working and fix it,
* or make deploying measures something you do via Slack