### PR TITLE
Recompile `requirements.txt` with pip-tools 4.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,70 +4,70 @@
 #
 #    pip-compile
 #
-backports.csv==1.0.5      # via -r requirements.in (line 9)
+backports.csv==1.0.5      # via -r requirements.in
 bcrypt==3.1.7             # via paramiko
-beautifulsoup4==4.8.2     # via -r requirements.in (line 10)
+beautifulsoup4==4.8.2     # via -r requirements.in
 cachetools==4.0.0         # via google-auth, premailer
 certifi==2019.11.28       # via requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-coverage==5.0.3           # via -r requirements.in (line 49)
+coverage==5.0.3           # via -r requirements.in
 cryptography==2.8         # via paramiko, pyopenssl, requests
 cssselect==1.1.0          # via premailer, pyquery
 cssutils==1.0.2           # via premailer
 decorator==4.4.2          # via networkx
-django-anymail[mailgun]==7.0.0  # via -r requirements.in (line 11)
-django-cors-headers==3.2.1  # via -r requirements.in (line 12)
-django-crispy-forms==1.9.0  # via -r requirements.in (line 13)
-django-debug-toolbar-template-timings==0.9  # via -r requirements.in (line 57)
-django-debug-toolbar==2.2  # via -r requirements.in (line 56), django-debug-toolbar-template-timings
-django-dotenv==1.4.2      # via -r requirements.in (line 14)
-django-extensions==2.2.8  # via -r requirements.in (line 58)
-django-redis==4.10.0      # via -r requirements.in (line 45)
-django==2.2.10            # via -r requirements.in (line 15), django-anymail, django-cors-headers, django-debug-toolbar, django-debug-toolbar-template-timings, django-redis, djangorestframework
-djangorestframework-csv==2.1.0  # via -r requirements.in (line 16)
-djangorestframework==3.11.0  # via -r requirements.in (line 17), djangorestframework-csv
+django-anymail[mailgun]==7.0.0  # via -r requirements.in
+django-cors-headers==3.2.1  # via -r requirements.in
+django-crispy-forms==1.9.0  # via -r requirements.in
+django-debug-toolbar-template-timings==0.9  # via -r requirements.in
+django-debug-toolbar==2.2  # via -r requirements.in, django-debug-toolbar-template-timings
+django-dotenv==1.4.2      # via -r requirements.in
+django-extensions==2.2.8  # via -r requirements.in
+django-redis==4.10.0      # via -r requirements.in
+django==2.2.10            # via -r requirements.in, django-anymail, django-cors-headers, django-debug-toolbar, django-debug-toolbar-template-timings, django-redis, djangorestframework
+djangorestframework-csv==2.1.0  # via -r requirements.in
+djangorestframework==3.11.0  # via -r requirements.in, djangorestframework-csv
 easyprocess==0.2.10       # via pyvirtualdisplay
 entrypoints==0.3          # via flake8
 et-xmlfile==1.0.1         # via openpyxl
-fabric3==1.14.post1       # via -r requirements.in (line 59)
-flake8==3.7.9             # via -r requirements.in (line 60)
+fabric3==1.14.post1       # via -r requirements.in
+flake8==3.7.9             # via -r requirements.in
 google-api-core==1.16.0   # via google-cloud-bigquery, google-cloud-core
-google-api-python-client==1.7.11  # via -r requirements.in (line 18)
+google-api-python-client==1.7.11  # via -r requirements.in
 google-auth-httplib2==0.0.3  # via google-api-python-client
 google-auth-oauthlib==0.4.1  # via pandas-gbq, pydata-google-auth
 google-auth==1.11.2       # via google-api-core, google-api-python-client, google-auth-httplib2, google-auth-oauthlib, google-cloud-bigquery, google-cloud-storage, pandas-gbq, pydata-google-auth
-google-cloud-bigquery==1.24.0  # via -r requirements.in (line 19), pandas-gbq
+google-cloud-bigquery==1.24.0  # via -r requirements.in, pandas-gbq
 google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-storage
-google-cloud-storage==1.26.0  # via -r requirements.in (line 20)
+google-cloud-storage==1.26.0  # via -r requirements.in
 google-resumable-media==0.5.0  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.51.0  # via google-api-core
-graphviz==0.13.2          # via -r requirements.in (line 61)
-gunicorn==20.0.4          # via -r requirements.in (line 21)
-hiredis==1.0.1            # via -r requirements.in (line 46)
-html2text==2020.1.16      # via -r requirements.in (line 22)
+graphviz==0.13.2          # via -r requirements.in
+gunicorn==20.0.4          # via -r requirements.in
+hiredis==1.0.1            # via -r requirements.in
+html2text==2020.1.16      # via -r requirements.in
 httplib2==0.17.0          # via google-api-python-client, google-auth-httplib2
 idna==2.9                 # via requests
 jdcal==1.4.1              # via openpyxl
-lxml==4.5.0               # via -r requirements.in (line 23), premailer, pyquery
-lz4==3.0.2                # via -r requirements.in (line 24)
+lxml==4.5.0               # via -r requirements.in, premailer, pyquery
+lz4==3.0.2                # via -r requirements.in
 mccabe==0.6.1             # via flake8
-mock==3.0.5               # via -r requirements.in (line 53)
-networkx==2.4             # via -r requirements.in (line 25)
-newrelic==5.8.0.136       # via -r requirements.in (line 26)
-numpy==1.18.1             # via -r requirements.in (line 27), pandas, pyarrow, scipy
+mock==3.0.5               # via -r requirements.in
+networkx==2.4             # via -r requirements.in
+newrelic==5.8.0.136       # via -r requirements.in
+numpy==1.18.1             # via -r requirements.in, pandas, pyarrow, scipy
 oauthlib==3.1.0           # via requests-oauthlib
-openpyxl==2.6.3           # via -r requirements.in (line 28)
-pandas-gbq==0.13.1        # via -r requirements.in (line 29)
-pandas==0.25.3            # via -r requirements.in (line 30), pandas-gbq
+openpyxl==2.6.3           # via -r requirements.in
+pandas-gbq==0.13.1        # via -r requirements.in
+pandas==0.25.3            # via -r requirements.in, pandas-gbq
 paramiko==2.7.1           # via fabric3
 pathtools==0.1.2          # via watchdog
-pip-tools==4.5.1          # via -r requirements.in (line 62)
-premailer==3.6.1          # via -r requirements.in (line 31)
+pip-tools==4.5.1          # via -r requirements.in
+premailer==3.6.1          # via -r requirements.in
 protobuf==3.11.3          # via google-api-core, google-cloud-bigquery, googleapis-common-protos
-psycopg2-binary==2.8.4    # via -r requirements.in (line 32)
-pyarrow==0.15.1           # via -r requirements.in (line 33)
+psycopg2-binary==2.8.4    # via -r requirements.in
+pyarrow==0.15.1           # via -r requirements.in
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycodestyle==2.5.0        # via flake8
@@ -76,29 +76,29 @@ pydata-google-auth==0.3.0  # via pandas-gbq
 pyflakes==2.1.1           # via flake8
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.1.0         # via requests
-pyquery==1.4.1            # via -r requirements.in (line 51)
-python-dateutil==2.8.1    # via -r requirements.in (line 34), pandas
-pytz==2019.3              # via -r requirements.in (line 35), django, google-api-core, pandas
-pyvirtualdisplay==0.2.5   # via -r requirements.in (line 52)
-raven==6.10.0             # via -r requirements.in (line 36)
+pyquery==1.4.1            # via -r requirements.in
+python-dateutil==2.8.1    # via -r requirements.in, pandas
+pytz==2019.3              # via -r requirements.in, django, google-api-core, pandas
+pyvirtualdisplay==0.2.5   # via -r requirements.in
+raven==6.10.0             # via -r requirements.in
 redis==3.4.1              # via django-redis
-requests-futures==1.0.0   # via -r requirements.in (line 37)
+requests-futures==1.0.0   # via -r requirements.in
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests[security]==2.23.0  # via -r requirements.in (line 38), django-anymail, google-api-core, premailer, requests-futures, requests-oauthlib
+requests[security]==2.23.0  # via -r requirements.in, django-anymail, google-api-core, premailer, requests-futures, requests-oauthlib
 rsa==4.0                  # via google-auth
-scipy==1.4.1              # via -r requirements.in (line 39)
-selenium==3.141.0         # via -r requirements.in (line 50)
+scipy==1.4.1              # via -r requirements.in
+selenium==3.141.0         # via -r requirements.in
 six==1.14.0               # via bcrypt, cryptography, django-anymail, django-extensions, djangorestframework-csv, fabric3, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-resumable-media, mock, pip-tools, protobuf, pyarrow, pynacl, pyopenssl, python-dateutil
 soupsieve==2.0            # via beautifulsoup4
 sqlparse==0.3.1           # via django, django-debug-toolbar
-titlecase==0.12.0         # via -r requirements.in (line 40)
-tqdm==4.43.0              # via -r requirements.in (line 41)
+titlecase==0.12.0         # via -r requirements.in
+tqdm==4.43.0              # via -r requirements.in
 unicodecsv==0.14.1        # via djangorestframework-csv
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.25.8           # via requests, selenium
 watchdog==0.10.2          # via when-changed
-when-changed==0.3.0       # via -r requirements.in (line 63)
-xlrd==1.2.0               # via -r requirements.in (line 42)
+when-changed==0.3.0       # via -r requirements.in
+xlrd==1.2.0               # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
The latest version of pip-tools removes the line number annotations as
this creates extraneous diff noise and makes merges more difficult.