### PR TITLE
fix: require functional tests to pass to notify success

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
 
   notify_slack:
     runs-on: ubuntu-latest
-    needs: [ unit_test , ansible_buildout_test, linting ]
+    needs: [ unit_test , functional_tests , ansible_buildout_test, linting ]
 
     steps:
       - name: Notify slack success


### PR DESCRIPTION
* when notify_slack was configured, the functional tests were not (usually) passing, now they (usually) are