### PR TITLE
Revert "Ensure data is in BQ before downloading it"

### DIFF
--- a/openprescribing/matrixstore/build/download_practice_stats.py
+++ b/openprescribing/matrixstore/build/download_practice_stats.py
@@ -28,11 +28,9 @@ def ensure_stats_downloaded_for_date(date):
     filename = get_practice_stats_filename(date)
     if os.path.exists(filename):
         return
-    client = Client("hscic")
-    check_stats_in_bigquery(date, client)
     logger.info("Downloading practice statistics for %s", date)
     temp_name = get_temp_filename(filename)
-    result = client.query(
+    result = Client("hscic").query(
         """
         SELECT *
         FROM {hscic}.practice_statistics_all_years
@@ -40,25 +38,9 @@ def ensure_stats_downloaded_for_date(date):
         """
         % (date,)
     )
-
     with gzip.open(temp_name, "wt") as f:
         writer = csv.writer(f)
         writer.writerow(result.field_names)
         for row in result.rows:
             writer.writerow(row)
     os.rename(temp_name, filename)
-
-
-def check_stats_in_bigquery(date, client):
-    """
-    Assert that practice statistics for date is in BigQuery.
-    """
-    results = client.query(
-        """
-        SELECT COUNT(*)
-        FROM {hscic}.practice_statistics_all_years
-        WHERE month = TIMESTAMP("%s")
-        """
-        % (date,)
-    )
-    assert results.rows[0][0] > 0

--- a/openprescribing/matrixstore/build/download_prescribing.py
+++ b/openprescribing/matrixstore/build/download_prescribing.py
@@ -120,7 +120,6 @@ def extract_data_for_date(date, bq_client):
     """
     Extract prescribing data for the given month into its own table on BigQuery
     """
-    check_prescribing_data_in_bigquery(date, bq_client)
     table_id = table_id_for_date(date)
     logger.info("Extracting data for %s into table %s", date, table_id)
     table = bq_client.get_table(table_id)
@@ -135,21 +134,6 @@ def extract_data_for_date(date, bq_client):
         """,
         substitutions={"month": date},
     )
-
-
-def check_prescribing_data_in_bigquery(date, bq_client):
-    """
-    Assert that prescribing data for date is in BigQuery.
-    """
-    results = bq_client.query(
-        """
-        SELECT COUNT(*)
-        FROM {hscic}.prescribing_v2
-        WHERE month = TIMESTAMP("%s")
-        """
-        % (date,)
-    )
-    assert results.rows[0][0] > 0
 
 
 def export_data_for_date(date, bq_client, bucket):


### PR DESCRIPTION
Reverts ebmdatalab/openprescribing#2612

This causes the e2e tests to fail.