### PR TITLE
feat: replace IE with Edge in automated tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        browser: [ "IE:11.0:Windows:7" , "Firefox:latest:OS X:Catalina" ]
+        browser: [ "Edge:latest:Windows:10", "Firefox:latest:OS X:Catalina" ]
     steps:
       - name: 'BrowserStack Env Setup'
         uses: 'browserstack/github-actions/setup-env@master'


### PR DESCRIPTION
* IE is officially dead, less than 1% of users in the last month used it to access the site according to Google Analytics, and Edge/Windows is now common