### PR TITLE
Run Github Actions CI on push to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: "OpenPrescribing CI"
 
-on: [ pull_request ]
+on:
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   unit_test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: "OpenPrescribing CI"
 
 on:
-on:
   push:
     branches:
       - master


### PR DESCRIPTION
* Pushes to pull requests are already automatically built
* If we enable builds for all pushes, opening a PR triggers two builds