### PR TITLE
Handle KeyErrors triggered by missing organisations

### DIFF
--- a/openprescribing/api/exception_handler.py
+++ b/openprescribing/api/exception_handler.py
@@ -1,0 +1,13 @@
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import APIException, status
+
+from matrixstore.db import UnknownOrgIDError
+
+
+def custom_exception_handler(exc, context):
+    # Convert UnknownOrgIDError into an appropriate API exception
+    if isinstance(exc, UnknownOrgIDError):
+        org_id = exc.args[0]
+        exc = APIException(detail=f"Unknown organisation ID: {org_id}")
+        exc.status_code = status.HTTP_400_BAD_REQUEST
+    return exception_handler(exc, context)

--- a/openprescribing/matrixstore/db.py
+++ b/openprescribing/matrixstore/db.py
@@ -14,6 +14,10 @@ from frontend.models import Practice
 from .connection import MatrixStore
 from .row_grouper import RowGrouper
 
+# We don't raise this directly here but consumers of the module should be able
+# to catch this exception without having to import from `row_grouper` directly,
+# which violates the abstraction
+from .row_grouper import UnknownGroupError as UnknownOrgIDError  # noqa
 
 # Create a memoize decorator (i.e. a decorator which caches the return value
 # for a given set of arguments). Here `maxsize=None` means "don't apply any

--- a/openprescribing/matrixstore/row_grouper.py
+++ b/openprescribing/matrixstore/row_grouper.py
@@ -1,8 +1,21 @@
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 import hashlib
 
 import numpy
 import scipy.sparse
+
+
+class UnknownGroupError(KeyError):
+    pass
+
+
+class GroupsDict(dict):
+    def __missing__(self, key):
+        """
+        Raise a specific error for unknown group IDs, rather than a generic
+        KeyError to make these easier to catch elsewhere
+        """
+        raise UnknownGroupError(key)
 
 
 class RowGrouper(object):
@@ -51,7 +64,7 @@ class RowGrouper(object):
             group_id: group_offset for (group_offset, group_id) in enumerate(self.ids)
         }
         # Maps group ID to the numpy object which selects the rows of that group
-        self._group_selectors = OrderedDict(
+        self._group_selectors = GroupsDict(
             [(group_id, numpy.array(groups[group_id])) for group_id in self.ids]
         )
         # Where each group contains only one row (which is the case whenever

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -272,6 +272,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.SessionAuthentication",
     ),
+    "EXCEPTION_HANDLER": "api.exception_handler.custom_exception_handler",
 }
 
 CORS_URLS_REGEX = r"^/api/.*$"


### PR DESCRIPTION
We do this by raising a specific exception class when an unrecognised organisation ID is requested and then adding a custom exception handler which converts these to an appropriate API response.

Closes #3042