### PR TITLE
Mark some measures as having no analyse_url

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -326,7 +326,8 @@ def create_or_update_measure(measure_def, end_date):
             get_num_or_denom_bnf_codes(measure, num_or_denom, end_date),
         )
 
-    measure.analyse_url = build_analyse_url(measure)
+    if not v.get("no_analyse_url"):
+        measure.analyse_url = build_analyse_url(measure)
 
     measure.save()
 

--- a/openprescribing/measure_definitions/bdzper1000.json
+++ b/openprescribing/measure_definitions/bdzper1000.json
@@ -39,5 +39,6 @@
     "p.bnf_code NOT LIKE '0401020K0%AE' AND --Diazepam_Soln 10mg/2.5ml Rectal Tube \n",
     "p.bnf_code NOT LIKE '0401020K0%BQ'     --Diazepam_Soln 2.5mg/1.25ml Rectal Tube"
   ],
-  "denominator_type": "list_size"
+  "denominator_type": "list_size",
+  "no_analyse_url": true
 }

--- a/openprescribing/measure_definitions/gabapentinoidsddd.json
+++ b/openprescribing/measure_definitions/gabapentinoidsddd.json
@@ -38,6 +38,7 @@
   ],
   "numerator_bnf_codes_query": "SELECT DISTINCT presentation_code FROM {hscic}.bnf WHERE presentation_code LIKE '0408010AE%' or presentation_code LIKE '0408010G0%'",
   "denominator_type": "list_size",
+  "no_analyse_url": true,
   "date_reviewed": [
     "2019-06-25"
   ],

--- a/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
+++ b/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
@@ -49,5 +49,6 @@
     "bnf_code LIKE '0501130R0%AA' OR --Nitrofurantoin_Cap 50mg (brands and generic) \n",
     "bnf_code LIKE '0501130R0%AD' OR --Nitrofurantoin_Tab 50mg (brands and generic) \n",
     "bnf_code LIKE '0501130R0%AG' --Nitrofurantoin_Cap 100mg M/R (brands and generic)"
-  ]
+  ],
+  "no_analyse_url": true
 }

--- a/openprescribing/measure_definitions/pregabalinmg.json
+++ b/openprescribing/measure_definitions/pregabalinmg.json
@@ -33,5 +33,6 @@
     "1 = 1"
   ],
   "numerator_bnf_codes_query": "SELECT DISTINCT presentation_code FROM {hscic}.bnf WHERE presentation_code LIKE '0408010AE%'",
-  "denominator_type": "list_size"
+  "denominator_type": "list_size",
+  "no_analyse_url": true
 }

--- a/openprescribing/measure_definitions/sildenafil.json
+++ b/openprescribing/measure_definitions/sildenafil.json
@@ -71,5 +71,6 @@
   "denominator_type": "bnf_items",
   "denominator_where": [
     "bnf_code LIKE '070405%' --Drugs For Erectile Dysfunction"
-  ]
+  ],
+  "no_analyse_url": true
 }


### PR DESCRIPTION
Because of non-standard numerators, certain measures cannot be
adequately represented via the analyse page:

* bdzper1000 -- numerator_columns: SUM(p.quantity * r.percent_of_adq)
* gabapentinoidsddd -- numerator_columns: SUM(gaba_ddd)
* ktt9_uti_antibiotics -- numerator_columns: SUM(p.quantity * r.adq_per_quantity)
* pregabalinmg -- numerator_columns: SUM(lyrica_mg) AS numerator"
* sildenafil -- numerator_where returns different things depending on the month