### PR TITLE
Fix NCSO importer

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -17,6 +17,10 @@ from openprescribing.slack import notify_slack
 
 logger = logging.getLogger(__file__)
 
+DEFAULT_HEADERS = {
+    "User-Agent": "OpenPrescribing-Bot (+https://openprescribing.net)",
+}
+
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
@@ -52,7 +56,7 @@ class Command(BaseCommand):
 
     def download_archive(self):
         url = "https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/archive/"
-        rsp = requests.get(url)
+        rsp = requests.get(url, headers=DEFAULT_HEADERS)
         return bs4.BeautifulSoup(rsp.content, "html.parser")
 
     def import_from_current(self):
@@ -74,7 +78,7 @@ class Command(BaseCommand):
 
     def download_current(self):
         url = "https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/"
-        rsp = requests.get(url)
+        rsp = requests.get(url, headers=DEFAULT_HEADERS)
         return bs4.BeautifulSoup(rsp.content, "html.parser")
 
     def date_from_heading(self, heading):

--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             self.delete_missing(drugs_and_pack_sizes, date)
 
     def download_archive(self):
-        url = "http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/"
+        url = "https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/archive/"
         rsp = requests.get(url)
         return bs4.BeautifulSoup(rsp.content, "html.parser")
 
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         self.delete_missing(drugs_and_pack_sizes, date)
 
     def download_current(self):
-        url = "http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/"
+        url = "https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/"
         rsp = requests.get(url)
         return bs4.BeautifulSoup(rsp.content, "html.parser")
 


### PR DESCRIPTION
The PSNC have a shiny new website, but unfortunately this seems to block (returning 403) requests with the default `requests` user-agent. However, changing this to an explicit OpenPrescribing user-agent seems to work fine.