### PR TITLE
Remove unused fields from prescribing schema

### DIFF
--- a/openprescribing/frontend/bq_schemas.py
+++ b/openprescribing/frontend/bq_schemas.py
@@ -44,10 +44,7 @@ CCG_SCHEMA = build_schema(
 
 PRESCRIBING_SCHEMA = build_schema(
     ("sha", "STRING"),
-    ("regional_team", "STRING"),
-    ("stp", "STRING"),
     ("pct", "STRING"),
-    ("pcn", "STRING"),
     ("practice", "STRING"),
     ("bnf_code", "STRING"),
     ("bnf_name", "STRING"),


### PR DESCRIPTION
These fields are not present in the prescribing_v1 table in BQ.  It would
be possible, but slightly risky, to add them.  We may as well remove
them from the schema since they are not used.

The presence of these fields in the schema means that prescribing_v1 and
prescribing_v2 cannot be UNION ALLed together.