### PR TITLE
Tweak dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: "disabled"
   open-pull-requests-limit: 99
   allow:
   - dependency-type: direct

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
     versions:
     - "< 3"
     - ">= 2.a"
+  - dependency-name: mock
+    versions:
+    - "> 3.0.5"
+  - dependency-name: networkx
+    versions:
+    - "> 2.4"
   - dependency-name: numpy
     versions:
     - "> 1.18.5"
@@ -39,3 +45,6 @@ updates:
   - dependency-name: scipy
     versions:
     - "> 1.4.1"
+  - dependency-name: titlecase
+    versions:
+    - "> 0.12.0"

--- a/README.md
+++ b/README.md
@@ -392,6 +392,26 @@ To install the hooks, run once:
 
 Details of the hooks are in .pre-commit-config.yaml
 
+# Maintenance
+
+## Dependabot
+
+### Python / pip
+
+Our policy is to keep python dependencies up to date as much as possible. Dependabot PRs should generally be merged if CI passes.
+
+### JavaScript / npm
+
+At the time of writing, we don't trust our JS test suite to notify us of failures, so dependabot is not currently enabled/encourage for these dependencies.
+
+### Rebase
+
+Auto-rebase is disabled, because of CI failures due to the number of PRs requiring more browserstack workers than our current plan allows for. The bot will help if you leave a comment on the PR saying `@dependabot rebase`.
+
+### Ignored dependencies
+
+At the time of writing, we have lots of dependencies ignored due to dependabot commands, which you can view by [searching the repository](https://github.com/ebmdatalab/openprescribing/search?q=%22%40dependabot+ignore%22+in%3Acomments&type=issues).
+
 # Philosophy
 
 This project follows design practices from [Two Scoops of Django](http://twoscoopspress.org/products/two-scoops-of-django-1-6).

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Details of the hooks are in .pre-commit-config.yaml
 
 # Maintenance
 
-## Dependabot
+## Dependency updates
 
 ### Python / pip
 
@@ -407,10 +407,6 @@ At the time of writing, we don't trust our JS test suite to notify us of failure
 ### Rebase
 
 Auto-rebase is disabled, because of CI failures due to the number of PRs requiring more browserstack workers than our current plan allows for. The bot will help if you leave a comment on the PR saying `@dependabot rebase`.
-
-### Ignored dependencies
-
-At the time of writing, we have lots of dependencies ignored due to dependabot commands, which you can view by [searching the repository](https://github.com/ebmdatalab/openprescribing/search?q=%22%40dependabot+ignore%22+in%3Acomments&type=issues).
 
 # Philosophy
 


### PR DESCRIPTION
* ignore more packages that do not support python 3.5. These were previously ignored with github PR comments, but dependabot no longer respects these.
* add a quick notes on policy to the README file
