### PR TITLE
Support PCNs in alerts

### DIFF
--- a/openprescribing/frontend/forms.py
+++ b/openprescribing/frontend/forms.py
@@ -84,6 +84,19 @@ class OrgBookmarkForm(forms.Form):
     pcn_id = forms.CharField(widget=forms.HiddenInput(), required=False)
 
 
+class NCSOConcessionBookmarkForm(forms.Form):
+    email = forms.EmailField(
+        label="",
+        error_messages={
+            "required": "This can't be blank!",
+            "invalid": "Please enter a valid email address",
+        },
+        widget=forms.TextInput(attrs={"placeholder": "Email address", "size": "35"}),
+    )
+    pct_id = forms.CharField(widget=forms.HiddenInput(), required=False)
+    practice_id = forms.CharField(widget=forms.HiddenInput(), required=False)
+
+
 class FeedbackForm(forms.Form):
 
     # This incredibly crude captcha technique has proved enough in the past to

--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -863,7 +863,7 @@ class OrgBookmark(models.Model):
         elif self.practice is not None:
             return "practice"
         elif self.pcn is not None:
-            return "pcn"
+            return "PCN"
         else:
             return "all_england"
 

--- a/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
@@ -81,6 +81,7 @@ class GetBookmarksTestCase(TestCase):
             recipient_email="s@s.com",
             ccg="03V",
             practice="P87629",
+            pcn=None,
             recipient_email_file=None,
             skip_email_file=None,
         )

--- a/openprescribing/frontend/tests/test_bookmark_utils.py
+++ b/openprescribing/frontend/tests/test_bookmark_utils.py
@@ -228,35 +228,31 @@ class TestBookmarkUtilsPerforming(TestCase):
     # Worst performing
     # CCG bookmarks
     def test_hit_where_ccg_worst_in_specified_number_of_months(self):
-        finder = bookmark_utils.InterestingMeasureFinder(pct=self.pct)
+        finder = bookmark_utils.InterestingMeasureFinder(self.pct)
         worst_measures = finder.worst_performing_in_period(3)
         self.assertIn(self.measure, worst_measures)
         self.assertNotIn(self.exotic_measure, worst_measures)
 
     def test_miss_where_not_enough_global_data(self):
-        finder = bookmark_utils.InterestingMeasureFinder(pct=self.pct)
+        finder = bookmark_utils.InterestingMeasureFinder(self.pct)
         worst_measures = finder.worst_performing_in_period(6)
         self.assertFalse(worst_measures)
 
     def test_miss_where_not_worst_in_specified_number_of_months(self):
         MeasureValue.objects.all().delete()
-        finder = bookmark_utils.InterestingMeasureFinder(pct=self.pct)
+        finder = bookmark_utils.InterestingMeasureFinder(self.pct)
         worst_measures = finder.worst_performing_in_period(3)
         self.assertFalse(worst_measures)
 
     # Practice bookmarks
     def test_hit_where_practice_worst_in_specified_number_of_months(self):
-        finder = bookmark_utils.InterestingMeasureFinder(
-            practice=self.high_percentile_practice
-        )
+        finder = bookmark_utils.InterestingMeasureFinder(self.high_percentile_practice)
         worst_measures = finder.worst_performing_in_period(3)
         self.assertIn(self.measure, worst_measures)
 
     # Best performing
     def test_hit_where_practice_best_in_specified_number_of_months(self):
-        finder = bookmark_utils.InterestingMeasureFinder(
-            practice=self.low_percentile_practice
-        )
+        finder = bookmark_utils.InterestingMeasureFinder(self.low_percentile_practice)
         best_measures = finder.best_performing_in_period(3)
         self.assertIn(self.measure, best_measures)
 
@@ -334,7 +330,7 @@ class TestBookmarkUtilsChanging(TestCase):
 
     def test_high_change_returned(self):
         finder = bookmark_utils.InterestingMeasureFinder(
-            practice=self.practice_with_high_change, interesting_change_window=10
+            self.practice_with_high_change, interesting_change_window=10
         )
         sorted_measure = finder.most_change_against_window(1)
         measure_info = sorted_measure["improvements"][0]
@@ -346,7 +342,7 @@ class TestBookmarkUtilsChanging(TestCase):
         self.measure.low_is_good = True
         self.measure.save()
         finder = bookmark_utils.InterestingMeasureFinder(
-            practice=self.practice_with_high_change, interesting_change_window=10
+            self.practice_with_high_change, interesting_change_window=10
         )
         sorted_measure = finder.most_change_against_window(1)
         measure_info = sorted_measure["declines"][0]
@@ -356,7 +352,7 @@ class TestBookmarkUtilsChanging(TestCase):
 
     def test_high_negative_change_returned(self):
         finder = bookmark_utils.InterestingMeasureFinder(
-            practice=self.practice_with_high_neg_change, interesting_change_window=10
+            self.practice_with_high_neg_change, interesting_change_window=10
         )
         sorted_measure = finder.most_change_against_window(1)
         measure_info = sorted_measure["declines"][0]
@@ -403,21 +399,21 @@ class TestBookmarkUtilsSavingsPossible(TestBookmarkUtilsSavingsBase):
         _makeCostSavingMeasureValues(self.measure, self.practice, [0, 1500, 2000])
 
     def test_possible_savings_for_practice(self):
-        finder = bookmark_utils.InterestingMeasureFinder(practice=self.practice)
+        finder = bookmark_utils.InterestingMeasureFinder(self.practice)
         savings = finder.top_and_total_savings_in_period(3)
         self.assertEqual(savings["possible_savings"], [(self.measure, 3500)])
         self.assertEqual(savings["achieved_savings"], [])
         self.assertEqual(savings["possible_top_savings_total"], 350000)
 
     def test_possible_savings_for_practice_not_enough_months(self):
-        finder = bookmark_utils.InterestingMeasureFinder(practice=self.practice)
+        finder = bookmark_utils.InterestingMeasureFinder(self.practice)
         savings = finder.top_and_total_savings_in_period(10)
         self.assertEqual(savings["possible_savings"], [])
         self.assertEqual(savings["achieved_savings"], [])
         self.assertEqual(savings["possible_top_savings_total"], 0)
 
     def test_possible_savings_for_ccg(self):
-        finder = bookmark_utils.InterestingMeasureFinder(pct=self.practice.ccg)
+        finder = bookmark_utils.InterestingMeasureFinder(self.practice.ccg)
         savings = finder.top_and_total_savings_in_period(3)
         self.assertEqual(savings["possible_savings"], [])
         self.assertEqual(savings["achieved_savings"], [])
@@ -426,7 +422,7 @@ class TestBookmarkUtilsSavingsPossible(TestBookmarkUtilsSavingsBase):
     def test_possible_savings_low_is_good(self):
         self.measure.low_is_good = True
         self.measure.save()
-        finder = bookmark_utils.InterestingMeasureFinder(practice=self.practice)
+        finder = bookmark_utils.InterestingMeasureFinder(self.practice)
         savings = finder.top_and_total_savings_in_period(3)
         self.assertEqual(savings["possible_savings"], [(self.measure, 3500)])
         self.assertEqual(savings["achieved_savings"], [])
@@ -439,7 +435,7 @@ class TestBookmarkUtilsSavingsAchieved(TestBookmarkUtilsSavingsBase):
         _makeCostSavingMeasureValues(self.measure, self.practice, [-1000, -500, 100])
 
     def test_achieved_savings(self):
-        finder = bookmark_utils.InterestingMeasureFinder(practice=self.practice)
+        finder = bookmark_utils.InterestingMeasureFinder(self.practice)
         savings = finder.top_and_total_savings_in_period(3)
         self.assertEqual(savings["possible_savings"], [])
         self.assertEqual(savings["achieved_savings"], [(self.measure, 1400)])
@@ -641,7 +637,7 @@ class TestContextForOrgEmail(unittest.TestCase):
             ordinal_measure_1,
             non_ordinal_measure_1,
         ]
-        finder = bookmark_utils.InterestingMeasureFinder(pct="foo")
+        finder = bookmark_utils.InterestingMeasureFinder(PCT.objects.create(code="000"))
         context = finder.context_for_org_email()
         self.assertCountEqual(
             context["most_changing_interesting"],

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -122,7 +122,7 @@ class TestSpendingViews(TestCase):
         self.assertEqual(NCSOConcessionBookmark.objects.count(), 1)
 
         url = "/practice/{}/concessions/".format(self.practice.code)
-        data = {"email": "alice@example.com", "practice": self.practice.code}
+        data = {"email": "alice@example.com", "practice_id": self.practice.code}
         response = self.client.post(url, data, follow=True)
         self.assertContains(response, "alerts about NCSO concessions for Practice 5")
 

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -138,6 +138,21 @@ class TestAlertViews(TestCase):
         self.assertEqual(bookmark.pct, None)
         self.assertEqual(bookmark.org_type(), "all_england")
 
+    def test_all_england_bookmark_created_when_user_has_another_org_bookmark(self):
+        # Regression test for #2440
+
+        self._post_org_signup("P87629")
+        self.assertEqual(OrgBookmark.objects.count(), 1)
+        # We don't follow the redirect, because we don't have the necessary test data for
+        # testing the all-england page.
+        response = self._post_org_signup("all_england", follow=False)
+        self.assertRedirects(response, "/all-england/", fetch_redirect_response=False)
+        self.assertEqual(OrgBookmark.objects.count(), 2)
+        bookmark = OrgBookmark.objects.last()
+        self.assertEqual(bookmark.practice, None)
+        self.assertEqual(bookmark.pct, None)
+        self.assertEqual(bookmark.org_type(), "all_england")
+
     def test_pcn_bookmark_created(self):
         self.assertEqual(OrgBookmark.objects.count(), 0)
         form_data = {

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -151,19 +151,6 @@ class TestAlertViews(TestCase):
         bookmark = OrgBookmark.objects.last()
         self.assertEqual(bookmark.pcn.code, "PCN0001")
 
-    def test_pcn_bookmark_created_with_old_args(self):
-        self.assertEqual(OrgBookmark.objects.count(), 0)
-        form_data = {
-            "email": "foo@baz.com",
-            "newsletters": ["alerts"],
-            "pcn": "PCN0001",
-        }
-        url = "/pcn/{}/".format("PCN0001")
-        self.client.post(url, form_data, follow=True)
-        self.assertEqual(OrgBookmark.objects.count(), 1)
-        bookmark = OrgBookmark.objects.last()
-        self.assertEqual(bookmark.pcn.code, "PCN0001")
-
 
 class TestFrontendHomepageViews(TestCase):
     fixtures = [

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -27,7 +27,7 @@ from frontend.models import ImportLog
 from frontend.models import Measure
 from frontend.models import MeasureValue
 from frontend.models import NCSOConcessionBookmark
-from frontend.models import Practice, PCT
+from frontend.models import Practice, PCN, PCT
 from frontend.views.spending_utils import (
     ncso_spending_for_entity,
     ncso_spending_breakdown_for_entity,
@@ -256,6 +256,8 @@ class InterestingMeasureFinder(object):
     def __init__(self, org, interesting_saving=1000, interesting_change_window=12):
         if isinstance(org, Practice):
             self.measure_filter_for_org = {"practice": org}
+        elif isinstance(org, PCN):
+            self.measure_filter_for_org = {"pcn": org, "practice": None}
         elif isinstance(org, PCT):
             self.measure_filter_for_org = {"pct": org, "practice": None}
         else:

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1165,7 +1165,7 @@ def _get_or_create_bookmark(request, bookmark_cls):
     form.full_clean()
     email = form.cleaned_data["email"].lower()
     user, _ = User.objects.get_or_create(username=email, defaults={"email": email})
-    bookmark_args = {k: v for k, v in form.cleaned_data.items() if k != "email" and v}
+    bookmark_args = {k: v or None for k, v in form.cleaned_data.items() if k != "email"}
     bookmark, _ = bookmark_cls.objects.get_or_create(user=user, **bookmark_args)
     return bookmark
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -39,6 +39,7 @@ from frontend.forms import BookmarkListForm
 from frontend.forms import FeedbackForm
 from frontend.forms import OrgBookmarkForm
 from frontend.forms import SearchBookmarkForm
+from frontend.forms import NCSOConcessionBookmarkForm
 from frontend.measure_tags import MEASURE_TAGS
 from frontend.models import Chemical
 from frontend.models import EmailMessage
@@ -1128,7 +1129,7 @@ def bookmarks(request, key):
 BOOKMARK_CLS_TO_FORM_CLS = {
     OrgBookmark: OrgBookmarkForm,
     SearchBookmark: SearchBookmarkForm,
-    NCSOConcessionBookmark: OrgBookmarkForm,
+    NCSOConcessionBookmark: NCSOConcessionBookmarkForm,
 }
 
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1166,18 +1166,6 @@ def _get_or_create_bookmark(request, bookmark_cls):
     email = form.cleaned_data["email"].lower()
     user, _ = User.objects.get_or_create(username=email, defaults={"email": email})
     bookmark_args = {k: v for k, v in form.cleaned_data.items() if k != "email" and v}
-
-    # Earlier versions of the OrgBookmarkForm used eg "pct" instead of
-    # "pct_id".  If a user has loaded an old version of the page and submits
-    # the form, we need to pass the correct arguments to get_or_create(),
-    # otherwise an all-england bookmark will be created.
-    #
-    # This can be removed after a few days.
-
-    for k in ["pct", "practice", "pcn"]:
-        if k in request.POST:
-            bookmark_args[k + "_id"] = request.POST[k]
-
     bookmark, _ = bookmark_cls.objects.get_or_create(user=user, **bookmark_args)
     return bookmark
 


### PR DESCRIPTION
There are no tests for PCN alerts, but I have tested manually and got something sensible in the email.

The existing alert-sending tests don't give me much confidence that it would be worthwhile to work out how to extend them to support PCNs.  The hairy part of this is calculating interesting measures, and from what I can tell `InterestingMeasureFinder.measure_filter_for_org()` does the right thing.  But I'd appreciate extra care when reviewing that part of the code.