### PR TITLE
Remove unused presentation metadata from MatrixStore

### DIFF
--- a/openprescribing/matrixstore/build/init_db.py
+++ b/openprescribing/matrixstore/build/init_db.py
@@ -20,9 +20,6 @@ logger = logging.getLogger(__name__)
 SCHEMA_SQL = """
     CREATE TABLE presentation (
         bnf_code TEXT,
-        is_generic BOOLEAN,
-        adq_per_quantity FLOAT,
-        name TEXT,
         -- The below columns will contain the actual prescribing data as
         -- serialized matrices of shape (number of practices, number of months)
         items BLOB,
@@ -85,7 +82,6 @@ def init_db(end_date, sqlite_path, months=None):
     dates = generate_dates(end_date, months=months)
     import_dates(sqlite_conn, dates)
     import_practices(bq_conn, sqlite_conn, dates)
-    import_presentations(bq_conn, sqlite_conn)
     sqlite_conn.commit()
     sqlite_conn.close()
     os.rename(temp_filename, sqlite_path)
@@ -124,33 +120,4 @@ def import_practices(bq_conn, sqlite_conn, dates):
     logger.info("Writing %s practice codes to SQLite", len(practice_codes))
     sqlite_conn.executemany(
         "INSERT INTO practice (offset, code) VALUES (?, ?)", enumerate(practice_codes)
-    )
-
-
-def import_presentations(bq_conn, sqlite_conn):
-    """
-    Query BigQuery for BNF codes and metadata on all presentations and insert
-    into SQLite
-    """
-    # We initially pull in metadata for all presentations. After we have
-    # imported prescribing data and applied the "BNF map" to apply any changed
-    # to codes we can delete entries for presentations that don't have
-    # associated prescribing.
-    logger.info("Querying all presentation metadata")
-    result = bq_conn.query(
-        """
-        SELECT bnf_code, is_generic, adq_per_quantity, name
-          FROM {hscic}.presentation
-          ORDER BY bnf_code
-        """
-    )
-    rows = result.rows
-    logger.info("Writing %s presentations to SQLite", len(rows))
-    sqlite_conn.executemany(
-        """
-        INSERT INTO presentation
-          (bnf_code, is_generic, adq_per_quantity, name)
-          VALUES (?, ?, ?, ?)
-        """,
-        rows,
     )

--- a/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
+++ b/openprescribing/matrixstore/tests/commands/test_matrixstore_build.py
@@ -127,22 +127,13 @@ class TestMatrixStoreBuild(SimpleTestCase):
         self.assertNotIn(self.closed_practice["code"], practice_codes)
 
     def test_presentations_are_correct(self):
-        expected = list(self.presentations)
-        expected.append(self.updated_presentation)
-        expected.sort(key=lambda i: i["bnf_code"])
-        # Allow us to get results as dicts
-        self.connection.row_factory = sqlite3.Row
+        expected = [p["bnf_code"] for p in self.presentations]
+        expected.append(self.updated_presentation["bnf_code"])
+        expected.sort()
         results = self.connection.execute(
-            """
-            SELECT
-              bnf_code, is_generic, adq_per_quantity, name
-            FROM
-              presentation
-            ORDER BY
-              bnf_code
-            """
+            "SELECT bnf_code FROM presentation ORDER BY bnf_code"
         )
-        results = [dict(row) for row in results]
+        results = [row[0] for row in results]
         self.assertEqual(results, expected)
         self.assertNotIn(self.presentation_to_update, results)
         self.assertNotIn(self.presentation_without_prescribing, results)

--- a/openprescribing/matrixstore/tests/import_test_data_fast.py
+++ b/openprescribing/matrixstore/tests/import_test_data_fast.py
@@ -47,18 +47,6 @@ def init_db(sqlite_conn, data_factory, dates):
     sqlite_conn.executemany(
         "INSERT INTO practice (offset, code) VALUES (?, ?)", enumerate(practice_codes)
     )
-    presentations = (
-        (p["bnf_code"], p["is_generic"], p["adq_per_quantity"], p["name"])
-        for p in data_factory.presentations
-    )
-    sqlite_conn.executemany(
-        """
-        INSERT INTO presentation
-          (bnf_code, is_generic, adq_per_quantity, name)
-          VALUES (?, ?, ?, ?)
-        """,
-        presentations,
-    )
 
 
 def import_practice_stats(sqlite_conn, data_factory, dates):


### PR DESCRIPTION
I think this ended up sticking around from the very first
proof-of-concept MatrixStore code, despite the fact that we have never
-- and now will never -- use it.

Removing it now while it occurs to me.