### PR TITLE
Fix robots.txt view

### DIFF
--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -246,6 +246,11 @@ class TestFrontendViews(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "index.html")
 
+    def test_robots_txt(self):
+        response = self.client.get("/robots.txt")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Disallow")
+
     def test_javascript_inclusion(self):
         with self.settings(DEBUG=False):
             response = self.client.get("")

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -339,7 +339,7 @@ urlpatterns = [
     path(r"docs/<doc_id>/", views.gdoc_view, name="docs"),
     # Other files.
     path(
-        r"robots\.txt/",
+        r"robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
     path(r"admin/", admin.site.urls),


### PR DESCRIPTION
Because this was broken, bots will happily follow "Download this CSV"
links to our API which results in lots of extra expensive requests.

See:
```sh
ssh largeweb2.ebmdatalab.net \
  grep -P '/api/.*bot' /webapps/openprescribing/logs/nginx-access.log
```