### PR TITLE
Fix Mapbox maps

### DIFF
--- a/openprescribing/media/js/package.json
+++ b/openprescribing/media/js/package.json
@@ -65,7 +65,7 @@
     "handlebars": "4.7.6",
     "humanize": "^0.0.9",
     "jquery": "^1.11.3",
-    "mapbox.js": "^2.2.1",
+    "mapbox.js": "^2.4.0",
     "moment": "^2.10.3",
     "npm-run-all": "^4.1.2",
     "uglify-js": "^3.2.2",

--- a/openprescribing/media/js/src/analyse-map.js
+++ b/openprescribing/media/js/src/analyse-map.js
@@ -23,7 +23,8 @@ var analyseMap = {
     _this.activeNames = _.pluck(options.orgIds, 'name');
     L.mapbox.accessToken = window.MAPBOX_PUBLIC_TOKEN;
     if (typeof _this.map === 'undefined') {
-      _this.map = L.mapbox.map('map', 'mapbox.streets');
+      _this.map = L.mapbox.map('map', null);
+      _this.map.addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
       _this.map.scrollWheelZoom.disable();
     } else {
       _this.map.removeLayer(_this.orgLayer);

--- a/openprescribing/media/js/src/measures.js
+++ b/openprescribing/media/js/src/measures.js
@@ -142,8 +142,10 @@ var measures = {
       var maxZoom = _this.zoomLevelForOrgType(options.orgType);
       var map = L.mapbox.map(
         _this.el.mapPanel,
-        'mapbox.streets',
-        {zoomControl: false}).setView([52.905, -1.79], maxZoom);
+        null,
+        {zoomControl: false});
+      map.setView([52.905, -1.79], maxZoom);
+      map.addLayer(L.mapbox.styleLayer('mapbox://styles/mapbox/streets-v11'));
       map.scrollWheelZoom.disable();
       var layer = L.mapbox.featureLayer()
           .loadURL(options['orgLocationUrl'])


### PR DESCRIPTION
This involved updating to the latest version of the 2.0 series, which is
still API compatible with our code. The size of this patch undersells
the grief involved in producing it ("cannot read property 0 of
undefined" etc.).

Closes #2544