### PR TITLE
Remove "compare all PCNs" link

### DIFF
--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -512,19 +512,20 @@ class MeasuresTests(SeleniumTestCase):
             "Split the measure into charts for individual practices",
             "/pcn/E00000000/core_0/",
         )
+        # Disabled for now (see commit message)
+        # self._verify_link(
+        #     panel_element,
+        #     ".inner li:nth-child(3)",
+        #     "Compare all PCNs in England on this measure",
+        #     "/measure/core_0/pcn/",
+        # )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all PCNs in England on this measure",
-            "/measure/core_0/pcn/",
-        )
-        self._verify_link(
-            panel_element,
-            ".inner li:nth-child(4)",
             "View this measure on the analyse page",
             MEASURE_CORE_0_ANALYSE_URL,
         )
-        self._verify_num_elements(panel_element, ".inner li", 4)
+        self._verify_num_elements(panel_element, ".inner li", 3)
 
         panel_element = self._find_measure_panel("measure_lpzomnibus")
         self._verify_link(
@@ -551,19 +552,20 @@ class MeasuresTests(SeleniumTestCase):
             "Split the measure into charts for individual practices",
             "/pcn/E00000000/lpzomnibus/",
         )
+        # Disabled for now (see commit message)
+        # self._verify_link(
+        #     panel_element,
+        #     ".inner li:nth-child(4)",
+        #     "Compare all PCNs in England on this measure",
+        #     "/measure/lpzomnibus/pcn/",
+        # )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(4)",
-            "Compare all PCNs in England on this measure",
-            "/measure/lpzomnibus/pcn/",
-        )
-        self._verify_link(
-            panel_element,
-            ".inner li:nth-child(5)",
             "View this measure on the analyse page",
             MEASURE_LPZOMNIBUS_ANALYSE_URL,
         )
-        self._verify_num_elements(panel_element, ".inner li", 5)
+        self._verify_num_elements(panel_element, ".inner li", 4)
 
     def test_measures_for_one_pcn_low_priority(self):
         self._get("/pcn/E00000000/measures/?tags=lowpriority")
@@ -587,19 +589,20 @@ class MeasuresTests(SeleniumTestCase):
             "Split the measure into charts for individual practices",
             "/pcn/E00000000/lp_2/",
         )
+        # Disabled for now (see commit message)
+        # self._verify_link(
+        #     panel_element,
+        #     ".inner li:nth-child(3)",
+        #     "Compare all PCNs in England on this measure",
+        #     "/measure/lp_2/pcn/",
+        # )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all PCNs in England on this measure",
-            "/measure/lp_2/pcn/",
-        )
-        self._verify_link(
-            panel_element,
-            ".inner li:nth-child(4)",
             "View this measure on the analyse page",
             MEASURE_LP_2_ANALYSE_URL,
         )
-        self._verify_num_elements(panel_element, ".inner li", 4)
+        self._verify_num_elements(panel_element, ".inner li", 3)
 
     def test_measures_for_one_stp(self):
         self._get("/stp/E00000000/measures/")
@@ -1003,19 +1006,20 @@ class MeasuresTests(SeleniumTestCase):
             "Split the measure into charts for individual practices",
             "/pcn/E00000000/lp_2/",
         )
+        # Disabled for now (see commit message)
+        # self._verify_link(
+        #     panel_element,
+        #     ".inner li:nth-child(2)",
+        #     "Compare all PCNs in England on this measure",
+        #     "/measure/lp_2/pcn/",
+        # )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all PCNs in England on this measure",
-            "/measure/lp_2/pcn/",
-        )
-        self._verify_link(
-            panel_element,
-            ".inner li:nth-child(3)",
             "View this measure on the analyse page",
             MEASURE_LP_2_ANALYSE_URL,
         )
-        self._verify_num_elements(panel_element, ".inner li", 3)
+        self._verify_num_elements(panel_element, ".inner li", 2)
 
     def test_measure_for_one_stp(self):
         self._get("/measure/lp_2/stp/E00000000/")

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1417,7 +1417,9 @@ def _add_measure_for_siblings_url(options, entity_type):
 def _add_measure_url(options, entity_type):
     if entity_type == "practice":
         options["measureUrlTemplate"] = _url_template("measure_for_all_ccgs")
-    else:
+    # We're deliberately not showing a link to compare all PCNS for "political"
+    # reasons
+    elif entity_type != "pcn":
         options["measureUrlTemplate"] = _url_template(
             "measure_for_all_{}s".format(entity_type)
         )

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -93,7 +93,9 @@
                 {{#if measureForSiblingsUrl }}
                   <li><a href="{{ measureForSiblingsUrl }}">Compare all practices in this CCG on this measure</a></li>
                 {{/if}}
-                <li><a href="{{ measureUrl }}">Compare all {{ comparisonOrgTypeHuman }}s in England on this measure</a></li>
+                {{#if measureUrl }}
+                  <li><a href="{{ measureUrl }}">Compare all {{ comparisonOrgTypeHuman }}s in England on this measure</a></li>
+                {{/if}}
                 {{#if analyseUrl }}
                   <li><a href="{{ analyseUrl }}">View this measure on the analyse page</a>.</li>
                 {{/if}}


### PR DESCRIPTION
We don't want to make this too easy to do right now.