### PR TITLE
Drop import_measures --definitions_only from pipeline

### DIFF
--- a/openprescribing/pipeline/metadata/tasks.json
+++ b/openprescribing/pipeline/metadata/tasks.json
@@ -244,11 +244,6 @@
             "create_bq_public_tables"
         ]
     },
-    "import_measure_definitions": {
-        "type": "post_process",
-        "command": "import_measures --definitions_only",
-        "dependencies": ["create_bq_measure_views", "build_matrixstore"]
-    },
     "create_bq_measure_views": {
         "type": "post_process",
         "command": "create_bq_measure_views",
@@ -259,7 +254,6 @@
         "command": "import_measures",
         "dependencies": [
             "upload_to_bigquery",
-            "import_measure_definitions",
             "create_bq_measure_views",
             "publish_matrixstore"
         ]


### PR DESCRIPTION
There's no need, as definitions get imported as part of import_measures.

This is being fixed now because it should depend on matrixstore_publish
(because it looks up all prescribed presentations from the MatrixStore)
and rather than fixing that, I'm just removing it.