### PR TITLE
Remove `openpyxl` version pin from requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ lxml
 lz4
 networkx
 numpy
-openpyxl==3.0.9
+openpyxl
 pandas-gbq
 pandas
 premailer


### PR DESCRIPTION
This was one of the few dependencies left with a specific version pin after
4b50f87228d401dc2d6196e390960cc401cd63fc but there's no record of
why that was (possibly something to do with Python version support?). In
any case, tests are now passing with the latest version.