### PR TITLE
Include PPU savings on presentations with no substitutes

### DIFF
--- a/openprescribing/frontend/price_per_unit/substitution_sets.py
+++ b/openprescribing/frontend/price_per_unit/substitution_sets.py
@@ -170,8 +170,6 @@ def get_substitution_sets_from_bnf_codes(bnf_codes, formulation_swaps_file):
             formulation_swaps=swap_descriptions.get(code),
         )
         for code, presentations in sorted(presentation_sets.items())
-        # There's no point in a substitution set with only one member
-        if len(presentations) > 1
     ]
     return DictWithCacheID([(s.id, s) for s in substitution_sets])
 


### PR DESCRIPTION
Even where a generic presentation has no substitutable presentations it
can still have wide variation in price-per-unit and we need to capture
this.

This increases the number of "substitution sets" (sets of equivalent
presentations) over which we calculate savings from 4164 to 7749. Given
that the calculation involves looping over these sets I expect this
change to roughly double the time the calculation takes.

The total savings figure for each organisation is calculated once and
then cached so the only impact here will be felt just after we upload
new data and the cache is being rebuilt. The extra delay might be mildly
annoying but I think we can live with it.

The PPU breakdown pages on the other hand will now just take twice as
long to load. This isn't ideal, but I don't see a quick way round this
given that the calculation currently misses an important class of
savings.

Closes #3233