### PR TITLE
Remove unnecessary npm clean 

### DIFF
--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -12,5 +12,4 @@ else
 fi
 mkdir logs
 cd openprescribing/media/js
-npm cache clean
 npm install -s


### PR DESCRIPTION
* As of npm@5, this command has only been outputting a deprecation warning as [cache clean is no longer required to verify cache integrity](https://docs.npmjs.com/cli/cache#details).
* At the time of writing, our docker-on-Travis setup is using npm `6.2.0`.
