### PR TITLE
Remove another broken YouTube embed

### DIFF
--- a/openprescribing/templates/how-to-use.html
+++ b/openprescribing/templates/how-to-use.html
@@ -9,14 +9,6 @@
 
 <h2>How to use</h2>
 
-<p>Ben Goldacre talks through some of the things you can do with the site.</p>
-
-<div class="embed-responsive embed-responsive-16by9">
-  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/2gG1mddb-IM"></iframe>
-</div>
-
-<br/>
-
-<p>See also our informal <a href="{% static 'downloads/walkthrough.pdf' %}">walkthough</a> (PDF) for prescribing analysts and our notes on <a href="{% url 'faq' %}">understanding the data</a>.</p>
+<p>See our informal <a href="{% static 'downloads/walkthrough.pdf' %}">walkthough</a> (PDF) for prescribing analysts and our notes on <a href="{% url 'faq' %}">understanding the data</a>.</p>
 
 {% endblock %}


### PR DESCRIPTION
This is the same underlyng issue identified in #3190 and fixed in #3193
whereby a previously public video is now private and no one has
credentials for the account which owns it. However this is a different
video from the one previously on the homepage.

I've grepped for YouTube embeds and confirmed that the remaining videos
are playable. Presumably because they all belong to the EBMDataLab
account:
https://www.youtube.com/channel/UC4V1SB4aV2-7zvzhyI98b4Q/videos