### PR TITLE
Fix CSV download URL on numerator breakdown page

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -455,7 +455,8 @@ def measure_for_one_entity(request, measure, entity_code, entity_type):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
-        "numerator_breakdown_url": "{}?{}".format(
+        "numerator_breakdown_url": "{}{}?{}".format(
+            settings.API_HOST,
             reverse("measure_numerators_by_org"),
             urlencode(
                 {"org": entity.code, "org_type": entity_type, "measure": measure.id}
@@ -492,7 +493,8 @@ def measure_for_all_england(request, measure):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
-        "numerator_breakdown_url": "{}?{}".format(
+        "numerator_breakdown_url": "{}{}?{}".format(
+            settings.API_HOST,
             reverse("measure_numerators_by_org"),
             urlencode({"org": "", "org_type": entity_type, "measure": measure.id}),
         ),

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -455,12 +455,9 @@ def measure_for_one_entity(request, measure, entity_code, entity_type):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
-        "numerator_breakdown_url": "{}{}?{}".format(
-            settings.API_HOST,
-            reverse("measure_numerators_by_org"),
-            urlencode(
-                {"org": entity.code, "org_type": entity_type, "measure": measure.id}
-            ),
+        "numerator_breakdown_url": _build_api_url(
+            "measure_numerators_by_org",
+            {"org": entity.code, "org_type": entity_type, "measure": measure.id},
         ),
     }
     return render(request, "measure_for_one_entity.html", context)
@@ -493,10 +490,9 @@ def measure_for_all_england(request, measure):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
-        "numerator_breakdown_url": "{}{}?{}".format(
-            settings.API_HOST,
-            reverse("measure_numerators_by_org"),
-            urlencode({"org": "", "org_type": entity_type, "measure": measure.id}),
+        "numerator_breakdown_url": _build_api_url(
+            "measure_numerators_by_org",
+            {"org": "", "org_type": entity_type, "measure": measure.id},
         ),
     }
     return render(request, "measure_for_one_entity.html", context)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -455,6 +455,12 @@ def measure_for_one_entity(request, measure, entity_code, entity_type):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
+        "numerator_breakdown_url": "{}?{}".format(
+            reverse("measure_numerators_by_org"),
+            urlencode(
+                {"org": entity.code, "org_type": entity_type, "measure": measure.id}
+            ),
+        ),
     }
     return render(request, "measure_for_one_entity.html", context)
 
@@ -486,6 +492,10 @@ def measure_for_all_england(request, measure):
         "measure": measure,
         "measure_options": measure_options,
         "current_at": ImportLog.objects.latest_in_category("prescribing").current_at,
+        "numerator_breakdown_url": "{}?{}".format(
+            reverse("measure_numerators_by_org"),
+            urlencode({"org": "", "org_type": entity_type, "measure": measure.id}),
+        ),
     }
     return render(request, "measure_for_one_entity.html", context)
 

--- a/openprescribing/templates/_measure_breakdown_table.html
+++ b/openprescribing/templates/_measure_breakdown_table.html
@@ -5,7 +5,7 @@
   $('#numerator_breakdown').DataTable(
     {
       "ajax": {
-        "url": "{{ API_HOST }}/api/1.0/measure_numerators_by_org/?org={{ entity.code }}&org_type={{ entity_type }}&measure={{ measure.id }}&format=json",
+        "url": "{{ numerator_breakdown_url|escapejs }}&format=json",
         "dataSrc": ""
       },
       "order": [[1, "desc"]],

--- a/openprescribing/templates/measure_for_one_entity.html
+++ b/openprescribing/templates/measure_for_one_entity.html
@@ -69,7 +69,7 @@
       </tbody>
     </table>
 
-    <a class="btn btn-primary" href="{% url 'measure_numerators_by_org' %}?org={{ entity.code }}&measure={{ measure.id }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
+    <a class="btn btn-primary" href="{{ numerator_breakdown_url }}&amp;format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
 
     <hr>
 


### PR DESCRIPTION
Previously, the URLs were built seperately for the DataTable request and
for the download link. This made it easy to omit the `org_type`
parameter from the download link. In addition, there is some backwards
compatibility code which makes the org type optional and, if it is
omitted, tries to guess the type from the length of the code. So in
fact, the download link worked OK for practices and CCGs which is
probably why we never noticed the issue before. The addition of PCNs
made the problem more obvious.

The fix here is to generate the URL once, inside the view, and then use
it both places.