### PR TITLE
Fixes for Python 3.8

### DIFF
--- a/openprescribing/frontend/tests/test_bookmark_utils.py
+++ b/openprescribing/frontend/tests/test_bookmark_utils.py
@@ -516,8 +516,9 @@ class GenerateImageTestCase(unittest.TestCase):
             if e.errno != errno.ENOENT:
                 raise
 
-    @patch("subprocess.check_output")
-    def test_empty_image_raises(self, check_output):
+    @patch("subprocess.run")
+    def test_empty_image_raises(self, run):
+        run.return_value.returncode = 0
         with open(self.file_path, "a"):
             # create an empty file
             os.utime(self.file_path, None)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -500,8 +500,24 @@ def attach_image(msg, url, file_path, selector, dimensions="1024x1024"):
         dimensions=dimensions,
         wait=wait,
     )
-    result = subprocess.check_output(cmd, shell=True)
-    logger.debug("Command %s completed with output %s" % (cmd, result.strip()))
+    response = subprocess.run(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    if response.returncode > 0:
+        raise BadAlertImageError(
+            f"phantomjs command failed with code {response.returncode}\n\n"
+            f"cmd:\n{cmd}\n\n"
+            f"stdout:\n{response.stdout}\n\n"
+            f"stderr:\n{response.stderr}"
+        )
+    else:
+        logger.debug(
+            "Command %s completed with output %s" % (cmd, response.stdout.strip())
+        )
     if os.path.getsize(file_path) == 0:
         msg = "File at %s empty (generated from url %s)" % (file_path, url)
         raise BadAlertImageError(msg)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -506,6 +506,9 @@ def attach_image(msg, url, file_path, selector, dimensions="1024x1024"):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
+        # Fix for PhantomJS under new versions of Debian/Ubuntu
+        # See https://github.com/ariya/phantomjs/issues/15449
+        env=dict(os.environ, OPENSSL_CONF="/etc/ssl"),
     )
     if response.returncode > 0:
         raise BadAlertImageError(

--- a/openprescribing/matrixstore/tests/import_test_data_fast.py
+++ b/openprescribing/matrixstore/tests/import_test_data_fast.py
@@ -51,8 +51,14 @@ def init_db(sqlite_conn, data_factory, dates):
 
 def import_practice_stats(sqlite_conn, data_factory, dates):
     filtered_practice_stats = _filter_by_date(data_factory.practice_statistics, dates)
-    practice_statistics_csv = _dicts_to_csv(filtered_practice_stats)
-    practice_statistics = parse_practice_statistics_csv(practice_statistics_csv)
+    filtered_practice_stats = list(filtered_practice_stats)
+    if filtered_practice_stats:
+        practice_statistics_csv = _dicts_to_csv(filtered_practice_stats)
+        # This blows up if we give it an empty CSV because it can't find the
+        # headers it expects
+        practice_statistics = parse_practice_statistics_csv(practice_statistics_csv)
+    else:
+        practice_statistics = []
     write_practice_stats(sqlite_conn, practice_statistics)
 
 


### PR DESCRIPTION
Contains fixes for running under Python 3.8 and on newer versions of the base OS.

These are backwards compatible and so can be merged while we're still running under Python 3.5.