### PR TITLE
Amend smi greeninhaler

### DIFF
--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -39,11 +39,7 @@
   ],
   "numerator_bnf_codes_filter": [
     "03",
-    "~0301011R0%",
-    "~0301040X0AA",
-    "~0301011Z0AA",
-    "~0301020Q0AAACAC",
-    "~0301020Q0AAAEAE"
+    "~0301011R0%"
   ],
   "denominator_type": "bnf_items",
   "denominator_bnf_codes_query": [

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -34,8 +34,7 @@
   "numerator_bnf_codes_query": [
     "SELECT DISTINCT(bnf_code)",
     "FROM {measures}.dmd_objs_with_form_route",
-    "WHERE form_route = 'pressurizedinhalation.inhalation'",
-    "AND bnf_name NOT LIKE '%Respimat%'"
+    "WHERE form_route = 'pressurizedinhalation.inhalation'"
   ],
   "numerator_bnf_codes_filter": [
     "03",

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -57,10 +57,10 @@
     "richard.croker@phc.ox.ac.uk"
   ],
   "date_reviewed": [
-    "2019-11-19"
+    "2021-11-18"
   ],
   "next_review": [
-    "2020-06-19"
+    "2021-06-18"
   ],
   "measure_notebook_url": [
     "https://github.com/ebmdatalab/jupyter-notebooks/blob/master/new_measures/Drafts/Enviromental%20Inhalers/Environmental%20Inhalers.ipynb"

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -45,7 +45,7 @@
   "denominator_bnf_codes_query": [
     "SELECT DISTINCT(bnf_code)",
     "FROM {measures}.dmd_objs_with_form_route",
-    "WHERE form_route IN ('pressurizedinhalation.inhalation', 'powderinhalation.inhalation')"
+    "WHERE form_route IN ('pressurizedinhalation.inhalation', 'powderinhalation.inhalation', 'inhalationsolution.inhalation')"
   ],
   "denominator_bnf_codes_filter": [
     "03",

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -60,7 +60,7 @@
     "2021-11-18"
   ],
   "next_review": [
-    "2021-06-18"
+    "2022-06-18"
   ],
   "measure_notebook_url": [
     "https://github.com/ebmdatalab/jupyter-notebooks/blob/master/new_measures/Drafts/Enviromental%20Inhalers/Environmental%20Inhalers.ipynb"

--- a/openprescribing/measure_definitions/environmental_inhalers.json
+++ b/openprescribing/measure_definitions/environmental_inhalers.json
@@ -20,9 +20,6 @@
     "including the rationale for excluding salbutamol."
   ],
   "tags": [
-    "staging"
-  ],
-  "staging_tags": [
     "core",
     "greenernhs",
     "iif",

--- a/openprescribing/measure_definitions/environmental_inhalers_staging.json
+++ b/openprescribing/measure_definitions/environmental_inhalers_staging.json
@@ -11,21 +11,24 @@
   "why_it_matters": [
     "The NHS has <a href='https://www.longtermplan.nhs.uk/wp-content/uploads/2019/08/nhs-long-term-plan-version-1.2.pdf'>committed",
     "to reducing its carbon footprint by 51% by 2025</a> to meet the target in the Climate Change Act, including a shift to dry powdered",
-    "inhalers (DPI) to deliver a reduction of 4%.  DPIs and other newer types of inhalers like soft mist inhalers are less harmful to the enviroment than traditional metered",
-    "dose inhalers (MDIs) and the NHS long term plan supports the use of these inahlers where it is clinically appropriate.",
+    "inhalers (DPI) to deliver a reduction of 4%.  DPIs and other newer types of inhalers like soft mist inhalers are less harmful to the environment than traditional metered",
+    "dose inhalers (MDIs) and the NHS long term plan supports the use of these inhalers where it is clinically appropriate.",
     "<a href='https://www.nice.org.uk/guidance/ng80/resources/inhalers-for-asthma-patient-decision-aid-pdf-6727144573'>NICE has ",
-    "produced a inhaler decision aid</a> to faciltiate discussion about inhaler options. ",
+    "produced a inhaler decision aid</a> to facilitiate discussion about inhaler options. ",
     "<p>You can read more about this measure ",
     "<a href='https://ebmdatalab.net/new-measure-inhalers-and-the-environment/'>on our blog</a>, ",
     "including the rationale for excluding salbutamol."
   ],
   "tags": [
+    "staging"
+  ],
+  "staging_tags": [
     "core",
     "greenernhs",
     "iif",
     "nice",
     "respiratory"
-  ],
+  ],  
   "url": null,
   "is_percentage": true,
   "is_cost_based": false,
@@ -37,8 +40,8 @@
     "WHERE form_route = 'pressurizedinhalation.inhalation'"
   ],
   "numerator_bnf_codes_filter": [
-    "03",
-    "~0301011R0%"
+    "03 #Respiratory",
+    "~0301011R0% #Salbutamol"
   ],
   "denominator_type": "bnf_items",
   "denominator_bnf_codes_query": [
@@ -47,8 +50,8 @@
     "WHERE form_route IN ('pressurizedinhalation.inhalation', 'powderinhalation.inhalation', 'inhalationsolution.inhalation')"
   ],
   "denominator_bnf_codes_filter": [
-    "03",
-    "~0301011R0"
+    "03 #Respiratory",
+    "~0301011R0 #Salbutamol"
   ],
   "authored_by": [
     "brian.mackenna@phc.ox.ac.uk"


### PR DESCRIPTION
I have been writing about greener NHS today and decided to tackle a long outstanding issue to programmatically account for soft mist inhalers (see #2144)  We previously manually exempted soft mist inhalers from the numerator as they were incorrectly identified in dm+d as MDIs. This appears to have been rectified .

I'm not sure why I didn't address in #2636 but I suspect as May 2020 I was being pragmatic.

It has been quite awhile since I tackled measures on OP so it would be good if someone could code review this a bit more thoroughly than normal.

I think it would also be useful to check this measure on staging before deployment.