### PR TITLE
Bump requests[security] from 2.24.0 to 2.25.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -240,7 +240,7 @@ requests-futures==1.0.0
     # via -r requirements.in
 requests-oauthlib==1.3.0
     # via google-auth-oauthlib
-requests[security]==2.24.0
+requests[security]==2.25.1
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
Bumps [requests[security]](https://github.com/psf/requests) from 2.24.0 to 2.25.1.
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/master/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.24.0...v2.25.1)

Signed-off-by: dependabot[bot] <support@github.com>