### PR TITLE
Update where we get Rx data from

### DIFF
--- a/openprescribing/templates/about.html
+++ b/openprescribing/templates/about.html
@@ -37,7 +37,7 @@ cross-platform testing.</p>
 
 <h3 id="sources">Data sources</h3>
 
-<p><strong>Prescribing data</strong> is from the monthly files published by the <a href="https://www.nhsbsa.nhs.uk/information-services-portal-isp">NHS Business Service Authority</a>, used under the terms of the Open Government Licence.</p>
+<p><strong>Prescribing data</strong> is from the monthly files published by the <a href="https://www.nhsbsa.nhs.uk/prescription-data/prescribing-data/english-prescribing-data-epd">NHS Business Service Authority</a>, used under the terms of the Open Government Licence.</p>
 
 <p><strong>Practice list sizes</strong> up to September 2016 are from the <a href="https://apps.nhsbsa.nhs.uk/infosystems/welcome">NHS Business Service Authority's Information Portal</a>, used under the terms of the Open Government Licence. From October 2016, practice list sizes are from <a href="http://content.digital.nhs.uk/article/2021/Website-Search?q=number+of+patients+registered+at+a+gp+practice&go=Go&area=both">NHS Digital</a>, used under the terms of the Open Government Licence. ASTRO-PU and STAR-PUs are calculated from list sizes, based on standard formulas.</p>
 


### PR DESCRIPTION
The BSA now publishes the data on its opendata portal. Updated the link to directly link to English prescribing dataset