### PR TITLE
Run tests under 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: "Linting"
         run: |
           pip install black==20.8b1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.5
+FROM python:3.8
 
-MAINTAINER Seb Bacon version: 0.1
+MAINTAINER Seb Bacon version: 0.2
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM ebmdatalab/openprescribing-py3-base:latest
+FROM ghcr.io/ebmdatalab/openprescribing-py38-base:latest
 
 RUN wget -qO- https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz | tar xvz -C /usr/bin
 RUN apt-get update && apt-get install -y firefox-esr xvfb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mdillon/postgis:latest
     env_file: environment-docker
   test:
-    image: ebmdatalab/openprescribing-py3-test:latest
+    image: ghcr.io/ebmdatalab/openprescribing-py38-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh test && cd openprescribing && make test'
     env_file: environment-docker
     environment:
@@ -40,7 +40,7 @@ services:
       - db-test
 
   test-production:
-    image: ebmdatalab/openprescribing-py3-base:latest
+    image: ghcr.io/ebmdatalab/openprescribing-py38-base:latest
     command: /bin/bash -c './scripts/docker_setup.sh production && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
     env_file: environment-docker
     environment:
@@ -72,7 +72,7 @@ services:
     image: mdillon/postgis:latest
     env_file: environment-docker
   dev:
-    image: ebmdatalab/openprescribing-py3-test:latest
+    image: ghcr.io/ebmdatalab/openprescribing-py38-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'
     env_file: environment-docker
     ports:

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -3,18 +3,8 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 from django.core.exceptions import ImproperlyConfigured
 from common import utils
-import warnings
 
 import sys
-
-# This `cryptography` warning is making our cronjobs chatty
-warnings.filterwarnings(
-    "ignore", "Python 3.5 support will be dropped in the next release"
-)
-if sys.version_info >= (3, 6):
-    warnings.warn(
-        "Warning supression on line above is now redundant and should be removed"
-    )
 
 
 # PATH CONFIGURATION


### PR DESCRIPTION
Now we're running 3.8 in production we should test using it as well.

This also removes a warning that's no longer relevant.

Instructions for updating the Python version are now in wiki:
https://github.com/ebmdatalab/openprescribing/wiki/Installing-a-new-Python-version-for-OpenPrescribing