### PR TITLE
Override newrelic log path for test environment

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -195,6 +195,7 @@ monitor_mode = false
 
 [newrelic:test]
 monitor_mode = false
+log_file = /openprescribing/logs/newrelic.log
 
 [newrelic:staging]
 app_name = Python Application (Staging)


### PR DESCRIPTION
* fix `2020-08-25 13:40:55,601 (18729/MainThread) newrelic ERROR - Falling back to stderr logging as unable to create log file '/webapps/openprescribing/logs/newrelic.log'.` error