### PR TITLE
Fix "Pattern length is too long" errors

### DIFF
--- a/openprescribing/media/js/src/list-filter.js
+++ b/openprescribing/media/js/src/list-filter.js
@@ -4,6 +4,8 @@ require('bootstrap');
 var Fuse = require('../vendor/fuse');
 var domready = require('domready');
 
+var maxPatternLength = 32;
+
 var listFilter = {
 
   setUp: function() {
@@ -21,6 +23,11 @@ var listFilter = {
       } else if (searchTerm === '') {
         r = allItems;
       } else {
+        // If the pattern is too long we're better off truncating it and
+        // returning something than just throwing an error
+        if (searchTerm.length > maxPatternLength) {
+          searchTerm = searchTerm.substring(0, maxPatternLength);
+        }
         r = fuse.search(searchTerm);
       }
       $resultsList.empty();
@@ -42,7 +49,7 @@ var listFilter = {
         threshold: 0.2,
         location: 0,
         distance: 1000,
-        maxPatternLength: 32,
+        maxPatternLength: maxPatternLength,
         keys: ['name', 'code'],
       };
       fuse = new Fuse(allItems, options);


### PR DESCRIPTION
We've been getting these for ages and I've always ignored them. But an
actual user bug report by email has persuaded me to take a look. I think
this workaround will return sensible results in most cases.

Newer versions of the fuzzy search library don't have this length
restriction at all, but even thinking about upgrading is fair too
painful at the moment.
https://github.com/krisk/Fuse/blob/5b9b4a42e2a12d/CHANGELOG.md#version-500-beta