### PR TITLE
Don't check data is in BQ in end-to-end tests

### DIFF
--- a/openprescribing/matrixstore/build/download_practice_stats.py
+++ b/openprescribing/matrixstore/build/download_practice_stats.py
@@ -7,6 +7,8 @@ import gzip
 import logging
 import os
 
+from django.conf import settings
+
 from gcutils.bigquery import Client
 
 from .common import get_practice_stats_filename, get_temp_filename
@@ -53,6 +55,8 @@ def check_stats_in_bigquery(date, client):
     """
     Assert that practice statistics for date is in BigQuery.
     """
+    if not settings.CHECK_DATA_IN_BQ:
+        return
     results = client.query(
         """
         SELECT COUNT(*)

--- a/openprescribing/matrixstore/build/download_prescribing.py
+++ b/openprescribing/matrixstore/build/download_prescribing.py
@@ -141,6 +141,8 @@ def check_prescribing_data_in_bigquery(date, bq_client):
     """
     Assert that prescribing data for date is in BigQuery.
     """
+    if not settings.CHECK_DATA_IN_BQ:
+        return
     results = bq_client.query(
         """
         SELECT COUNT(*)

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -414,3 +414,7 @@ CHECK_NUMBERS_BASE_PATH = "/tmp/numbers-checker/"
 
 # Path of directory containing measure definitions.
 MEASURE_DEFINITIONS_PATH = join(APPS_ROOT, "measure_definitions")
+
+# When building the matrixstore, should we check whether data is in BQ before
+# downloading it?
+CHECK_DATA_IN_BQ = True

--- a/openprescribing/openprescribing/settings/e2etest.py
+++ b/openprescribing/openprescribing/settings/e2etest.py
@@ -28,3 +28,9 @@ BQ_DEFAULT_TABLE_EXPIRATION_MS = 24 * 60 * 60 * 1000  # 24 hours
 
 # We want to use the real measure definitions, not the test ones!
 MEASURE_DEFINITIONS_PATH = os.path.join(APPS_ROOT, "measure_definitions")
+
+# When building the matrixstore, should we check whether data is in BQ before
+# downloading it?  Usually we want to, but because only two months of data are
+# uploaded in the end-to-end tests, and because we try to download five years
+# of data, we need to disable the checks.
+CHECK_DATA_IN_BQ = False


### PR DESCRIPTION
The checks are useful, but we need to disable them in the end-to-end tests.  Supersedes #2632.