### PR TITLE
Raise 404 on request for old data

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from rest_framework.decorators import api_view
@@ -438,8 +439,12 @@ def spending_by_org(request, format=None, org_type=None):
     if org_type != "practice":
         orgs = orgs.only(code_field, "name")
 
-    data = _get_prescribing_entries(codes, orgs, org_type, date=date)
-    response = Response(list(data))
+    try:
+        data = list(_get_prescribing_entries(codes, orgs, org_type, date=date))
+    except KeyError:
+        raise Http404
+
+    response = Response(data)
     if request.accepted_renderer.format == "csv":
         filename = "spending-by-{}-{}.csv".format(org_type, "-".join(codes))
         response["content-disposition"] = "attachment; filename={}".format(filename)

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -1,11 +1,10 @@
-from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, NotFound
 
-from common.utils import nhs_titlecase
+from common.utils import nhs_titlecase, parse_date
 from frontend.models import Practice, PCT, STP, RegionalTeam, PCN, NCSOConcession
 from frontend.price_per_unit.prescribing_breakdown import (
     get_prescribing,
@@ -28,6 +27,21 @@ from . import view_utils as utils
 class NotValid(APIException):
     status_code = 400
     default_detail = "The code you provided is not valid"
+
+
+class BadDate(NotFound):
+    def __init__(self, date):
+        try:
+            parsed = parse_date(date)
+            # Ensures that strings like "2020-1-1" are treated as format errors
+            # even though they can be parsed correctly
+            if parsed.isoformat() != date:
+                raise ValueError()
+        except ValueError:
+            detail = "Dates must be in YYYY-MM-DD format"
+        else:
+            detail = "Date is outside the 5 years of data available"
+        super().__init__(detail)
 
 
 def _get_org_or_404(org_code, org_type=None):
@@ -439,10 +453,7 @@ def spending_by_org(request, format=None, org_type=None):
     if org_type != "practice":
         orgs = orgs.only(code_field, "name")
 
-    try:
-        data = list(_get_prescribing_entries(codes, orgs, org_type, date=date))
-    except KeyError:
-        raise Http404
+    data = list(_get_prescribing_entries(codes, orgs, org_type, date=date))
 
     response = Response(data)
     if request.accepted_renderer.format == "csv":
@@ -484,7 +495,10 @@ def _get_prescribing_entries(bnf_code_prefixes, orgs, org_type, date=None):
     # Pair each date with its column offset (either all available dates or just
     # the specified one)
     if date:
-        date_offsets = [(date, db.date_offsets[date])]
+        try:
+            date_offsets = [(date, db.date_offsets[date])]
+        except KeyError:
+            raise BadDate(date)
     else:
         date_offsets = sorted(db.date_offsets.items())
     # Yield entries for each organisation on each date

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -352,7 +352,14 @@ class TestSpendingByPractice(ApiTestBase):
     def test_total_spending_by_practice_with_old_date(self):
         params = {"date": "1066-11-01"}
         rsp = self._get(params)
-        self.assertEqual(rsp.status_code, 404)
+        self.assertContains(
+            rsp, "Date is outside the 5 years of data available", status_code=404
+        )
+
+    def test_total_spending_by_practice_with_malformed_date(self):
+        params = {"date": "2015-1-1"}
+        rsp = self._get(params)
+        self.assertContains(rsp, "Dates must be in YYYY-MM-DD format", status_code=404)
 
     def test_spending_by_practice_on_chemical(self):
         params = {"code": "0204000I0", "date": "2014-11-01"}

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -349,6 +349,11 @@ class TestSpendingByPractice(ApiTestBase):
         self.assertEqual(rows[0]["items"], "41")
         self.assertEqual(rows[0]["quantity"], "2544.0")
 
+    def test_total_spending_by_practice_with_old_date(self):
+        params = {"date": "1066-11-01"}
+        rsp = self._get(params)
+        self.assertEqual(rsp.status_code, 404)
+
     def test_spending_by_practice_on_chemical(self):
         params = {"code": "0204000I0", "date": "2014-11-01"}
         rows = self._get_rows(params)


### PR DESCRIPTION
Only the last five years of data are available via the API.

Thanks to Thomas Richards for the bug report.