### PR TITLE
Call create_normalised_prescribing_view directly in e2e setup

### DIFF
--- a/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
+++ b/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
@@ -104,7 +104,7 @@ def run_end_to_end():
     for model in apps.get_app_config("dmd").get_models():
         client.upload_model(model)
 
-    call_command("generate_presentation_replacements")
+    call_command("create_normalised_prescribing_view")
 
     copy_tree(os.path.join(e2e_path, "data-1"), os.path.join(e2e_path, "data"))
 


### PR DESCRIPTION
Since 0375e05b, create_normalised_prescribing_view is not called as part
of generate_presentation_replacements.  And I'm fairly sure that the
only reason we called generate_presentation_replacements in the e2e
setup was to ensure that normalised_prescribing_* existed.