### PR TITLE
Add `measures` ImportLog event

### DIFF
--- a/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
@@ -14,7 +14,7 @@ class CommandTestCase(ApiTestBase):
     def setUpTestData(cls):
         super(CommandTestCase, cls).setUpTestData()
         max_ppu_date = PPUSaving.objects.order_by("-date")[0].date
-        ImportLog.objects.create(current_at=max_ppu_date, category="ppu")
+        ImportLog.objects.create(current_at=max_ppu_date, category="measures")
 
     def test_send_alerts(self):
         factory = DataFactory()

--- a/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py
@@ -14,7 +14,7 @@ class CommandTestCase(ApiTestBase):
     def setUpTestData(cls):
         super(CommandTestCase, cls).setUpTestData()
         max_ppu_date = PPUSaving.objects.order_by("-date")[0].date
-        ImportLog.objects.create(current_at=max_ppu_date, category="measures")
+        ImportLog.objects.create(current_at=max_ppu_date, category="dashboard_data")
 
     def test_send_alerts(self):
         factory = DataFactory()

--- a/openprescribing/frontend/tests/fixtures/functional-measures.json
+++ b/openprescribing/frontend/tests/fixtures/functional-measures.json
@@ -48405,7 +48405,7 @@
     "imported_at": "2019-09-10T14:03:23.256Z",
     "current_at": "2018-08-01",
     "filename": "",
-    "category": "measures"
+    "category": "dashboard_data"
   }
 }
 ]

--- a/openprescribing/frontend/tests/fixtures/functional-measures.json
+++ b/openprescribing/frontend/tests/fixtures/functional-measures.json
@@ -48397,5 +48397,15 @@
     "filename": "",
     "category": "ppu"
   }
+},
+{
+  "model": "frontend.importlog",
+  "pk": 71,
+  "fields": {
+    "imported_at": "2019-09-10T14:03:23.256Z",
+    "current_at": "2018-08-01",
+    "filename": "",
+    "category": "measures"
+  }
 }
 ]

--- a/openprescribing/frontend/tests/fixtures/functional_test_data.json
+++ b/openprescribing/frontend/tests/fixtures/functional_test_data.json
@@ -1541,15 +1541,24 @@
     "category": "prescribing"
   }
 },
-  {
-    "model":"frontend.importlog",
-    "pk": 3,
-    "fields":
-    {"imported_at": "2016-06-23T13:25:15.003Z",
-     "current_at": "2015-09-01",
-     "filename": "/tmp/foo",
-     "category": "ppu"
-    }
+{
+  "model":"frontend.importlog",
+  "pk": 3,
+  "fields":
+  {"imported_at": "2016-06-23T13:25:15.003Z",
+   "current_at": "2015-09-01",
+   "filename": "/tmp/foo",
+   "category": "ppu"
   }
-
+},
+{
+  "model":"frontend.importlog",
+  "pk": 4,
+  "fields":
+  {"imported_at": "2016-06-23T13:25:15.003Z",
+   "current_at": "2015-09-01",
+   "filename": "/tmp/foo",
+   "category": "measures"
+  }
+}
 ]

--- a/openprescribing/frontend/tests/fixtures/functional_test_data.json
+++ b/openprescribing/frontend/tests/fixtures/functional_test_data.json
@@ -1558,7 +1558,7 @@
   {"imported_at": "2016-06-23T13:25:15.003Z",
    "current_at": "2015-09-01",
    "filename": "/tmp/foo",
-   "category": "measures"
+   "category": "dashboard_data"
   }
 }
 ]

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -875,7 +875,7 @@ def make_all_england_email(bookmark, tag=None):
     msg = initialise_email(bookmark, "all-england-alerts")
     msg.subject = "Your monthly update on prescribing across NHS England"
 
-    date = ImportLog.objects.latest_in_category("ppu").current_at
+    date = ImportLog.objects.latest_in_category("measures").current_at
 
     # This allows us to switch between calculating savings at the practice or
     # CCG level. We use CCG at present for performance reasons but we may want

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -875,7 +875,7 @@ def make_all_england_email(bookmark, tag=None):
     msg = initialise_email(bookmark, "all-england-alerts")
     msg.subject = "Your monthly update on prescribing across NHS England"
 
-    date = ImportLog.objects.latest_in_category("measures").current_at
+    date = ImportLog.objects.latest_in_category("dashboard_data").current_at
 
     # This allows us to switch between calculating savings at the practice or
     # CCG level. We use CCG at present for performance reasons but we may want

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -337,7 +337,7 @@ def all_england(request):
 
     tag_filter = _get_measure_tag_filter(request.GET)
     entity_type = request.GET.get("entity_type", "CCG")
-    date = _specified_or_last_date(request, "measures")
+    date = _specified_or_last_date(request, "dashboard_data")
     # We cache the results of these expensive function calls which only change
     # when `date` changes
     ppu_savings = cached(all_england_ppu_savings, entity_type, date)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -337,7 +337,7 @@ def all_england(request):
 
     tag_filter = _get_measure_tag_filter(request.GET)
     entity_type = request.GET.get("entity_type", "CCG")
-    date = _specified_or_last_date(request, "ppu")
+    date = _specified_or_last_date(request, "measures")
     # We cache the results of these expensive function calls which only change
     # when `date` changes
     ppu_savings = cached(all_england_ppu_savings, entity_type, date)

--- a/openprescribing/pipeline/management/commands/create_importlog_for_dashboard_data.py
+++ b/openprescribing/pipeline/management/commands/create_importlog_for_dashboard_data.py
@@ -3,8 +3,10 @@ from frontend.models import ImportLog
 
 
 class Command(BaseCommand):
-    help = "Records the fact that measures have finished importing"
+    help = (
+        "Records the fact that all data needed to render dashboards finished importing"
+    )
 
     def handle(self, *args, **kwargs):
         date = ImportLog.objects.latest_in_category("prescribing").current_at
-        ImportLog.objects.get_or_create(category="measures", current_at=date)
+        ImportLog.objects.get_or_create(category="dashboard_data", current_at=date)

--- a/openprescribing/pipeline/management/commands/create_importlog_for_measures.py
+++ b/openprescribing/pipeline/management/commands/create_importlog_for_measures.py
@@ -1,0 +1,10 @@
+from django.core.management import BaseCommand
+from frontend.models import ImportLog
+
+
+class Command(BaseCommand):
+    help = "Records the fact that measures have finished importing"
+
+    def handle(self, *args, **kwargs):
+        date = ImportLog.objects.latest_in_category("prescribing").current_at
+        ImportLog.objects.get_or_create(category="measures", current_at=date)

--- a/openprescribing/pipeline/metadata/tasks.json
+++ b/openprescribing/pipeline/metadata/tasks.json
@@ -277,6 +277,14 @@
             "upload_to_bigquery"
         ]
     },
+    "create_importlog_for_measures": {
+        "type": "post_process",
+        "command": "create_importlog_for_measures",
+        "dependencies": [
+            "import_measures",
+            "generate_ppu"
+        ]
+    },
     "import_generic_mappings": {
         "type": "post_process",
         "command": "import_generic_mappings",

--- a/openprescribing/pipeline/metadata/tasks.json
+++ b/openprescribing/pipeline/metadata/tasks.json
@@ -277,9 +277,9 @@
             "upload_to_bigquery"
         ]
     },
-    "create_importlog_for_measures": {
+    "create_importlog_for_dashboard_data": {
         "type": "post_process",
-        "command": "create_importlog_for_measures",
+        "command": "create_importlog_for_dashboard_data",
         "dependencies": [
             "import_measures",
             "generate_ppu"


### PR DESCRIPTION
This is created when all measures have finished importing and all PPU calculations have completed. The All England views now use this date, rather than just the PPU date, which should avoid the problems described in the two linked issues.

Closes #2228 
Closes #2391