### PR TITLE
Automatically update setuptools when running docker

### DIFF
--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -4,6 +4,7 @@
 # application session via docker-compose
 
 python ./scripts/wait_for_postgres.py
+pip install -q -U pip setuptools
 pip install -q -r requirements.txt
 if ! [ -r openprescribing/media/js/node_modules ]; then
     ln -s /npm/node_modules openprescribing/media/js/


### PR DESCRIPTION
* Fixes `google-auth 1.20.1 has requirement setuptools>=40.3.0, but you'll have setuptools 40.0.0 which is incompatible.`