### PR TITLE
Bump django-debug-toolbar from 3.1.1 to 3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ django-crispy-forms==1.9.2
     # via -r requirements.in
 django-debug-toolbar-template-timings==0.9
     # via -r requirements.in
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
     # via
     #   -r requirements.in
     #   django-debug-toolbar-template-timings


### PR DESCRIPTION
* Another security patch https://github.com/ebmdatalab/openprescribing/security/dependabot/requirements.txt/django-debug-toolbar/open
* re-run CI with access to secrets

Bumps [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) from 3.1.1 to 3.2.1.
- [Release notes](https://github.com/jazzband/django-debug-toolbar/releases)
- [Changelog](https://github.com/jazzband/django-debug-toolbar/blob/main/docs/changes.rst)
- [Commits](https://github.com/jazzband/django-debug-toolbar/compare/3.1.1...3.2.1)

Signed-off-by: dependabot[bot] <support@github.com>