### PR TITLE
Restore accidentally removed closing `</style>` tag

### DIFF
--- a/openprescribing/templates/research.html
+++ b/openprescribing/templates/research.html
@@ -22,6 +22,7 @@ p.has-very-light-gray-background-color {
 p.has-pale-cyan-blue-background-color {
     background-color: #8ed1fc;
 }
+</style>
 
 <article class="post-5445 page type-page status-publish entry" itemscope itemtype="http://schema.org/CreativeWork"><header class="entry-header"><h1 class="entry-title" itemprop="headline">OpenPrescribing Research</h1>
 </header><div class="entry-content" itemprop="text">


### PR DESCRIPTION
Removed in https://github.com/ebmdatalab/openprescribing/pull/3434