### PR TITLE
Tag  green nice

### DIFF
--- a/openprescribing/measure_definitions/arb.json
+++ b/openprescribing/measure_definitions/arb.json
@@ -23,7 +23,8 @@
   "tags": [
     "cardiovascular",
     "core",
-    "cost"
+    "cost",
+    "nice"
   ],
   "numerator_type": "bnf_quantity",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ciclosporin.json
+++ b/openprescribing/measure_definitions/ciclosporin.json
@@ -22,7 +22,8 @@
   "tags": [
     "core",
     "generic",
-    "safety"
+    "safety",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/dipyridamole.json
+++ b/openprescribing/measure_definitions/dipyridamole.json
@@ -29,7 +29,8 @@
   "tags": [
     "cardiovascular",
     "core",
-    "efficacy"
+    "efficacy",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/doacs.json
+++ b/openprescribing/measure_definitions/doacs.json
@@ -24,7 +24,8 @@
   "low_is_good": null,
   "tags": [
     "cardiovascular",
-    "core"
+    "core",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -25,6 +25,8 @@
   "low_is_good": true,
   "tags": [
     "core",
+    "greenernhs",
+    "nice",
     "respiratory"
   ],
   "numerator_type": "bnf_items",

--- a/openprescribing/measure_definitions/ktt12_diabetes_insulin.json
+++ b/openprescribing/measure_definitions/ktt12_diabetes_insulin.json
@@ -22,7 +22,8 @@
   "tags": [
     "core",
     "cost",
-    "diabetes"
+    "diabetes",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ktt13_nsaids_ibuprofen.json
+++ b/openprescribing/measure_definitions/ktt13_nsaids_ibuprofen.json
@@ -24,6 +24,7 @@
   "tags": [
     "cardiovascular",
     "core",
+    "nice",
     "pain",
     "safety"
   ],

--- a/openprescribing/measure_definitions/ktt9_antibiotics.json
+++ b/openprescribing/measure_definitions/ktt9_antibiotics.json
@@ -22,7 +22,8 @@
   "tags": [
     "antimicrobial",
     "core",
-    "infections"
+    "infections",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ktt9_cephalosporins.json
+++ b/openprescribing/measure_definitions/ktt9_cephalosporins.json
@@ -24,7 +24,8 @@
   "tags": [
     "antimicrobial",
     "core",
-    "infections"
+    "infections",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ktt9_cephalosporins_star.json
+++ b/openprescribing/measure_definitions/ktt9_cephalosporins_star.json
@@ -22,7 +22,8 @@
   "tags": [
     "antimicrobial",
     "core",
-    "infections"
+    "infections",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
+++ b/openprescribing/measure_definitions/ktt9_uti_antibiotics.json
@@ -28,7 +28,8 @@
   "tags": [
     "antimicrobial",
     "core",
-    "infections"
+    "infections",
+    "nice"
   ],
   "numerator_type": "custom",
   "numerator_columns": [

--- a/openprescribing/measure_definitions/lpaliskiren.json
+++ b/openprescribing/measure_definitions/lpaliskiren.json
@@ -20,8 +20,9 @@
   "low_is_good": true,
   "tags": [
     "cost",
-    "lowpriority",
-    "cardiovascular"
+    "cardiovascular",
+    "lowpriority",    
+    "nice"
   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lpdosulepin.json
+++ b/openprescribing/measure_definitions/lpdosulepin.json
@@ -21,6 +21,7 @@
     "cost",
     "lowpriority",
     "mentalhealth",
+    "nice",
     "safety"
   ],
   "numerator_type": "bnf_cost",

--- a/openprescribing/measure_definitions/lpdronedarone.json
+++ b/openprescribing/measure_definitions/lpdronedarone.json
@@ -22,8 +22,10 @@
   "low_is_good": true,
   "tags": [
     "cost",
+    "cardiovascular",
     "lowpriority",
     "cardiovascular",
+    "nice",
     "safety"
   ],
   "numerator_type": "bnf_cost",

--- a/openprescribing/measure_definitions/lpglucosamine.json
+++ b/openprescribing/measure_definitions/lpglucosamine.json
@@ -19,7 +19,8 @@
   "tags": [
     "cost",
     "efficacy",
-    "lowpriority"
+    "lowpriority",
+    "nice"
   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lplidocaine.json
+++ b/openprescribing/measure_definitions/lplidocaine.json
@@ -21,6 +21,7 @@
     "cost",
     "efficacy",
     "lowpriority",
+    "nice",
     "pain"
   ],
   "numerator_type": "bnf_cost",

--- a/openprescribing/measure_definitions/lpminocycline.json
+++ b/openprescribing/measure_definitions/lpminocycline.json
@@ -21,8 +21,10 @@
   "tags": [
     "antimicrobial",
     "cost",
+    "lowpriority",
+    "nice",
     "safety",
-    "lowpriority"
+    
   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [

--- a/openprescribing/measure_definitions/lpminocycline.json
+++ b/openprescribing/measure_definitions/lpminocycline.json
@@ -23,9 +23,8 @@
     "cost",
     "lowpriority",
     "nice",
-    "safety",
-    
-  ],
+    "safety"
+   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [
     "bnf_code LIKE '0501030P0%' --Minocycline Hydrochloride"

--- a/openprescribing/measure_definitions/lpomega3.json
+++ b/openprescribing/measure_definitions/lpomega3.json
@@ -20,7 +20,8 @@
     "cardiovascular",
     "cost",
     "efficacy",
-    "lowpriority"
+    "lowpriority",
+    "nice"
   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [

--- a/openprescribing/measure_definitions/other_lipid_modifying_drugs.json
+++ b/openprescribing/measure_definitions/other_lipid_modifying_drugs.json
@@ -22,7 +22,7 @@
   "tags": [
     "cardiovascular",
     "core",
-    "efficacy"
+    "efficacy",
     "nice"
   ],
   "numerator_type": "bnf_cost",

--- a/openprescribing/measure_definitions/other_lipid_modifying_drugs.json
+++ b/openprescribing/measure_definitions/other_lipid_modifying_drugs.json
@@ -23,6 +23,7 @@
     "cardiovascular",
     "core",
     "efficacy"
+    "nice"
   ],
   "numerator_type": "bnf_cost",
   "numerator_where": [

--- a/openprescribing/measure_definitions/ppidose.json
+++ b/openprescribing/measure_definitions/ppidose.json
@@ -24,6 +24,7 @@
   "tags": [
     "core",
     "gastrointestinal",
+    "nice",
     "safety"
   ],
   "numerator_type": "bnf_items",

--- a/openprescribing/measure_definitions/seven_day_prescribing.json
+++ b/openprescribing/measure_definitions/seven_day_prescribing.json
@@ -20,7 +20,9 @@
     "include; a seven day prescription may be clinically relevant even for long-term conditions in certain circumstances, some",
     "pharmacies will supply a MCA without a seven day prescritpion after making an individual assessement, and some local areas",
     "may fund provision of MCAs via a seperate payment. Locally you may wish to review presciptions of seven duration for clinical",
-    "appropriateness.",
+    "appropriateness. Additionally the NHS Long Term Plan has set out targets for the NHS to reduce the negative impact it has on the",
+    "environment. Many MCAs will be single use plastics or cardboards so if they are being supplied inappropriately there will ",
+    "be an oppurtunity to reduce waste in this area.",
     "<p>The medicines we have used for the measure are generally used once daily for longterm conditions: atorvastatin, ",
     "simvastatin, levothyroxine, amlodipine and ramipril.",
     "<p><b>Please note that this is an experimental measure. We would be grateful for any feedback at",
@@ -38,7 +40,8 @@
 	"low_is_good": true,
 	"tags": [
 		"core",
-		"safety"
+		"safety",
+		"greenernhs"
 	],
 	"numerator_type": "custom",
 	"numerator_columns": [

--- a/openprescribing/measure_definitions/silver.json
+++ b/openprescribing/measure_definitions/silver.json
@@ -22,7 +22,8 @@
   "tags": [
     "core",
     "efficacy",
-    "infections"
+    "infections",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/statinintensity.json
+++ b/openprescribing/measure_definitions/statinintensity.json
@@ -24,7 +24,8 @@
   "tags": [
     "cardiovascular",
     "core",
-    "efficacy"
+    "efficacy",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [

--- a/openprescribing/measure_definitions/tamoxifen.json
+++ b/openprescribing/measure_definitions/tamoxifen.json
@@ -25,6 +25,7 @@
   "is_cost_based": false,
   "low_is_good": null,
   "tags": [
+    "nice",
     "paper"
   ],
   "include_in_alerts": false,

--- a/openprescribing/measure_definitions/vitb.json
+++ b/openprescribing/measure_definitions/vitb.json
@@ -24,7 +24,8 @@
   "low_is_good": true,
   "tags": [
     "core",
-    "efficacy"
+    "efficacy",
+    "nice"
   ],
   "numerator_type": "bnf_items",
   "numerator_where": [


### PR DESCRIPTION
I have updated measure definitions to tag them for NICE or Greener NHS Dashboard. There are 2 green measures currently and approximately 35 NICE ones.

I have tagged as nice if our _why it matters_ sections refers to 
- [NICE Clinical Knowledge Summaries](https://cks.nice.org.uk/#?char=A) These are commissioned by NICE but technically aren't a NICE product (this may be raised at some point)
- NICE Technology Appraisal 
- NICE Guidance 