### PR TITLE
Pin google-cloud-bigquery-* to < 2.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     versions:
     - "< 3"
     - ">= 2.a"
+  - dependency-name: google-cloud-bigquery
+    versions:
+    - "< 2.0.0"
   - dependency-name: google-cloud-bigquery-storage
     versions:
     - "< 2.0.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
     versions:
     - "< 3"
     - ">= 2.a"
+  - dependency-name: google-cloud-bigquery-storage
+    versions:
+    - "< 2.0.0"
   - dependency-name: mock
     versions:
     - "> 3.0.5"


### PR DESCRIPTION
* pin these packages because 2.0.0 drops support for python 3.5, makes breaking changes to the api, and causes our unit tests to fail
* see also https://github.com/ebmdatalab/openprescribing/pull/2873 and https://github.com/ebmdatalab/openprescribing/pull/2875

