### PR TITLE
Create Github Actions Slack notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
-name: CI
+name: "OpenPrescribing CI"
 
-on:
-  push:
+on: [ pull_request ]
 
 jobs:
   unit_test:
@@ -21,6 +20,15 @@ jobs:
         run: docker-compose run --service-ports test && docker-compose run --service-ports test-production
         env:
           TEST_SUITE: nonfunctional
+      - name: Notify slack failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: technoise
+          status: "FAILURE (unit_test)"
+          color: danger
 
   # Functional tests are failing on Travis too!
   #
@@ -53,6 +61,15 @@ jobs:
         run: docker run -v ${GITHUB_WORKSPACE}:/openprescribing/ dockette/stretch /bin/bash -c "cd /openprescribing/ansible && bash test_playbook.sh"
         env:
           LANG: en_US.UTF-8
+      - name: Notify slack failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: technoise
+          status: "FAILURE (ansible)"
+          color: danger
 
   linting:
     runs-on: ubuntu-latest
@@ -69,3 +86,26 @@ jobs:
           pip install black==19.3b0
           pip install flake8==3.7.8
           scripts/lint.sh
+      - name: Notify slack failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: technoise
+          status: "FAILURE (linting)"
+          color: danger
+
+  notify_slack:
+    runs-on: ubuntu-latest
+    needs: [ unit_test , ansible_buildout_test, linting ]
+
+    steps:
+      - name: Notify slack success
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: technoise
+          status: SUCCESS
+          color: good


### PR DESCRIPTION
* use https://github.com/voxmedia/github-action-slack-notify-build as it seems to be one of the few plugin options that will easily link to the PR page (which I think is very useful!)
* authenticate with `SLACK_BOT_TOKEN` in Github Secrets
* notify failures separately - can be useful to be aware of (e.g.) linting fail vs unit test fail
* although it is possible to get the plugin to update a message as the CI progresses, this proved to be fiddly to do with multiple jobs, so I haven't set that up
