### PR TITLE
Remove dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,47 +10,8 @@ updates:
   - dependency-type: direct
   - dependency-type: indirect
   ignore:
-  - dependency-name: bcrypt
-    versions:
-    - "> 3.1.7"
-  - dependency-name: django
-    versions:
-    - ">= 3.a"
-    - "< 4"
-  - dependency-name: fabric
-    versions:
-    - "< 3"
-    - ">= 2.a"
-  - dependency-name: google-cloud-bigquery
-    versions:
-    - ">= 2.0.0"
-  - dependency-name: google-cloud-bigquery-storage
-    versions:
-    - ">= 2.0.0"
-  - dependency-name: mock
-    versions:
-    - "> 3.0.5"
-  - dependency-name: networkx
-    versions:
-    - "> 2.4"
-  - dependency-name: numpy
-    versions:
-    - "> 1.18.5"
-  - dependency-name: openpyxl
-    versions:
-    - ">= 3.a"
-    - "< 4"
-  - dependency-name: pandas
-    versions:
-    - ">= 1.a"
-    - "< 2"
-  - dependency-name: pandas-gbq
-    versions:
-    - ">= 0.11.a"
-    - "< 0.12"
-  - dependency-name: scipy
-    versions:
-    - "> 1.4.1"
+  # We're just not interested in messing around with updates to this module
+  # (changes to its capitalisation rules break our tests)
   - dependency-name: titlecase
     versions:
     - "> 0.12.0"


### PR DESCRIPTION
We think most of these are only there because of Python version
incompatibilities which should no longer apply now we're running 3.8.

In future we should include comments with each ignore rule so we know
why each is there. (I'm assuming the intial version of this file was
auto-generated so not finger-pointing here!)

Possibly addresses #2927