### PR TITLE
Update paper refs & DataLab website

### DIFF
--- a/openprescribing/measure_definitions/statinintensity.json
+++ b/openprescribing/measure_definitions/statinintensity.json
@@ -14,7 +14,8 @@
     "2014 NICE guidance on <a href='https://www.nice.org.uk/guidance/cg181/chapter/1-Recommendations#lipid-modification-therapy-for-the-primary-and-secondary-prevention-of-cvd-2'>primary and secondary lipid modification</a>",
     "recommends the use of a high-intensity statin (i.e. one that reduces LDL cholesterol by 40% or more) with a low acquisition cost. ",
     "A table showing the percentage reduction of LDL cholesterol by statin doses can be found ",
-    "<a href='https://www.nice.org.uk/guidance/cg181/chapter/appendix-a-grouping-of-statins'>here</a>.  Please note, we have excluded ",
+    "<a href='https://www.nice.org.uk/guidance/cg181/chapter/appendix-a-grouping-of-statins'>here</a> and you can read our research paper on suboptimal ",
+    " statin treatment regimens in the <a href='https://doi.org/10.3399/bjgp20X710873'>British Journal of General Practice</a>.Please note, we have excluded ",
     "liquid preparations from this measure."
   ],
   "tags": [

--- a/openprescribing/measure_definitions/trimethoprim.json
+++ b/openprescribing/measure_definitions/trimethoprim.json
@@ -11,7 +11,9 @@
   "why_it_matters": [
     "Resistance to trimethoprim is increasing, and therefore Public Health England ",
     "is recommending that <a href='https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/664740/Managing_common_infections_guidance_for_consultation_and_adaptation.pdf'> ",
-    "nitrofurantoin is used first for empirical treatment of urinary tract infections.</a>"
+    "nitrofurantoin is used first for empirical treatment of urinary tract infections.</a>",
+    "</p> You can read our paper on the implementation of this guidance in the <a href='https://doi.org/10.1093/jac/dky509'>Journal of Antimicrobial Chemotherapy</a>.</p>"
+    
   ],
   "tags": [
     "antimicrobial",

--- a/openprescribing/measure_definitions/trimethoprim.json
+++ b/openprescribing/measure_definitions/trimethoprim.json
@@ -12,7 +12,7 @@
     "Resistance to trimethoprim is increasing, and therefore Public Health England ",
     "is recommending that <a href='https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/664740/Managing_common_infections_guidance_for_consultation_and_adaptation.pdf'> ",
     "nitrofurantoin is used first for empirical treatment of urinary tract infections.</a>",
-    "</p> You can read our paper on the implementation of this guidance in the <a href='https://doi.org/10.1093/jac/dky509'>Journal of Antimicrobial Chemotherapy</a>.</p>"
+    "<p> You can read our paper on the implementation of this guidance in the <a href='https://doi.org/10.1093/jac/dky509'>Journal of Antimicrobial Chemotherapy</a>.</p>"
     
   ],
   "tags": [


### PR DESCRIPTION
Updated measures with new paper refs.

Additionally the DataLab website changes need to be imported to OP research page. Changes have been made on wordpress

Link to instructions
https://github.com/ebmdatalab/openprescribing/blob/672e04478536f747e1ea7d2d82190ee3983368c6/openprescribing/templates/research.html