### PR TITLE
Fix Drug Tariff download script

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         imported_months = []
 
-        for a in doc.findAll("a", href=re.compile("Part%20VIIIA")):
+        for a in doc.findAll("a", href=re.compile(r"Part%20VIIIA.+\.xlsx$")):
             # a.attrs['href'] typically has a filename part like
             # Part%20VIIIA%20September%202017.xlsx
             #


### PR DESCRIPTION
The index page now include links to CSV files, which breaks the filename
parsing. Restritcting the regex to match only links ending in `.xlsx`
seems to do the trick.