### PR TITLE
Create environment file

### DIFF
--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -4,7 +4,7 @@
 # application session via docker-compose
 
 # environment file required by wait_for_postgres
-cp ../environment-test ../environment
+cp ./environment-test ./environment
 # wait_for_postgres seems to be unnecessary for Travis & Github Actions,
 # other configurations not tested
 python ./scripts/wait_for_postgres.py

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -3,7 +3,12 @@
 # Commands that should be run before starting a docker-based
 # application session via docker-compose
 
+# environment file required by wait_for_postgres
+cp ../environment-test ../environment
+# wait_for_postgres seems to be unnecessary for Travis & Github Actions,
+# other configurations not tested
 python ./scripts/wait_for_postgres.py
+
 pip install -q -r requirements.txt
 if ! [ -r openprescribing/media/js/node_modules ]; then
     ln -s /npm/node_modules openprescribing/media/js/


### PR DESCRIPTION
* `wait_for_postgres.sh` wants to read it, and it's currently not created until later in the process
* also note for future reference that `wait_for_postgres.sh` seems to be unnecessary (for at least some environments), but I don't think it's a problem to keep it
