### PR TITLE
Remove analyse_url length limit

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -358,9 +358,6 @@ def build_analyse_url(measure):
     querystring = urlencode(params)
     url = "{}#{}".format(reverse("analyse"), querystring)
 
-    if len(url) > 1000:
-        return
-
     return url
 
 


### PR DESCRIPTION
A limit of 1000 characters was always slightly arbitrary.  Long URLs may
cause problems with older versions of IE, but very few visitors now use
older IEs.  See https://stackoverflow.com/q/417142.