### PR TITLE
Exclude non-finite PPU values

### DIFF
--- a/openprescribing/frontend/price_per_unit/prescribing_breakdown.py
+++ b/openprescribing/frontend/price_per_unit/prescribing_breakdown.py
@@ -75,7 +75,7 @@ def get_ppu_breakdown(prescribing, org_type, org_id):
         ppu = net_costs / quantities
         rounded_ppu = numpy.rint(ppu)
         ppu_values = numpy.unique(rounded_ppu)
-        ppu_values = ppu_values[~numpy.isnan(ppu_values)]
+        ppu_values = ppu_values[numpy.isfinite(ppu_values)]
         if len(ppu_values):
             presentations.append(
                 {


### PR DESCRIPTION
When building the list of unique PPUs at which a drug has been obtained
we ignore the NaN values which result from practices which have not
prescribed that drug at all. However because of the issue where
quantities are occasionally rounded down to zero while cost remains
positive (#1373) we also occasionally get PPU values of `+inf` which
also need to be excluded. The `isfinite` check excludes both these and
NaN values.