### PR TITLE
Comment out production environment variables

### DIFF
--- a/environment-sample
+++ b/environment-sample
@@ -47,7 +47,7 @@ NEW_RELIC_LICENSE_KEY=new_relic_license_key
 
 # The path to a file containing your credentials for accessing Google Cloud
 # Platform services (eg BigQuery, Cloud Storage).
-GOOGLE_APPLICATION_CREDENTIALS=
+# GOOGLE_APPLICATION_CREDENTIALS=
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Only required for the pipeline


### PR DESCRIPTION
These environment variables are unneeded in development.  In particular
GOOGLE_APPLICATION_CREDENTIALS must not be set to an empty string,
otherwise it prevents use of user's OAuth token.