### PR TITLE
Ensure max_errors is converted to int

### DIFF
--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -226,7 +226,7 @@ class Command(BaseCommand):
             .current_at.strftime("%Y-%m-%d")
             .lower()
         )
-        with EmailErrorDeferrer(options["max_errors"]) as error_deferrer:
+        with EmailErrorDeferrer(int(options["max_errors"])) as error_deferrer:
             for org_bookmark in self.get_org_bookmarks(now_month, **options):
                 error_deferrer.try_email(
                     self.send_org_bookmark_email, org_bookmark, now_month, options

--- a/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
@@ -136,7 +136,7 @@ class FailingEmailTestCase(TestCase):
         test_context = _makeContext(worst=[measure])
         self.assertEqual(EmailMessage.objects.count(), 1)
         with self.assertRaises(BatchedEmailErrors):
-            call_mocked_command(test_context, finder, max_errors=4)
+            call_mocked_command(test_context, finder, max_errors="4")
         self.assertEqual(EmailMessage.objects.count(), 3)
         self.assertEqual(len(mail.outbox), 2)
 
@@ -145,7 +145,7 @@ class FailingEmailTestCase(TestCase):
         measure = MagicMock()
         measure.id = "measureid"
         test_context = _makeContext(worst=[measure])
-        call_mocked_command(test_context, finder, max_errors=0)
+        call_mocked_command(test_context, finder, max_errors="0")
         self.assertEqual(len(mail.outbox), 0)
 
     def test_max_errors(self, attach_image, finder):
@@ -155,7 +155,7 @@ class FailingEmailTestCase(TestCase):
         test_context = _makeContext(worst=[measure])
         self.assertEqual(EmailMessage.objects.count(), 1)
         with self.assertRaises(BatchedEmailErrors):
-            call_mocked_command(test_context, finder, max_errors=0)
+            call_mocked_command(test_context, finder, max_errors="0")
         self.assertEqual(EmailMessage.objects.count(), 1)
         self.assertEqual(len(mail.outbox), 0)
 


### PR DESCRIPTION
Fixes issue raised in https://github.com/ebmdatalab/openprescribing/issues/2434#issuecomment-581976823