### PR TITLE
Use django-2.2.20

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-cors-headers
 django-crispy-forms
 django-dotenv
 django-import-export
-django==2.2.18
+django==2.2.20
 djangorestframework
 djangorestframework-csv
 google-api-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ django-extensions==3.0.9
     # via -r requirements.in
 django-import-export==2.4.0
     # via -r requirements.in
-django==2.2.18
+django==2.2.20
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
* fix `CVE-2021-28658`
* see also https://github.com/ebmdatalab/openprescribing/security/dependabot/requirements.txt/Django/open