### PR TITLE
Hide Analyse alert signup form until search is made

### DIFF
--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -231,9 +231,9 @@ var analyseChart = {
     var alertForm = $(_this.el.alertForm);
     var title = encodeURIComponent(
       _this.globalOptions.friendly.chartTitle.replace(/<br\/>/g, ''));
-    alertForm.parent().show();
-    $('[name="url"]').val(this.hash);
-    $('[name="name"]').val(title);
+    alertForm.find('[name="url"]').val(this.hash);
+    alertForm.find('[name="name"]').val(title);
+    alertForm.show();
   },
 
   setUpSaveUrlUI: function() {

--- a/openprescribing/templates/_alert_signup_form.html
+++ b/openprescribing/templates/_alert_signup_form.html
@@ -1,5 +1,5 @@
 {% load crispy_forms_tags %}
-<form method="post" class="form form-inline">
+<form method="post" class="form form-inline" id="alert-form" {% if alert_type == 'analyse' %}style="display: none"{% endif%}>
  {% csrf_token %}
  <p>
    {% if alert_type == 'analyse' %}


### PR DESCRIPTION
This was the original behaviour of the form but it was broken in
7979fc495. Previously if someone did try to subscribe without having
created a search it would create a SearchBookmark with an empty URL.
Since #2271 it now triggers a `MultipleObjectsReturned` error, which is
how it got spotted.

Closes #2062