### PR TITLE
Pin setuptools to a working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Install library dependencies (current as of Debian Jessie):
 
 Ensure pip and setuptools are up to date:
 
-    pip install -U pip setuptools
+    pip install -U pip
+    pip install setuptools==49.6.0
 
 Install Python dependencies:
 

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,11 +1,16 @@
 ---
-- name: Setup Virtualenv and upgrade setuptools and pip
+- name: Setup Virtualenv and upgrade pip
   pip:
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     name:
-      - setuptools
       - pip
+
+- name: Upgrade setuptools
+  pip:
+    virtualenv: "{{ virtualenv_path }}"
+    name:
+      - setuptools==49.6.0
 
 - name: install virtualenvwrapper
   pip:

--- a/ansible/test_playbook.sh
+++ b/ansible/test_playbook.sh
@@ -6,6 +6,8 @@ set -e -o pipefail
 cd /openprescribing/ansible
 apt-get update && apt-get -qq -y install locales curl python3
 curl https://bootstrap.pypa.io/get-pip.py | python3
+echo "Downgrading setuptools to <50 for Debian/Ubuntu compatibility"
+pip install setuptools==49.6.0
 /usr/local/bin/pip install -r vagrant_requirements.txt
 
 # Set up the locale we use in postgres

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -9,7 +9,8 @@ cp ./environment-test ./environment
 # other configurations not tested
 python ./scripts/wait_for_postgres.py
 
-pip install -q -U pip setuptools
+pip install -q -U pip
+pip install -q setuptools==49.6.0
 pip install -q -r requirements.txt
 if ! [ -r openprescribing/media/js/node_modules ]; then
     ln -s /npm/node_modules openprescribing/media/js/


### PR DESCRIPTION
* v50 was just released and doesn't work for us
* pin to last known working (49.6.0)
* seems like this is a common problem https://github.com/pypa/setuptools/issues/2350