### PR TITLE
Handle new column in drug tariff data

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
@@ -101,6 +101,7 @@ def import_month(rows, date):
         "medicine",
         "packsize",
         "?",
+        "vmpsnomedcode",
         "vmppsnomedcode",
         "drugtariffcategory",
         "basicprice",


### PR DESCRIPTION
There is now a "VMP Snomed Code" header, in addition to the "VMPP Snomed
Code" one. We don't do anything with this, but we need to know that it's
expected to be there.

Fixes this error:
https://sentry.io/organizations/ebm-datalab/issues/3460117173/?project=1254683