### PR TITLE
Replace "/all-england/" URL with "/national/england/"

### DIFF
--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -76,20 +76,20 @@ class MeasuresTests(SeleniumTestCase):
         return self.find_by_css("#{} .panel".format(id_))
 
     def test_all_england(self):
-        self._get("/all-england/")
+        self._get("/national/england/")
 
         panel_element = self._find_measure_panel("measure_lpzomnibus")
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break it down into its constituent measures.",
-            "/all-england/?tags=lowpriority",
+            "/national/england/?tags=lowpriority",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Break the overall score down into individual presentations",
-            "/measure/lpzomnibus/all-england/",
+            "/measure/lpzomnibus/national/england/",
         )
         self._verify_link(
             panel_element,
@@ -122,7 +122,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".inner li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/core_0/all-england/",
+            "/measure/core_0/national/england/",
         )
         self._verify_link(
             panel_element,
@@ -145,14 +145,14 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 4)
 
     def test_all_england_low_priority(self):
-        self._get("/all-england/?tags=lowpriority")
+        self._get("/national/england/?tags=lowpriority")
 
         panel_element = self._find_measure_panel("measure_lp_2")
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/lp_2/all-england/",
+            "/measure/lp_2/national/england/",
         )
         self._verify_link(
             panel_element,
@@ -1008,7 +1008,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".explanation li", 3)
 
     def test_measure_for_all_england(self):
-        self._get("/measure/lp_2/all-england/")
+        self._get("/measure/lp_2/national/england/")
         panel_element = self._find_measure_panel("measure_lp_2")
         self._verify_link(
             panel_element, ".measure-panel-title", "LP measure 2", "/measure/lp_2/"
@@ -1298,7 +1298,7 @@ class MeasuresTests(SeleniumTestCase):
             mv.cost_savings["50"] for mv in mvs if mv.cost_savings["50"] > 0
         )
 
-        self._get("/all-england/")
+        self._get("/national/england/")
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -100,7 +100,7 @@ class TestSpendingViews(TestCase):
             "/ccg/{}/concessions/".format(self.ccg.code),
             "/stp/{}/concessions/".format(self.stp.code),
             "/regional-team/{}/concessions/".format(self.regional_team.code),
-            "/all-england/concessions/",
+            "/national/england/concessions/",
         ]
         for url in urls:
             with self.subTest(url=url):
@@ -135,7 +135,7 @@ class TestSpendingViews(TestCase):
 
         self.assertEqual(NCSOConcessionBookmark.objects.count(), 1)
 
-        url = "/all-england/concessions/"
+        url = "/national/england/concessions/"
         data = {"email": "alice@example.com"}
         response = self.client.post(url, data, follow=True)
         self.assertContains(
@@ -154,7 +154,7 @@ class TestSpendingViews(TestCase):
         self.assertContains(response, "Get email updates")
 
     def test_all_england_alert_signup_form(self):
-        url = "/all-england/concessions/".format(self.practice.code)
+        url = "/national/england/concessions/".format(self.practice.code)
         response = self.client.get(url)
         self.assertContains(response, "Get email updates")
 

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -35,7 +35,7 @@ class TestAlertViews(TestCase):
     def _post_org_signup(self, entity_id, email="foo@baz.com", follow=True):
         form_data = {"email": email}
         if entity_id == "all_england":
-            url = "/all-england/"
+            url = "/national/england/"
         elif len(entity_id) == 3:
             url = "/ccg/%s/" % entity_id
             form_data["pct_id"] = entity_id
@@ -127,7 +127,9 @@ class TestAlertViews(TestCase):
         # We don't follow the redirect, because we don't have the necessary test data for
         # testing the all-england page.
         response = self._post_org_signup("all_england", follow=False)
-        self.assertRedirects(response, "/all-england/", fetch_redirect_response=False)
+        self.assertRedirects(
+            response, "/national/england/", fetch_redirect_response=False
+        )
         self.assertEqual(OrgBookmark.objects.count(), 1)
         bookmark = OrgBookmark.objects.last()
         self.assertEqual(bookmark.practice, None)
@@ -142,7 +144,9 @@ class TestAlertViews(TestCase):
         # We don't follow the redirect, because we don't have the necessary test data for
         # testing the all-england page.
         response = self._post_org_signup("all_england", follow=False)
-        self.assertRedirects(response, "/all-england/", fetch_redirect_response=False)
+        self.assertRedirects(
+            response, "/national/england/", fetch_redirect_response=False
+        )
         self.assertEqual(OrgBookmark.objects.count(), 2)
         bookmark = OrgBookmark.objects.last()
         self.assertEqual(bookmark.practice, None)
@@ -454,7 +458,7 @@ class TestFrontendViews(TestCase):
         self.assertNotContains(response, "This list is filtered")
 
     def test_call_single_measure_for_all_england(self):
-        response = self.client.get("/measure/cerazette/all-england/")
+        response = self.client.get("/measure/cerazette/national/england/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "measure_for_one_entity.html")
 

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -676,3 +676,33 @@ class TestCacheWrapper(SimpleTestCase):
             cached(test_func)
             cached(test_func)
         self.assertEqual(test_func.call_count, 2)
+
+
+class TestNationalRedirects(TestCase):
+    def test_dashboard(self):
+        self.assertRedirects(
+            self.client.get("/all-england/?foo=bar"),
+            "/national/england/?foo=bar",
+            fetch_redirect_response=False,
+        )
+
+    def test_price_per_unit(self):
+        self.assertRedirects(
+            self.client.get("/all-england/ABCD00001/price-per-unit/?date=2020-01"),
+            "/national/england/ABCD00001/price-per-unit/?date=2020-01",
+            fetch_redirect_response=False,
+        )
+
+    def test_concessions(self):
+        self.assertRedirects(
+            self.client.get("/all-england/concessions/"),
+            "/national/england/concessions/",
+            fetch_redirect_response=False,
+        )
+
+    def test_measures(self):
+        self.assertRedirects(
+            self.client.get("/measure/somemeasure/all-england/"),
+            "/measure/somemeasure/national/england/",
+            fetch_redirect_response=False,
+        )

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -42,6 +42,11 @@ def redirect_if_tags_query(view_fn):
     return wrapper
 
 
+def all_england_redirects(request, *args, **kwargs):
+    url = request.get_full_path().replace("/all-england/", "/national/england/")
+    return HttpResponseRedirect(url)
+
+
 urlpatterns = [
     # Static pages.
     path(r"", TemplateView.as_view(template_name="index.html"), name="home"),
@@ -120,6 +125,7 @@ urlpatterns = [
     ),
     # All England
     path(r"national/england/", views.all_england, name="all_england"),
+    path(r"all-england/", all_england_redirects),
     # Analyse
     path(r"analyse/", views.analyse, name="analyse"),
     # Price per unit
@@ -140,6 +146,7 @@ urlpatterns = [
         views.all_england_price_per_unit,
         name="all_england_price_per_unit",
     ),
+    path(r"all-england/price-per-unit/", all_england_redirects),
     path(
         r"practice/<entity_code>/<bnf_code>/price_per_unit/",
         views.price_per_unit_by_presentation,
@@ -155,6 +162,7 @@ urlpatterns = [
         views.all_england_price_per_unit_by_presentation,
         name="all_england_price_per_unit_by_presentation",
     ),
+    path(r"all-england/<bnf_code>/price-per-unit/", all_england_redirects),
     # Ghost generics
     path(
         r"practice/<code>/ghost_generics/",
@@ -207,6 +215,7 @@ urlpatterns = [
         name="spending_for_all_england",
         kwargs={"entity_type": "all_england", "entity_code": None},
     ),
+    path(r"all-england/concessions/", all_england_redirects),
     # Measures
     path(r"measure/", views.all_measures, name="all_measures"),
     path(
@@ -244,6 +253,7 @@ urlpatterns = [
         views.measure_for_all_england,
         name="measure_for_all_england",
     ),
+    path(r"measure/<measure>/all-england/", all_england_redirects),
     path(
         r"practice/<practice_code>/measures/",
         views.measures_for_one_practice,

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -119,7 +119,7 @@ urlpatterns = [
         name="regional_team_home_page",
     ),
     # All England
-    path(r"all-england/", views.all_england, name="all_england"),
+    path(r"national/england/", views.all_england, name="all_england"),
     # Analyse
     path(r"analyse/", views.analyse, name="analyse"),
     # Price per unit
@@ -136,7 +136,7 @@ urlpatterns = [
         name="ccg_price_per_unit",
     ),
     path(
-        r"all-england/price-per-unit/",
+        r"national/england/price-per-unit/",
         views.all_england_price_per_unit,
         name="all_england_price_per_unit",
     ),
@@ -151,7 +151,7 @@ urlpatterns = [
         name="price_per_unit_by_presentation",
     ),
     path(
-        r"all-england/<bnf_code>/price-per-unit/",
+        r"national/england/<bnf_code>/price-per-unit/",
         views.all_england_price_per_unit_by_presentation,
         name="all_england_price_per_unit_by_presentation",
     ),
@@ -202,7 +202,7 @@ urlpatterns = [
         kwargs={"entity_type": "regional_team"},
     ),
     path(
-        r"all-england/concessions/",
+        r"national/england/concessions/",
         views.spending_for_one_entity,
         name="spending_for_all_england",
         kwargs={"entity_type": "all_england", "entity_code": None},
@@ -240,7 +240,7 @@ urlpatterns = [
         kwargs={"entity_type": "regional_team"},
     ),
     path(
-        r"measure/<measure>/all-england/",
+        r"measure/<measure>/national/england/",
         views.measure_for_all_england,
         name="measure_for_all_england",
     ),

--- a/openprescribing/pipeline/management/commands/check_numbers.py
+++ b/openprescribing/pipeline/management/commands/check_numbers.py
@@ -118,7 +118,7 @@ def paths_to_scrape():
 
         # Ignore any URLs that are not either parameterisable (these static
         # pages or lists of entities) or for All England.
-        if "%" not in pattern and "all-england" not in pattern:
+        if "%" not in pattern and "national/england" not in pattern:
             continue
 
         path = build_path(pattern, keys)


### PR DESCRIPTION
This gives us a consistent `<org-type>/<org-id>` URL pattern which will
make later refactoring easier. It also doesn't hurt that it suggests the
possibility of other national datasets...

We automatically redirect from old to new URLs.