### PR TITLE
Create bnf_map table in BQ in e2e test setup

### DIFF
--- a/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
+++ b/openprescribing/pipeline/management/commands/run_pipeline_e2e_tests.py
@@ -63,6 +63,7 @@ def run_end_to_end():
 
     client = BQClient("hscic")
     client.create_table("bnf", schemas.BNF_SCHEMA)
+    client.create_table("bnf_map", schemas.BNF_MAP_SCHEMA)
     client.create_table("pcns", schemas.PCN_SCHEMA)
     client.create_table("ccgs", schemas.CCG_SCHEMA)
     client.create_table("stps", schemas.STP_SCHEMA)


### PR DESCRIPTION
It was created by generate_presentation_replacements, which we no longer
call.