### PR TITLE
Support downloading practice level PPU data for CCG

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -123,6 +123,7 @@ def price_per_unit(request, format=None):
     """
     entity_code = request.query_params.get("entity_code", "")
     entity_type = request.query_params.get("entity_type", "").lower()
+    child_org_type = request.query_params.get("child_org_type", "")
     date = request.query_params.get("date")
     bnf_code = request.query_params.get("bnf_code")
     aggregate = bool(request.query_params.get("aggregate"))
@@ -163,8 +164,9 @@ def price_per_unit(request, format=None):
             entity_codes = get_row_grouper(entity_type).ids
         else:
             # When looking at a specific BNF code for a specific CCG we
-            # actually want the results over its practices
-            if entity_type == "ccg" and bnf_code:
+            # actually want the results over its practices. And the same goes
+            # if we've explicitly asked for practice level data
+            if entity_type == "ccg" and (bnf_code or child_org_type == "practice"):
                 entity_type = "practice"
                 entity_codes = _get_practice_codes_for_ccg(entity_code)
             # Otherwise we should just show the specified org

--- a/openprescribing/templates/_ppu_data_table.html
+++ b/openprescribing/templates/_ppu_data_table.html
@@ -45,5 +45,24 @@
 
 </table>
 
-<a class="btn btn-primary" href="{% url 'price_per_unit_api' %}?entity_code={{ entity.code }}&date={{ date|date:'Y-m-d' }}&bnf_code={{ bnf_code }}&aggregate={{ aggregate }}&entity_type={{ entity_type }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
+<div class="btn-group" role="group">
+  <a class="btn btn-primary" href="{% url 'price_per_unit_api' %}?entity_code={{ entity.code }}&date={{ date|date:'Y-m-d' }}&bnf_code={{ bnf_code }}&aggregate={{ aggregate }}&entity_type={{ entity_type }}&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download this data</a>
+
+  {% if by_ccg and not aggregate and not bnf_code %}
+    <div class="btn-group" role="group">
+      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li>
+          <a href="{% url 'price_per_unit_api' %}?entity_code={{ entity.code }}&date={{ date|date:'Y-m-d' }}&bnf_code={{ bnf_code }}&aggregate={{ aggregate }}&entity_type={{ entity_type }}&child_org_type=practice&format=csv">
+            Download data at practice level
+          </a>
+        </li>
+      </ul>
+    </div>
+  {% endif %}
+
+</div>
+
 <hr>


### PR DESCRIPTION
Previously @richiecroker used BigQuery to get this as it ended up being
stored there as a side-effect of the calculation method.

This PR patches on another argument to what is already a pig's ear of an
API. (Note: this uses "org" rather than "entity" as that's what we've
settled on elsewhere.) It also adds a dropdown option to the download
button (where applicable) to allow downloading this data via the UI.

![localhost_8000_ccg_02W_price_per_unit_](https://user-images.githubusercontent.com/19630/94128169-b45cad00-fe51-11ea-8fe4-0e486029eff2.png)