### PR TITLE
Don't restrict measure BNF codes to those with prescribing

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -31,7 +31,7 @@ from gcutils.bigquery import Client
 
 from common import utils
 from frontend.models import MeasureGlobal, MeasureValue, Measure, ImportLog
-from frontend.utils.bnf_hierarchy import get_all_bnf_codes, simplify_bnf_codes
+from frontend.utils.bnf_hierarchy import simplify_bnf_codes
 
 from google.api_core.exceptions import BadRequest
 
@@ -431,9 +431,7 @@ def get_bnf_codes(base_query, filter_):
 
     # Before 2017, the published prescribing data included trailing spaces in
     # certain BNF codes.  We strip those here.  See #2447.
-    bnf_codes = {row[0].strip() for row in results.rows}
-
-    return sorted(bnf_codes & get_all_bnf_codes())
+    return sorted(row[0].strip() for row in results.rows)
 
 
 def build_bnf_codes_query(base_query, filter_):


### PR DESCRIPTION
Since cb80cd89, the numerator_/denominator_where attributes have been
constructed based on presentations matching numerator_/
denominator_bnf_codes_filters, which are then restricted to
only those presentations with prescribing.

But doing so causes the end-to-end tests to fail because the end-to-end
tests import only a limited amount of prescribing, so several measures
end up with no matching presentations.  This causes the numerator_/
denominator_where fragments to contain invalid SQL.

This change will have no practical effect on the measure calculations.