### PR TITLE
add link to audits for greener practice

### DIFF
--- a/openprescribing/common/measure_tags.json
+++ b/openprescribing/common/measure_tags.json
@@ -45,7 +45,7 @@
   },
     "greenernhs": {
     "name": "Greener NHS",
-    "description": "These measures support work to reduce the impact of medicines on overall enviromental impact of the NHS."
+    "description": "These measures support work to reduce the impact of medicines on overall enviromental impact of the NHS. More resources for reviewing prescribing are available at <a href=\"https://www.greenerpractice.co.uk\">Greener Practice </a>"
   },
     "iif": {
     "name": "NHS England Investment and Impact Fund",


### PR DESCRIPTION
I have proposed Greener Practice link as it is useful resource with practical recommendations by practices, similar to how we link to Opioids Aware. The group already uses OP as a key part of their audit recs and is being promoted by NHSE to support with IIF