### PR TITLE
Use pysqlite3 instead of stdlib sqlite3

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -6,6 +6,14 @@ from common import utils
 
 import sys
 
+# Replace stdlib sqlite3 with a more up-to-date version. This bit of
+# monkey-patching is required because we want the DiskCache library to use this
+# version as well and we can't (easily) rewrite its imports. And also, because
+# this is an experiment for now this is a quick and non-invasive way of trying
+# it out. Longer term we can change our own code to import pysqlite3 directly
+# and do some more targetted monkey patching for DiskCache.
+__import__("pysqlite3")
+sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
 
 # PATH CONFIGURATION
 # Absolute filesystem path to the Django project directory:

--- a/requirements.in
+++ b/requirements.in
@@ -33,6 +33,7 @@ pandas
 premailer
 psycopg2-binary
 pyarrow
+pysqlite3-binary
 python-dateutil
 pytz
 raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -220,6 +220,8 @@ pyparsing==2.4.7
     # via httplib2
 pyquery==1.4.1
     # via -r requirements.in
+pysqlite3-binary==0.4.6
+    # via -r requirements.in
 python-dateutil==2.8.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
This is so we can make use of the bundled version of SQLite in
pysqlite3-binary which (since [this PR][1]) has been compiled with a
much higher memory-map limit. Since, our 6G prescribing files were
exceeding the previous 2G limit its possible that this will have
significant performance benefits for us. The easiest way of finding out
is just to try it and see. We have nginx logging response times so a
before/after comparison should be fairly straightforward.

[1]: https://github.com/coleifer/pysqlite3/pull/22