### PR TITLE
Consistent panel heading height

### DIFF
--- a/openprescribing/media/css/dashboard.less
+++ b/openprescribing/media/css/dashboard.less
@@ -59,6 +59,7 @@
 
     .panel-heading {
       white-space: normal;
+      min-height: 5em
     }
 
     .panel-body {


### PR DESCRIPTION
Before: 
<img width="1664" alt="Screenshot 2021-04-02 at 15 20 32" src="https://user-images.githubusercontent.com/2082895/113424041-665bcf80-93c7-11eb-9caa-74a6e0c72065.png">

After:
<img width="1664" alt="Screenshot 2021-04-02 at 15 20 50" src="https://user-images.githubusercontent.com/2082895/113423988-547a2c80-93c7-11eb-9461-8ba8fe5ad11b.png">
