### PR TITLE
feat: labs/outliers to entity home page

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1502,6 +1502,8 @@ def _home_page_context_for_entity(request, entity):
     if entity_type == "practice":
         measure_options["parentOrgId"] = entity.ccg_id
 
+    entity_outlier_report_url = f"{settings.OUTLIERS_PATH}/html/static_{entity_type}_{entity.code}.html"
+
     context.update(
         {
             "measure": extreme_measure,
@@ -1520,6 +1522,7 @@ def _home_page_context_for_entity(request, entity):
             "spending_for_one_entity_url": "spending_for_one_{}".format(
                 entity_type.lower()
             ),
+            "entity_outlier_report_url": entity_outlier_report_url
         }
     )
 

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -455,3 +455,6 @@ GDAL_LIBRARY_PATH = utils.get_env_setting("GDAL_LIBRARY_PATH", default="")
 
 # outlier prescribing reports static file output
 OUTLIERS_DIR = join(APPS_ROOT, "static", "outlier_reports")
+
+# outlier reports url
+OUTLIERS_PATH = r"labs/outliers"

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -7,6 +7,8 @@ from django.views.generic import RedirectView, TemplateView
 from django.contrib import admin
 from django.http.response import HttpResponseRedirect
 from frontend.views import views
+from django.conf.urls.static import static
+from django.conf import settings
 
 admin.autodiscover()
 
@@ -366,4 +368,6 @@ urlpatterns = [
     path(
         r"<ccg_code>/", views.measures_for_one_ccg, name="measures_for_one_ccg_tracking"
     ),
+    # Labs, currently only outlier reports
+    static(settings.OUTLIERS_PATH, document_root=settings.OUTLIERS_DIR),
 ]

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -187,6 +187,11 @@
   </div>
   <div class="col-md-6">
     <div class="landing-panel">
+      <h3>OpenPrescribing Labs</h3>
+      <p>
+        We are piloting a number of data-driven approaches to identify unusual prescribing and collect feedback on this prescribing to inform development of new tools to support
+        prescribers and organisations to audit and review prescribing. <a href="{% url 'entity_outlier_report_url'%}">Click here</a> to view this {{entity_type_human}}'s outlier prescribing report.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* configure labs/outliers/... urls
* generate entity-specific outlier report url
* add section to entity homepage outlining "labs" and link to outlier report