### PR TITLE
Nicer loading indicator for PPU savings

### DIFF
--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -63,7 +63,7 @@
       </p>
     </div>
     <p>
-      We have identified about <strong>£<span id="total-savings">0</span> of possible savings</strong>
+      We have identified about <strong>£<span id="total-savings"><span class="text-muted">(&hellip;)</span></span> of possible savings</strong>
       {% if presentation %} for {{ presentation.product_name }}{% endif %} in
       {% if entity.ccg %}
         <a href="{% url 'practice_price_per_unit' highlight %}?date={{ date|date:"Y-m-d" }}">{{entity_name }}</a>


### PR DESCRIPTION
Previously it would show £0 savings until the API call finished, which
seems potentially confusing.

Screenshot:
![localhost_8000_all-england_price-per-unit_](https://user-images.githubusercontent.com/19630/74336664-a2cd0600-4d96-11ea-8f8d-7dd76fd1020c.png)
