### PR TITLE
Changed deprecated Docker instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8
 
-MAINTAINER Seb Bacon version: 0.2
+LABEL maintainer="Seb Bacon version: 0.2"
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
MAINTAINER is deprecated and should be replaced with LABEL.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated