### PR TITLE
Use correct default for `include_in_alerts` measure config

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -298,7 +298,7 @@ def create_or_update_measure(measure_def, end_date):
     m.is_cost_based = v["is_cost_based"]
     m.is_percentage = v["is_percentage"]
     m.low_is_good = v["low_is_good"]
-    m.include_in_alerts = v.get("include_in_alerts", False)
+    m.include_in_alerts = v.get("include_in_alerts", True)
 
     m.numerator_type = v["numerator_type"]
 


### PR DESCRIPTION
At some point in past, all measures were included in alerts. We then
added an `include_in_alerts` config value which was set to `False` for
measures we didn't want included but omitted for all others. We then
realised that we weren't actually reading this config value anywhere
which we fixed in #2908 but got the default the wrong way round.

After this is merged we'll need to re-import the measure definitions
with:

    ./manage.py import_measures --definitions_only

Closes #2941