### PR TITLE
Fi fetch_prescribing_metadata

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_prescribing_metadata.py
+++ b/openprescribing/pipeline/management/commands/fetch_prescribing_metadata.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         rsp = requests.get(url)
         doc = BeautifulSoup(rsp.content, "html.parser")
         tag = doc.find("script", type="application/ld+json")
-        metadata = json.loads(tag.text)
+        metadata = json.loads(list(tag.descendants)[0])
 
         filename_fragment = {"addresses": "ADDR%20BNFT", "chemicals": "CHEM%20SUBS"}[
             kwargs["dataset"]


### PR DESCRIPTION
It was broken by a change in BeautifulSoup 4.9.0