### PR TITLE
Experimental PR to run tests for Dependabot PRs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -196,7 +196,7 @@ protobuf==3.13.0
     #   googleapis-common-protos
 psycopg2-binary==2.8.6
     # via -r requirements.in
-pyarrow==2.0.0
+pyarrow==3.0.0
     # via -r requirements.in
 pyasn1-modules==0.2.8
     # via google-auth


### PR DESCRIPTION
Dependabot PRs run without access to secrets so the tests (which rely on the BigQuery test account credentials) can't run.

However, because CI runs are attached to the commit ID it's possible to create a separate PR with the some commit which will cause the tests to run and then update the status of the original dependabot PR.

This is an experiment at a workflow where we leave this PR open and force push dependabot commits to it in order to force test runs.