### PR TITLE
Fix "active class" declarations

### DIFF
--- a/openprescribing/media/css/navbar.less
+++ b/openprescribing/media/css/navbar.less
@@ -14,9 +14,7 @@
 }
 .home .active_home > a,
 .analyse .active_analyse > a,
-.ccg .active_ccg > a,
-.practice .active_practice > a,
-.all_england .active_all_england > a,
+.dashboards .active_dashboards > a,
 .trends .active_trends > a,
 .more .active_more > a
  {

--- a/openprescribing/templates/all_ccgs.html
+++ b/openprescribing/templates/all_ccgs.html
@@ -2,7 +2,7 @@
 {% load template_extras %}
 
 {% block title %}All CCGs{% endblock %}
-{% block active_class %}ccg{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_chemicals.html
+++ b/openprescribing/templates/all_chemicals.html
@@ -2,7 +2,7 @@
 {% load template_extras %}
 
 {% block title %}All chemicals{% endblock %}
-{% block active_class %}bnf{% endblock %}
+{% block active_class %}trends{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_england.html
+++ b/openprescribing/templates/all_england.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}All {{ entity_type }}s across NHS England{% endblock %}
-{% block active_class %}all_england{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block extra_css %}
 <link href='https://api.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />

--- a/openprescribing/templates/all_measures.html
+++ b/openprescribing/templates/all_measures.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}Prescribing measures{% endblock %}
-{% block active_class %}ccg{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_pcns.html
+++ b/openprescribing/templates/all_pcns.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}All PCNs{% endblock %}
-{% block active_class %}pcn{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_practices.html
+++ b/openprescribing/templates/all_practices.html
@@ -2,7 +2,7 @@
 {% load template_extras %}
 
 {% block title %}All practices{% endblock %}
-{% block active_class %}practice{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_regional_teams.html
+++ b/openprescribing/templates/all_regional_teams.html
@@ -2,7 +2,7 @@
 {% load template_extras %}
 
 {% block title %}All Regional Teams{% endblock %}
-{% block active_class %}regional_team{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/all_stps.html
+++ b/openprescribing/templates/all_stps.html
@@ -2,7 +2,7 @@
 {% load template_extras %}
 
 {% block title %}All STPs{% endblock %}
-{% block active_class %}stp{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/chemical.html
+++ b/openprescribing/templates/chemical.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}{{ chemical.chem_name }}: BNF Code {{ chemical.bnf_code }}{% endblock %}
-{% block active_class %}bnf{% endblock %}
+{% block active_class %}trends{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -4,7 +4,7 @@
 {% load template_extras %}
 
 {% block title %}Prescribing measures for {{ entity.name }}{% endblock %}
-{% block active_class %}{{ entity_type }}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 {% block container_class %}landing-page{% endblock %}
 
 {% block extra_css %}

--- a/openprescribing/templates/ghost_generics.html
+++ b/openprescribing/templates/ghost_generics.html
@@ -4,7 +4,7 @@
 {% load staticfiles %}
 
 {% block title %}Ghost-branded generics savings for {{ entity_name }}{% endblock %}
-{% block active_class %}{% if entity %}ccg{% else %}all_england{% endif %}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/measure_for_all_entities.html
+++ b/openprescribing/templates/measure_for_all_entities.html
@@ -4,7 +4,7 @@
 {% load template_extras %}
 
 {% block title %} {{ measure }} by all {{ entity_type_human }}s{% endblock %}
-{% block active_class %}{{ entity_type }}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
   <h1>{{measure.name}} by all {{ entity_type_human }}s</h1>

--- a/openprescribing/templates/measure_for_children_in_entity.html
+++ b/openprescribing/templates/measure_for_children_in_entity.html
@@ -4,7 +4,7 @@
 {% load template_extras %}
 
 {% block title %}{{ measure.name }} by {{ child_entity_type_human }}s in {{ parent.name }}{% endblock %}
-{% block active_class %}{{ parent_entity_type }}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
   <h1>{{measure.name}} by {{ child_entity_type_human }}s in {{ parent.name }}</h1>

--- a/openprescribing/templates/measure_for_one_entity.html
+++ b/openprescribing/templates/measure_for_one_entity.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}Prescribing on {{ measure.name }} for {{ entity.name }}{% endblock %}
-{% block active_class %}{{ entity_type }}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block extra_css %}
   <link href='https://api.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />

--- a/openprescribing/templates/measures_for_one_entity.html
+++ b/openprescribing/templates/measures_for_one_entity.html
@@ -3,7 +3,7 @@
 {% load template_extras %}
 
 {% block title %}Prescribing measures for {{ entity.name }}{% endblock %}
-{% block active_class %}entity_type{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block extra_css %}
   <link href='https://api.mapbox.com/mapbox.js/v2.2.1/mapbox.css' rel='stylesheet' />

--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -4,7 +4,7 @@
 {% load staticfiles %}
 
 {% block title %}PPU savings for {{ entity_name }}{% endblock %}
-{% block active_class %}{% if entity %}ccg{% else %}all_england{% endif %}{% endblock %}
+{% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 

--- a/openprescribing/templates/tariff.html
+++ b/openprescribing/templates/tariff.html
@@ -4,7 +4,7 @@
 {% load template_extras %}
 
 {% block title %}Drug tariff for {{ chart_title }}{% endblock %}
-{% block active_class %}tariff{% endblock %}
+{% block active_class %}trends{% endblock %}
 
 {% block extra_css %}
 <link href="{% static 'css/select2.min.css' %}" rel="stylesheet">


### PR DESCRIPTION
These are supposed to make sure that the appropriate top-level menu item
is highlighted, but they have been broken for a long time (ever since we
restructured the menu).