### PR TITLE
Run selenium tests on multiple browsers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
   functional_tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        browser: [ "IE:11.0:Windows:7" , "Firefox:latest:OS X:Catalina" ]
     steps:
       - name: 'BrowserStack Env Setup'
         uses: 'browserstack/github-actions/setup-env@master'
@@ -57,7 +60,7 @@ jobs:
         run: docker-compose run --service-ports test
         env:
           TEST_SUITE: functional
-          BROWSER: "IE:11.0:Windows:7"
+          BROWSER: ${{ matrix.browser }}
       - name: 'BrowserStackLocal Stop'
         uses: 'browserstack/github-actions/setup-local@master'
         with:


### PR DESCRIPTION
* also run tests on Firefox for interest
* tests run quicker overall & two tests that timeout on IE11 don't timeout, the salient points:

```
 test_summary_totals_on_analyse_page (frontend.tests.functional.test_charts.AnalyseSummaryTotalsTest) ... expected failure
test_map_slider (frontend.tests.functional.test_charts.MapTest) ... unexpected success
test_nothing_hidden_by_default (frontend.tests.functional.test_charts.SmallListTest) ... unexpected success
```
