### PR TITLE
Import measures after matrixstore has been built

### DIFF
--- a/openprescribing/pipeline/metadata/tasks.json
+++ b/openprescribing/pipeline/metadata/tasks.json
@@ -260,7 +260,8 @@
         "dependencies": [
             "upload_to_bigquery",
             "import_measure_definitions",
-            "create_bq_measure_views"
+            "create_bq_measure_views",
+            "publish_matrixstore"
         ]
     },
     "refresh_views": {


### PR DESCRIPTION
When building measure.analyse_url, import_measures uses the matrixstore
to find a list of all prescribed presentations.  Before this change, it
would miss any presentations that were new this month.  Additionally,
the end-to-end tests would sometimes fail because the matrixstore had
not yet been built.