### PR TITLE
Change wording on concessions

### DIFF
--- a/openprescribing/frontend/tests/test_bookmark_utils.py
+++ b/openprescribing/frontend/tests/test_bookmark_utils.py
@@ -802,11 +802,11 @@ class TestNCSOConcessions(TestCase):
             msg.subject, "Your update about Price Concessions for Practice 2"
         )
         self.assertIn("published for **July 2018**", msg.body)
-        self.assertIn("prescribed at Practice 2", msg.body)
+        self.assertIn("at Practice 2", msg.body)
         additional_cost = round(
             ncso_spending_for_entity(self.practice, "practice", 1)[0]["additional_cost"]
         )
-        self.assertIn("an additional **\xa3{:,}**".format(additional_cost), msg.body)
+        self.assertIn("**\xa3{:,}**".format(additional_cost), msg.body)
 
         html = msg.alternatives[0][0]
         self.assertInHTML("<b>July 2018</b>", html)
@@ -821,9 +821,7 @@ class TestNCSOConcessions(TestCase):
         additional_cost = round(
             ncso_spending_for_entity(self.ccg, "ccg", 1)[0]["additional_cost"]
         )
-        self.assertIn(
-            "cost CCG 0 an additional **\xa3{:,}**".format(additional_cost), msg.body
-        )
+        self.assertIn("**\xa3{:,}**".format(additional_cost), msg.body)
 
         html = msg.alternatives[0][0]
         self.assertInHTML("<b>July 2018</b>", html)
@@ -840,12 +838,7 @@ class TestNCSOConcessions(TestCase):
         additional_cost = round(
             ncso_spending_for_entity(None, "all_england", 1)[0]["additional_cost"]
         )
-        self.assertIn(
-            "cost the NHS in England an additional **\xa3{:,}**".format(
-                additional_cost
-            ),
-            msg.body,
-        )
+        self.assertIn("**\xa3{:,}**".format(additional_cost), msg.body)
 
         html = msg.alternatives[0][0]
         self.assertInHTML("<b>July 2018</b>", html)

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -95,8 +95,8 @@
 
 <h3>Impact of price concessions</h3>
 <p>
-  We have estimated the additional spending due to price concessions on
-  out-of-stock products by taking the latest available prescribing data from
+  We have estimated the additional spending due to price concessions
+  by taking the latest available prescribing data from
   <strong>{{ ncso_spending.last_prescribing_date|date:"F Y" }}</strong>
   and projecting forwards.
   In <strong>{{ ncso_spending.month|date:"F Y" }}</strong> this amounts to:<br>

--- a/openprescribing/templates/bookmarks/email_for_ncso_concessions.html
+++ b/openprescribing/templates/bookmarks/email_for_ncso_concessions.html
@@ -20,7 +20,7 @@
 {% if entity_type == 'practice' %}
 <p>
   We estimate that in {{ latest_month|date:"F Y" }} total price concessions for
-  out-of-stock medicines prescribed at {{ entity_name }} will cost your CCG an
+  products reported to only be available above Drug Tariff price at {{ entity_name }} will cost your CCG an
   additional <b>£{{ additional_cost|sigfigs:5|floatformat:"0"|intcomma }}</b>.
   This is for information only; you should discuss with your CCG before
   modifying a patient's medicine treatments based solely on Price Concessions.
@@ -28,7 +28,7 @@
 {% else %}
 <p>
   We estimate that in {{ latest_month|date:"F Y" }} total price concessions for
-  out-of-stock medicines will cost {{ entity_name }} an additional
+  products reported to only be available above Drug Tariff price will cost {{ entity_name }} an additional
   <b>£{{ additional_cost|sigfigs:5|floatformat:"0"|intcomma }}</b>.
 </p>
 {% endif %}


### PR DESCRIPTION
I have amended wording on email alerts (rationale below). I have changed 
- NCSO template
- All England alert template (although see #2517 as they aren't going atm)

Is there anywhere else it needs changing? I don't think so but not sure with templates


------

We have received feedback that are wording on price concessions is not perfect. We say

> We estimate that in November 2020 total price concessions for out-of-stock medicines will cost

I think "out of stock"  was my/our attempt at describing types of items in plain english but it is not technically true as concessions are not applied to things that can't be gotten! More accurately they are described by wording suggested by a user

> We estimate that in November 2020 total price concessions for products reported to only be available above Drug Tariff price 

