### PR TITLE
Upgrade docker-compose in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 sudo: required
-env:
-  global:
-    DOCKER_COMPOSE_VERSION: 1.9.0
 matrix:
   include:
     - name: "Unit tests"
@@ -39,10 +36,6 @@ python:
   # running the Travis jobs.  3.6 is required to run black in lint.sh.
   - "3.6"
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   - openssl aes-256-cbc -K $encrypted_c3e391f06205_key -iv $encrypted_c3e391f06205_iv -in google-credentials-ebmdatalabtest-1ad80daf5cc1.json.enc -out google-credentials.json -d
 install:
   - docker pull dockette/stretch


### PR DESCRIPTION
* was previously pinned to 1.9.0 -> I think this was an upgrade at the time it was done, in order to support v2.1 of the Dockerfile syntax, but is now a downgrade.
* Use whichever docker-compose comes by default, currently `1.23.1`