### PR TITLE
Update measure definitions to read from hscic.presentation

### DIFF
--- a/openprescribing/measure_definitions/gabapentinoidsddd.json
+++ b/openprescribing/measure_definitions/gabapentinoidsddd.json
@@ -36,7 +36,7 @@
   "numerator_where": [
     "1 = 1"
   ],
-  "numerator_bnf_codes_query": "SELECT DISTINCT presentation_code FROM {hscic}.bnf WHERE presentation_code LIKE '0408010AE%' or presentation_code LIKE '0408010G0%'",
+  "numerator_bnf_codes_query": "SELECT DISTINCT bnf_code FROM {hscic}.presentation WHERE bnf_code LIKE '0408010AE%' or bnf_code LIKE '0408010G0%'",
   "denominator_type": "list_size",
   "no_analyse_url": true,
   "authored_by": [

--- a/openprescribing/measure_definitions/opioidome.json
+++ b/openprescribing/measure_definitions/opioidome.json
@@ -38,13 +38,13 @@
     "1 = 1"
   ],
   "numerator_bnf_codes_query": [
-    "SELECT DISTINCT bnf.presentation_code",
-    "FROM {hscic}.bnf",
+    "SELECT DISTINCT presentation.bnf_code",
+    "FROM {hscic}.presentation",
     "JOIN ebmdatalab.richard.opioid_measure",
     "ON CONCAT(",
-    "    SUBSTR(bnf.presentation_code,0,9),",
+    "    SUBSTR(presentation.bnf_code,0,9),",
     "    'AA',",
-    "    SUBSTR(bnf.presentation_code,-2,2)",
+    "    SUBSTR(presentation.bnf_code,-2,2)",
     "  ) = CONCAT(",
     "    SUBSTR(opioid_measure.bnf_code,0,11),",
     "    SUBSTR(opioid_measure.bnf_code,-2,2)",

--- a/openprescribing/measure_definitions/pregabalinmg.json
+++ b/openprescribing/measure_definitions/pregabalinmg.json
@@ -32,7 +32,7 @@
   "numerator_where": [
     "1 = 1"
   ],
-  "numerator_bnf_codes_query": "SELECT DISTINCT presentation_code FROM {hscic}.bnf WHERE presentation_code LIKE '0408010AE%'",
+  "numerator_bnf_codes_query": "SELECT DISTINCT presentation_code FROM {hscic}.presentation WHERE bnf_code LIKE '0408010AE%'",
   "denominator_type": "list_size",
   "no_analyse_url": true
 }


### PR DESCRIPTION
hscic.bnf has columns for chapter/sections/paragraph/etc, but we do not
yet have an updated copy of the full BNF hieararchy.  These measures
only use presentation codes, which are present in hscic.presentation --
and which we can populate based on the names/codes in the prescribing
data.