### PR TITLE
Run cache garbage collection from a cron job

### DIFF
--- a/deploy/clearsessions.sh
+++ b/deploy/clearsessions.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. /webapps/openprescribing/.venv/bin/activate
+python /webapps/openprescribing/openprescribing/manage.py clearsessions

--- a/deploy/crontab-openprescribing
+++ b/deploy/crontab-openprescribing
@@ -6,3 +6,4 @@
 30 03 * * * hello /webapps/openprescribing/deploy/fetch_and_import_dmd.sh
 00 04 * * * hello /webapps/openprescribing/deploy/clean_up_bq_test_data.sh
 00 05 * * * hello /webapps/openprescribing/deploy/diskcache_garbage_collect.sh
+30 05 * * * hello /webapps/openprescribing/deploy/clearsessions.sh

--- a/deploy/crontab-openprescribing
+++ b/deploy/crontab-openprescribing
@@ -5,3 +5,4 @@
 00 03 * * * hello /webapps/openprescribing/deploy/fetch_drug_tariff.sh
 30 03 * * * hello /webapps/openprescribing/deploy/fetch_and_import_dmd.sh
 00 04 * * * hello /webapps/openprescribing/deploy/clean_up_bq_test_data.sh
+00 05 * * * hello /webapps/openprescribing/deploy/diskcache_garbage_collect.sh

--- a/deploy/diskcache_garbage_collect.sh
+++ b/deploy/diskcache_garbage_collect.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. /webapps/openprescribing/.venv/bin/activate
+python /webapps/openprescribing/openprescribing/manage.py diskcache_garbage_collect

--- a/openprescribing/frontend/management/commands/diskcache_garbage_collect.py
+++ b/openprescribing/frontend/management/commands/diskcache_garbage_collect.py
@@ -1,0 +1,20 @@
+import textwrap
+
+from django.core.management.base import BaseCommand
+from django.core.cache import cache
+
+
+class Command(BaseCommand):
+    help = textwrap.dedent(
+        """
+        Deletes oldest values from the DiskCache instance until it is within
+        its specified maximum size. See the CACHE section of the settings file
+        for more detail.
+        """
+    )
+
+    def handle(self, *args, **options):
+        while True:
+            deleted = cache.cull()
+            if deleted <= 0:
+                break

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -375,6 +375,15 @@ CACHES = {
             # that.
             "disk_min_file_size": cache_size_limit,
             "sqlite_mmap_size": cache_size_limit,
+            # This disables automatic deletion of older values when the cache
+            # exceeds its size limit. By default this is done automatically
+            # after each write (synchronously, as part of the same thread) but
+            # in our case, posssibly because we're storing unusually large
+            # objects in the db, this results in SQLite locking up and the
+            # request erroring out. So we disable this behaviour and instead do
+            # the garbage collection in the `diskcache_garbage_collect`
+            # management command triggered by a cron job.
+            "cull_limit": 0,
         },
     }
 }


### PR DESCRIPTION
By default, DiskCache does this automatically as part of the request
which is convenient but has caused us database locking problems.

On both previous occasions I've seen the issue early and have been able
to fix it by stopping the server, deleting the cache, and restarting.
But we're unlikely to continue being so lucky so this feels worth fixing
now.

While we're here, I've also added a cron job to delete stale data from the `sessions` table, which will otherwise grow without bound.