### PR TITLE
Send Slack notifications to #technoise

### DIFF
--- a/deploy/notify_deploy.py
+++ b/deploy/notify_deploy.py
@@ -10,7 +10,7 @@ def notify_slack(message):
     # Set the webhook_url to the one provided by Slack when you create
     # the webhook at
     # https://my.slack.com/services/new/incoming-webhook/
-    webhook_url = os.environ["SLACK_GENERAL_POST_KEY"]
+    webhook_url = os.environ["SLACK_TECHNOISE_POST_KEY"]
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)

--- a/environment-sample
+++ b/environment-sample
@@ -38,7 +38,7 @@ GUNICORN_TIMEOUT=60
 GUNICORN_NUM_WORKERS=6
 GUNICORN_LOG_LEVEL=warn
 
-SLACK_GENERAL_POST_KEY=slack_general_post_key
+SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
 CF_API_KEY=cf_api_key
 CF_API_EMAIL=cf_api_email
 

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -339,7 +339,9 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 GRAB_HOST = "https://openprescribing.net"
 
 # For sending messages to Slack
-SLACK_GENERAL_POST_KEY = utils.get_env_setting("SLACK_GENERAL_POST_KEY", default="")
+# Webhook URLs for posting to different channels can be configured at
+# https://api.slack.com/apps/A6B85C8KC/incoming-webhooks
+SLACK_TECHNOISE_POST_KEY = utils.get_env_setting("SLACK_TECHNOISE_POST_KEY", default="")
 SLACK_SENDING_ACTIVE = True
 
 

--- a/openprescribing/openprescribing/slack.py
+++ b/openprescribing/openprescribing/slack.py
@@ -4,14 +4,14 @@ from django.conf import settings
 
 
 def notify_slack(message):
-    """Posts the message to #general
+    """Posts the message to #technoise
 
     See https://my.slack.com/services/new/incoming-webhook/
     """
     if not settings.SLACK_SENDING_ACTIVE:
         return
 
-    webhook_url = settings.SLACK_GENERAL_POST_KEY
+    webhook_url = settings.SLACK_TECHNOISE_POST_KEY
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)


### PR DESCRIPTION
This will affect the overnight fetching jobs, the end-to-end test notifications, and deploy notifications.

I've added `SLACK_TECHNOISE_POST_KEY` to the environment variables file.