### PR TITLE
Support previewing measures directly from Github

### DIFF
--- a/openprescribing/frontend/management/commands/delete_measure.py
+++ b/openprescribing/frontend/management/commands/delete_measure.py
@@ -7,11 +7,13 @@ from gcutils.bigquery import Client
 
 class Command(BaseCommand):
     def handle(self, measure_id, **options):
-        if not measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
-            raise CommandError(
-                f"Not deleting '{measure_id}' because it doesn't look like a preview "
-                f"measure (it doesn't start with '{settings.MEASURE_PREVIEW_PREFIX}')"
-            )
+        if not options["delete_live_measure"]:
+            if not measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
+                raise CommandError(
+                    f"Not deleting '{measure_id}' because it doesn't look like a "
+                    f"preview measure (it doesn't start with "
+                    f"'{settings.MEASURE_PREVIEW_PREFIX}')"
+                )
         try:
             measure = Measure.objects.get(id=measure_id)
         except Measure.DoesNotExist:
@@ -24,6 +26,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("measure_id")
+        parser.add_argument("--delete-live-measure", action="store_true")
 
 
 def delete_from_bigquery(measure_id):

--- a/openprescribing/frontend/management/commands/delete_measure.py
+++ b/openprescribing/frontend/management/commands/delete_measure.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+
+from frontend.models import Measure
+
+
+class Command(BaseCommand):
+    def handle(self, measure_id, **options):
+        if not measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
+            raise CommandError(
+                f"Not deleting '{measure_id}' because it doesn't look like a preview "
+                f"measure (it doesn't start with '{settings.MEASURE_PREVIEW_PREFIX}')"
+            )
+        try:
+            measure = Measure.objects.get(id=measure_id)
+        except Measure.DoesNotExist:
+            raise CommandError(f"No measure with ID '{measure_id}'")
+        # The ON DELETE CASCADE configuration ensures that all MeasureValues are deleted
+        # as well
+        measure.delete()
+        self.stdout.write(f"Deleted measure '{measure_id}'")
+
+    def add_arguments(self, parser):
+        parser.add_argument("measure_id")

--- a/openprescribing/frontend/management/commands/delete_measure.py
+++ b/openprescribing/frontend/management/commands/delete_measure.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
 from frontend.models import Measure
+from gcutils.bigquery import Client
 
 
 class Command(BaseCommand):
@@ -15,6 +16,7 @@ class Command(BaseCommand):
             measure = Measure.objects.get(id=measure_id)
         except Measure.DoesNotExist:
             raise CommandError(f"No measure with ID '{measure_id}'")
+        delete_from_bigquery(measure_id)
         # The ON DELETE CASCADE configuration ensures that all MeasureValues are deleted
         # as well
         measure.delete()
@@ -22,3 +24,16 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("measure_id")
+
+
+def delete_from_bigquery(measure_id):
+    # Dataset name from `import_measures.MeasureCalculation.get_table()`
+    client = Client("measures")
+    # Table naming convention from `import_measures.MeasureCalculation.table_name()`
+    table_suffix = f"_data_{measure_id}"
+
+    tables_to_delete = [
+        table for table in client.list_tables() if table.table_id.endswith(table_suffix)
+    ]
+    for table in tables_to_delete:
+        client.delete_table(table.table_id)

--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -175,6 +175,11 @@ def load_measure_defs(measure_ids=None):
     glob_path = os.path.join(settings.MEASURE_DEFINITIONS_PATH, "*.json")
     for path in sorted(glob.glob(glob_path)):
         measure_id = os.path.basename(path).split(".")[0]
+        if measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
+            errors.append(
+                f"'{measure_id}' starts with the prefix reserved for previews"
+            )
+            continue
 
         with open(path) as f:
             try:

--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -19,7 +19,11 @@ class Command(BaseCommand):
                 f"Importing measure preview failed for {github_url}\n\n{e.message}"
             )
         measure_url = f"https://openprescribing.net/measure/{measure_id}/"
-        self.stdout.write(f"Measure can be previewed at:\n{measure_url}")
+        self.stdout.write(
+            f"Measure can be previewed at:\n{measure_url}\n\n"
+            f"When you've finished remember to delete the preview with:\n"
+            f"@ebmbot op delete_measure {measure_id}"
+        )
 
     def add_arguments(self, parser):
         parser.add_argument("github_url")

--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -1,0 +1,110 @@
+import re
+
+import requests
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from requests.exceptions import InvalidJSONError, RequestException
+
+from .import_measures import BadRequest
+from .import_measures import Command as ImportMeasuresCommand
+from .import_measures import ImportLog, relativedelta
+
+
+class Command(BaseCommand):
+    def handle(self, github_url, **options):
+        try:
+            measure_id = import_preview_measure(github_url)
+        except BadRequest as e:
+            raise CommandError(
+                f"Importing measure preview failed for {github_url}\n\n{e.message}"
+            )
+        measure_url = f"https://openprescribing.net/measure/{measure_id}/"
+        self.stdout.write(f"Measure can be previewed at:\n{measure_url}")
+
+    def add_arguments(self, parser):
+        parser.add_argument("github_url")
+
+
+def import_preview_measure(github_url):
+    measure_id, json_url = get_id_and_json_url(github_url)
+    measure_def = fetch_measure_def(json_url)
+    measure_def["id"] = measure_id
+
+    measure_def = make_preview_measure(measure_def)
+    import_measure(measure_def)
+
+    return measure_def["id"]
+
+
+def get_id_and_json_url(github_url):
+    match = re.match(
+        r"^"
+        r"https://github\.com/ebmdatalab/openprescribing/blob/"
+        r"(?P<git_ref>[^/\.]+)"
+        r"/openprescribing/measure_definitions/"
+        r"(?P<measure_id>[^/\.]+)"
+        r"\.json"
+        r"$",
+        github_url,
+    )
+    if not match:
+        raise BadRequest(
+            "Expecting a URL in the format:\n"
+            "https://github.com/ebmdatalab/openprescribing/blob/<GIT_REF>/"
+            "openprescribing/measure_definitions/<MEASURE_ID>.json\n"
+            "\n"
+            "You can get this URL by finding the measure file in your branch on "
+            "Github:\n"
+            "https://github.com/ebmdatalab/openprescribing/branches\n"
+            "\n"
+            "Or if you have a PR open you can go to the Files tab, click the three "
+            "dots next to the measure filename and select 'View file'"
+        )
+    git_ref = match.group("git_ref")
+    measure_id = match.group("measure_id")
+    json_url = (
+        f"https://raw.githubusercontent.com/ebmdatalab/openprescribing/"
+        f"{git_ref}/openprescribing/measure_definitions/{measure_id}.json"
+    )
+    return measure_id, json_url
+
+
+def fetch_measure_def(json_url):
+    try:
+        response = requests.get(json_url)
+        response.raise_for_status()
+    except RequestException as e:
+        raise BadRequest(f"Failed to fetch measure JSON, got error:\n{e}")
+    try:
+        measure_def = response.json()
+    except InvalidJSONError as e:
+        raise BadRequest(f"Measure definition was not valid JSON, got error:\n{e}")
+    return measure_def
+
+
+def make_preview_measure(measure_def):
+    measure_def = measure_def.copy()
+    measure_def["id"] = settings.MEASURE_PREVIEW_PREFIX + measure_def["id"]
+    measure_def["name"] = f"PREVIEW: {measure_def['name']}"
+    measure_def["tags"] = []
+    measure_def["include_in_alerts"] = False
+    return measure_def
+
+
+def import_measure(measure_def):
+    end_date = ImportLog.objects.latest_in_category("prescribing").current_at
+    start_date = end_date - relativedelta(years=5)
+
+    command = ImportMeasuresCommand()
+    command.check_definitions([measure_def], start_date, end_date, verbose=False)
+    command.build_measures(
+        [measure_def],
+        start_date,
+        end_date,
+        verbose=False,
+        options={
+            "measure": measure_def["id"],
+            "definitions_only": False,
+            "bigquery_only": False,
+        },
+    )

--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Measure can be previewed at:\n{measure_url}\n\n"
             f"When you've finished remember to delete the preview with:\n"
-            f"@ebmbot op delete_measure {measure_id}"
+            f"@ebmbot op measures delete_preview {measure_id}"
         )
 
     def add_arguments(self, parser):

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -438,6 +438,10 @@ def all_measures(request):
     if tag_filter["tags"]:
         query["tags__overlap"] = tag_filter["tags"]
     measures = Measure.objects.filter(**query).order_by("name")
+    if not request.GET.get("show_previews"):
+        measures = measures.exclude(id__startswith=settings.MEASURE_PREVIEW_PREFIX)
+    else:
+        measures = measures.filter(id__startswith=settings.MEASURE_PREVIEW_PREFIX)
     context = {"tag_filter": tag_filter, "measures": measures}
     return render(request, "all_measures.html", context)
 

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -444,3 +444,7 @@ MEASURE_DEFINITIONS_PATH = join(APPS_ROOT, "measure_definitions")
 # When building the matrixstore, should we check whether data is in BQ before
 # downloading it?
 CHECK_DATA_IN_BQ = True
+
+# Prefix we add to measure IDs to indicate that they are "previews" and should not be
+# shown by default
+MEASURE_PREVIEW_PREFIX = "preview_"


### PR DESCRIPTION
This adds a pair of commands:

    ./manage.py preview_measure [url_of_measure_file_on_github]
    ./manage.py delete_measure [measure_id]

The `preview_measure` command rewrites the measure ID to have the prefix `preview_` (so it's possible to use this to test a new version of an already existing measure) and removes any tags and alert configuration. There's also a little bit of nasty logic to hide it from the "all measures" view. It's still accessible to anyone who knows the URL, but we don't want to cause confusion by showing it by default.

The `delete_measure` command has a safety check so it will only work for measures that have the `preview_` prefix. 

This is not a thing of beauty but it was a reasonably quick way to unlock the workflow we need.