### PR TITLE
Include unsubscribe link in confirmation email

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1118,11 +1118,16 @@ def _send_alert_signup_confirmation(user):
     """Send email confirming that user has signed up for alert."""
 
     subject = "[OpenPrescribing] Your OpenPrescribing alert subscription"
+    context = {
+        "user": user,
+        "unsubscribe_link": settings.GRAB_HOST
+        + reverse("bookmarks", kwargs={"key": user.profile.key}),
+    }
 
     bodies = {}
     for ext in ["html", "txt"]:
         template_name = "account/email/email_confirmation_signup_message." + ext
-        bodies[ext] = render_to_string(template_name, {"user": user}).strip()
+        bodies[ext] = render_to_string(template_name, context).strip()
 
     msg = EmailMultiAlternatives(
         subject, bodies["txt"], settings.DEFAULT_FROM_EMAIL, [user.email]

--- a/openprescribing/templates/account/email/email_confirmation_signup_message.html
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.html
@@ -2,7 +2,7 @@
 
 <p>You've been subscribed to alerts about {{ user.profile.most_recent_bookmark.topic }}.</p>
 
-<p>You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.</p>
+<p>You can unsubscribe from this service at any time using the <a href="{{ unsubscribe_link }}">Unsubscribe</a> link, which will also be provided in each email we send.</p>
 
 <p>Thanks,</p>
 

--- a/openprescribing/templates/account/email/email_confirmation_signup_message.txt
+++ b/openprescribing/templates/account/email/email_confirmation_signup_message.txt
@@ -2,7 +2,8 @@
 
 You've been subscribed to alerts about {{ user.profile.most_recent_bookmark.topic }}.
 
-You can unsubscribe from this service at any time using the "Unsubscribe" link provided in each email we send.
+You can unsubscribe from this service at any time using the "Unsubscribe" link, which will also be provided in each email we send:
+{{ unsubscribe_link }}
 
 {% endautoescape %}
 


### PR DESCRIPTION
Just noticed while testing something that we don't do this (I think it
was basically impossible to do under the AllAuth regieme). Given that
we're not requiring confirmation any more I think it's more important
that we give people an easy way to unsubsribe in case they do so
accidentally or someone puts the wrong email address in.