### PR TITLE
Update handlebars to 4.0.14

### DIFF
--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -62,7 +62,7 @@
     "domready": "^1.0.8",
     "downloadjs": "^1.4.7",
     "factor-bundle": "^2.5.0",
-    "handlebars": "4.0.5",
+    "handlebars": "4.0.14",
     "humanize": "^0.0.9",
     "jquery": "^1.11.3",
     "mapbox.js": "^2.2.1",


### PR DESCRIPTION
* in general, we're not confident in our js tests, but bumping to the latest 4.0.x is probably safe