### PR TITLE
Exit zero even on failure :(

### DIFF
--- a/openprescribing/frontend/management/commands/delete_measure.py
+++ b/openprescribing/frontend/management/commands/delete_measure.py
@@ -11,19 +11,19 @@ class Command(BaseCommand):
     def handle(self, measure_id, **options):
         if not options["delete_live_measure"]:
             if not measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
-                # We want these errors to be visble to users who run via ebmbot, but
-                # ebmbot doesn't show stderr so we can't just raise CommandError here
+                # We want these errors to be visble to users who run via ebmbot but the
+                # only way to achieve that is to write them to stderr and exit 0 :(
                 self.stdout.write(
                     f"Not deleting '{measure_id}' because it doesn't look like a "
                     f"preview measure (it doesn't start with "
                     f"'{settings.MEASURE_PREVIEW_PREFIX}')"
                 )
-                sys.exit(1)
+                sys.exit(0)
         try:
             measure = Measure.objects.get(id=measure_id)
         except Measure.DoesNotExist:
             self.stdout.write(f"No measure with ID '{measure_id}'")
-            sys.exit(1)
+            sys.exit(0)
         delete_from_bigquery(measure_id)
         # The ON DELETE CASCADE configuration ensures that all MeasureValues are deleted
         # as well

--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -16,12 +16,12 @@ class Command(BaseCommand):
         try:
             measure_id = import_preview_measure(github_url)
         except BadRequest as e:
-            # We want these errors to be visble to users who run via ebmbot, but ebmbot
-            # doesn't show stderr so we can't just raise CommandError here
+            # We want these errors to be visble to users who run via ebmbot but the only
+            # way to achieve that is to write them to stderr and exit 0 :(
             self.stdout.write(
                 f"Importing measure preview failed for {github_url}\n\n{e.message}"
             )
-            sys.exit(1)
+            sys.exit(0)
         measure_url = f"https://openprescribing.net/measure/{measure_id}/"
         self.stdout.write(
             f"Measure can be previewed at:\n{measure_url}\n\n"


### PR DESCRIPTION
This is currently the only way to get error message back to the user if they run
via ebmbot. We should probably fix this.