### PR TITLE
Allow e2e tests to handle measures with no prescribing

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -502,7 +502,7 @@ def build_where(bnf_codes):
     if not bnf_codes:
         # hackety hack: this is for the end-to-end tests, where we don't import
         # enough prescribing data for there to be prescribing for every measure.
-        return "1 = 1"
+        return "1 = 0"
 
     bnf_code_sql_fragment = ", ".join('"{}"'.format(bnf_code) for bnf_code in bnf_codes)
     return "bnf_code IN ({})".format(bnf_code_sql_fragment)


### PR DESCRIPTION
Previous attempt to fix (7386a584) caused other problems... by setting
numerator_/denominator_where to `1 = 1`, all BNF codes are included in
the calculation for the numerator/denominator.  This means that the
numerator value can be much larger than the denominator value, which
doesn't make sense for measures where the numerator is a proportion of
the denominator.  When there's no prescribing, the numerator should be
zero.