### PR TITLE
Replace CCGs and STPs in URLs and text

### DIFF
--- a/openprescribing/api/urls.py
+++ b/openprescribing/api/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path(r"bubble/", views_spending.bubble, name="bubble"),
     path(r"tariff/", views_spending.tariff, name="tariff_api"),
     path(
-        r"spending_by_ccg/",
+        r"spending_by_sicbl/",
         views_spending.spending_by_org,
         name="spending_by_ccg",
         kwargs={"org_type": "ccg"},
@@ -26,13 +26,13 @@ urlpatterns = [
     ),
     path(r"spending_by_org/", views_spending.spending_by_org, name="spending_by_org"),
     path(r"measure/", views_measures.measure_global, name="measure"),
-    path(r"measure_by_stp/", views_measures.measure_by_stp, name="measure_by_stp"),
+    path(r"measure_by_icb/", views_measures.measure_by_stp, name="measure_by_stp"),
     path(
         r"measure_by_regional_team/",
         views_measures.measure_by_regional_team,
         name="measure_by_regional_team",
     ),
-    path(r"measure_by_ccg/", views_measures.measure_by_ccg, name="measure_by_ccg"),
+    path(r"measure_by_sicbl/", views_measures.measure_by_ccg, name="measure_by_ccg"),
     path(r"measure_by_pcn/", views_measures.measure_by_pcn, name="measure_by_pcn"),
     path(
         r"measure_numerators_by_org/",

--- a/openprescribing/common/utils.py
+++ b/openprescribing/common/utils.py
@@ -29,7 +29,7 @@ def nhs_abbreviations(word, **kwargs):
         return word.upper()
     elif word.lower() in ["dr", "st"]:
         return word.title()
-    elif word.upper() in ("NHS", "CCG", "PMS", "SMA", "PWSI", "OOH", "HIV"):
+    elif word.upper() in ("NHS", "CCG", "SICBL", "PMS", "SMA", "PWSI", "OOH", "HIV"):
         return word.upper()
     elif "&" in word:
         return word.upper()

--- a/openprescribing/frontend/admin.py
+++ b/openprescribing/frontend/admin.py
@@ -84,7 +84,7 @@ class OrgBookmarkTypeFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         return (
             ("practice", "Practice"),
-            ("ccg", "CCG"),
+            ("ccg", "SICBL"),
             ("all_england", "All England"),
         )
 

--- a/openprescribing/frontend/management/commands/import_ccgs.py
+++ b/openprescribing/frontend/management/commands/import_ccgs.py
@@ -20,9 +20,13 @@ class Command(BaseCommand):
 
             ccg, created = PCT.objects.get_or_create(code=row[0])
             if created:
+                # For existing CCGs, we don't want to take the name in eccg.csv, since
+                # it's a meaningless combination of the ICB name and the CCG code.
                 ccg.name = row[1]
             ccg.regional_team_id = row[2]
-            ccg.stp = STP.objects.get_or_create(code=row[3], name=f"ICB {row[3]}")[0]
+            ccg.stp, _ = STP.objects.get_or_create(
+                code=row[3], defaults={"name": f"ICB {row[3]}"}
+            )
             ccg.address = ", ".join([r for r in row[4:9] if r])
             ccg.postcode = row[9]
             od = row[10]

--- a/openprescribing/frontend/management/commands/infer_practice_boundaries.py
+++ b/openprescribing/frontend/management/commands/infer_practice_boundaries.py
@@ -123,7 +123,7 @@ def _get_practice_code_to_region_map(cursor, regions, clip_boundary):
         )
         raise RuntimeError(
             f"Some practices appear to be located entirely outside the national "
-            f"boundary (as determined by aggregating all CCG boundaries) so probably "
+            f"boundary (as determined by aggregating all SICBL boundaries) so probably "
             f"there's some dodgy data somewhere. Offending practices are:\n\n"
             f"{practice_desc}"
         )
@@ -178,8 +178,8 @@ def update_national_boundary_file():
     if ccgs_without_boundary.exists():
         raise RuntimeError(
             """
-            Some active CCGs missing boundary data, meaning we can't reliably
-            synthesize a national boundary by aggregating CCGs
+            Some active SICBLs missing boundary data, meaning we can't reliably
+            synthesize a national boundary by aggregating SICBLs
             """
         )
     boundary = PCT.objects.filter(boundary__isnull=False).aggregate(

--- a/openprescribing/frontend/middleware.py
+++ b/openprescribing/frontend/middleware.py
@@ -5,12 +5,35 @@ from frontend.models import STP
 
 def stp_redirect_middleware(get_response):
     def middleware(request):
-        match = re.search("/stp/(E\d{8})", request.path)
+        path = request.get_full_path()
+
+        # Redirect STP URLs with 9-character ONS codes
+        match = re.search("/stp/(E\d{8})", path)
         if match:
             ons_code = match.groups()[0]
             stp = get_object_or_404(STP, ons_code=ons_code)
-            new_path = request.path.replace(ons_code, stp.code)
+            new_path = path.replace(ons_code, stp.code)
+            new_path = new_path.replace("/stp/", "/icb/")
             return redirect(new_path)
+
+        # Redirect STP URLs
+        if "/stp/" in path:
+            new_path = path.replace("/stp/", "/icb/")
+            return redirect(new_path)
+
+        if "by_stp" in path:
+            new_path = path.replace("by_stp", "by_icb")
+            return redirect(new_path)
+
+        # Redirect CCG URLs
+        if "/ccg/" in path:
+            new_path = path.replace("/ccg/", "/sicbl/")
+            return redirect(new_path)
+
+        if "by_ccg" in path:
+            new_path = path.replace("by_ccg", "by_sicbl")
+            return redirect(new_path)
+
         return get_response(request)
 
     return middleware

--- a/openprescribing/frontend/tests/functional/mock_api_server.py
+++ b/openprescribing/frontend/tests/functional/mock_api_server.py
@@ -83,7 +83,7 @@ class MockApiRequestHandler(BaseHTTPRequestHandler):
             )
         elif "/org_location" in o.path:
             data = _load_json("org_location_ccg")
-        elif "/measure_by_ccg/" in o.path:
+        elif "/measure_by_sicbl/" in o.path:
             code = q.get("tags", "")
             measure = q.get("measure", "")
             if not measure and "core" not in code:

--- a/openprescribing/frontend/tests/functional/test_charts.py
+++ b/openprescribing/frontend/tests/functional/test_charts.py
@@ -94,7 +94,7 @@ class AnalyseSummaryTotalsTest(SeleniumTestCase):
         expected = {
             "panel-heading": (
                 "Total prescribing for Rosuvastatin Calcium across all "
-                "CCGs in NHS England"
+                "SICBLs in NHS England"
             ),
             "js-selected-month": "Sep '16",
             "js-financial-year-range": "Apr—Sep '16",

--- a/openprescribing/frontend/tests/functional/test_general.py
+++ b/openprescribing/frontend/tests/functional/test_general.py
@@ -29,8 +29,8 @@ class GeneralFrontendTest(SeleniumTestCase):
 
     def test_menu_dropdown(self):
         for url in [
-            "/ccg/03Q/",
-            "/ccg/03Q/measures/",
+            "/sicbl/03Q/",
+            "/sicbl/03Q/measures/",
             "/practice/P87629/",
             "/measure/cerazette/",
             "/chemical/0202010D0/",
@@ -53,7 +53,7 @@ class GeneralFrontendTest(SeleniumTestCase):
 
     def test_message_and_action(self):
         for url in [
-            "/ccg/03Q/",
+            "/sicbl/03Q/",
             "/practice/P87629/",
             "/measure/cerazette/",
             "/chemical/0202010D0/",
@@ -96,7 +96,7 @@ class GeneralFrontendTest(SeleniumTestCase):
         self.find_by_xpath('//ul[@id="select2-orgIds-results"]//li')
 
     def test_ccg_measures_sorting(self):
-        url = self.live_server_url + "/ccg/02Q/measures/"
+        url = self.live_server_url + "/sicbl/02Q/measures/"
         self.browser.get(url)
         # The default should be sorting by percentile, then id
         self.assertEqual(
@@ -118,7 +118,7 @@ class GeneralFrontendTest(SeleniumTestCase):
         )
 
     def test_ccg_measures_tags(self):
-        url = self.live_server_url + "/ccg/02Q/measures/?tags=foobar"
+        url = self.live_server_url + "/sicbl/02Q/measures/?tags=foobar"
         self.browser.get(url)
         # nothing is tagged foobar, so should return the text expected
         # when no measures are shown
@@ -128,7 +128,7 @@ class GeneralFrontendTest(SeleniumTestCase):
         self.assertTrue(self.find_by_xpath("//p[contains(text(), 'Unrecognised tag')]"))
 
     def test_ccg_measures_explore_link(self):
-        url = self.live_server_url + "/ccg/02Q/measures/"
+        url = self.live_server_url + "/sicbl/02Q/measures/"
         self.browser.get(url)
         measure = self.find_by_xpath("//div[@id='measure_keppra']")
         self.assertIn(
@@ -138,7 +138,7 @@ class GeneralFrontendTest(SeleniumTestCase):
             ),
         )
         self.assertIn(
-            "/ccg/02Q/keppra",
+            "/sicbl/02Q/keppra",
             measure.find_element_by_partial_link_text(
                 "Split the measure"
             ).get_attribute("href"),

--- a/openprescribing/frontend/tests/functional/test_general.py
+++ b/openprescribing/frontend/tests/functional/test_general.py
@@ -133,9 +133,9 @@ class GeneralFrontendTest(SeleniumTestCase):
         measure = self.find_by_xpath("//div[@id='measure_keppra']")
         self.assertIn(
             "/measure/keppra",
-            measure.find_element_by_partial_link_text("Compare all CCGs").get_attribute(
-                "href"
-            ),
+            measure.find_element_by_partial_link_text(
+                "Compare all SICBLs"
+            ).get_attribute("href"),
         )
         self.assertIn(
             "/sicbl/02Q/keppra",

--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -702,7 +702,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all STPs in England on this measure",
+            "Compare all ICBs in England on this measure",
             "/measure/core_0/icb/",
         )
         self._verify_link(
@@ -747,7 +747,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(4)",
-            "Compare all STPs in England on this measure",
+            "Compare all ICBs in England on this measure",
             "/measure/lpzomnibus/icb/",
         )
         self._verify_link(
@@ -1161,7 +1161,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all STPs in England on this measure",
+            "Compare all ICBs in England on this measure",
             "/measure/lp_2/icb/",
         )
         self._verify_link(
@@ -1544,13 +1544,13 @@ class MeasuresTests(SeleniumTestCase):
         s2 = [s for s in ss if s.cost_saving_10 > 0 and s.cost_saving_50 < 0][0]
         s3 = [s for s in ss if s.cost_saving_10 > 0 and s.cost_saving_50 > 0][0]
 
-        s1_exp_text = "By prescribing better than the median, this STP has saved the NHS £{} over the past 6 months.".format(
+        s1_exp_text = "By prescribing better than the median, this ICB has saved the NHS £{} over the past 6 months.".format(
             _humanize(s1.cost_saving_50)
         )
-        s2_exp_text = "By prescribing better than the median, this STP has saved the NHS £{} over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
+        s2_exp_text = "By prescribing better than the median, this ICB has saved the NHS £{} over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
             _humanize(s2.cost_saving_50), _humanize(s2.cost_saving_10)
         )
-        s3_exp_text = "If it had prescribed in line with the median, this STP would have spent £{} less over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
+        s3_exp_text = "If it had prescribed in line with the median, this ICB would have spent £{} less over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
             _humanize(s3.cost_saving_50), _humanize(s3.cost_saving_10)
         )
 
@@ -1695,7 +1695,7 @@ class MeasuresTests(SeleniumTestCase):
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all STPs had prescribed at the median ratio or better, then NHS England would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all ICBs had prescribed at the median ratio or better, then NHS England would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1791,14 +1791,14 @@ class MeasuresTests(SeleniumTestCase):
             if cost_saving > 0:
                 break
         else:
-            assert False, "Could not find STP with cost saving!"
+            assert False, "Could not find ICB with cost saving!"
 
         self._get("/icb/{}/core_0/".format(r.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all SICBLs had prescribed at the median ratio or better, then this STP would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all SICBLs had prescribed at the median ratio or better, then this ICB would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1928,14 +1928,14 @@ class MeasuresTests(SeleniumTestCase):
             if cost_saving > 0:
                 break
         else:
-            assert False, "Could not find STP with cost saving!"
+            assert False, "Could not find ICB with cost saving!"
 
         self._get("/icb/{}/measures/".format(r.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if this STP had prescribed at the median ratio or better on all cost-saving measures below, then it would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if this ICB had prescribed at the median ratio or better on all cost-saving measures below, then it would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)

--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -223,7 +223,7 @@ class MeasuresTests(SeleniumTestCase):
         )
 
     def test_ccg_home_page(self):
-        self._get("/ccg/AAA/")
+        self._get("/sicbl/AAA/")
 
         ccg = PCT.objects.get(code="AAA")
         mvs = MeasureValue.objects.filter_by_org_type("ccg").filter(pct=ccg)
@@ -234,7 +234,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             extreme_measure.name,
-            "/measure/{}/ccg/AAA/".format(extreme_measure.id),
+            "/measure/{}/sicbl/AAA/".format(extreme_measure.id),
         )
 
         panel_element = self._find_measure_panel("lpzomnibus-container")
@@ -242,11 +242,11 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "LP omnibus measure",
-            "/measure/lpzomnibus/ccg/AAA/",
+            "/measure/lpzomnibus/sicbl/AAA/",
         )
 
     def test_stp_home_page(self):
-        self._get("/stp/E00/")
+        self._get("/icb/E00/")
 
         stp = STP.objects.get(code="E00")
         mvs = MeasureValue.objects.filter_by_org_type("stp").filter(stp=stp)
@@ -257,7 +257,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             extreme_measure.name,
-            "/measure/{}/stp/E00/".format(extreme_measure.id),
+            "/measure/{}/icb/E00/".format(extreme_measure.id),
         )
 
         panel_element = self._find_measure_panel("lpzomnibus-container")
@@ -265,7 +265,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "LP omnibus measure",
-            "/measure/lpzomnibus/stp/E00/",
+            "/measure/lpzomnibus/icb/E00/",
         )
 
     def test_regional_team_home_page(self):
@@ -313,7 +313,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".inner li:nth-child(2)",
             "Compare all practices in this CCG on this measure",
-            "/ccg/AAA/core_0/",
+            "/sicbl/AAA/core_0/",
         )
         self._verify_link(
             panel_element,
@@ -358,7 +358,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".inner li:nth-child(3)",
             "Compare all practices in this CCG on this measure",
-            "/ccg/AAA/lpzomnibus/",
+            "/sicbl/AAA/lpzomnibus/",
         )
         self._verify_link(
             panel_element,
@@ -400,7 +400,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".inner li:nth-child(2)",
             "Compare all practices in this CCG on this measure",
-            "/ccg/AAA/lp_2/",
+            "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
@@ -423,26 +423,26 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 5)
 
     def test_measures_for_one_ccg(self):
-        self._get("/ccg/AAA/measures/")
+        self._get("/sicbl/AAA/measures/")
 
         panel_element = self._find_measure_panel("measure_core_0")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "Core measure 0",
-            "/measure/core_0/ccg/AAA/",
+            "/measure/core_0/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/core_0/ccg/AAA/",
+            "/measure/core_0/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/core_0/",
+            "/sicbl/AAA/core_0/",
         )
         self._verify_link(
             panel_element,
@@ -463,25 +463,25 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "LP omnibus measure",
-            "/measure/lpzomnibus/ccg/AAA/",
+            "/measure/lpzomnibus/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break it down into its constituent measures.",
-            "/ccg/AAA/measures/?tags=lowpriority",
+            "/sicbl/AAA/measures/?tags=lowpriority",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Break the overall score down into individual presentations",
-            "/measure/lpzomnibus/ccg/AAA/",
+            "/measure/lpzomnibus/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/lpzomnibus/",
+            "/sicbl/AAA/lpzomnibus/",
         )
         self._verify_link(
             panel_element,
@@ -504,26 +504,26 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 6)
 
     def test_measures_for_one_ccg_low_priority(self):
-        self._get("/ccg/AAA/measures/?tags=lowpriority")
+        self._get("/sicbl/AAA/measures/?tags=lowpriority")
 
         panel_element = self._find_measure_panel("measure_lp_2")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "LP measure 2",
-            "/measure/lp_2/ccg/AAA/",
+            "/measure/lp_2/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/lp_2/ccg/AAA/",
+            "/measure/lp_2/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/lp_2/",
+            "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
@@ -678,32 +678,32 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 4)
 
     def test_measures_for_one_stp(self):
-        self._get("/stp/E00/measures/")
+        self._get("/icb/E00/measures/")
 
         panel_element = self._find_measure_panel("measure_core_0")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "Core measure 0",
-            "/measure/core_0/stp/E00/",
+            "/measure/core_0/icb/E00/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/core_0/stp/E00/",
+            "/measure/core_0/icb/E00/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Split the measure into charts for individual CCGs",
-            "/stp/E00/core_0/",
+            "/icb/E00/core_0/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
             "Compare all STPs in England on this measure",
-            "/measure/core_0/stp/",
+            "/measure/core_0/icb/",
         )
         self._verify_link(
             panel_element,
@@ -724,31 +724,31 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "LP omnibus measure",
-            "/measure/lpzomnibus/stp/E00/",
+            "/measure/lpzomnibus/icb/E00/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Break it down into its constituent measures.",
-            "/stp/E00/measures/?tags=lowpriority",
+            "/icb/E00/measures/?tags=lowpriority",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Break the overall score down into individual presentations",
-            "/measure/lpzomnibus/stp/E00/",
+            "/measure/lpzomnibus/icb/E00/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
             "Split the measure into charts for individual CCGs",
-            "/stp/E00/lpzomnibus/",
+            "/icb/E00/lpzomnibus/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(4)",
             "Compare all STPs in England on this measure",
-            "/measure/lpzomnibus/stp/",
+            "/measure/lpzomnibus/icb/",
         )
         self._verify_link(
             panel_element,
@@ -859,19 +859,19 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "AAA: CCG 0/0/0",
-            "/ccg/AAA/measures/",
+            "/sicbl/AAA/measures/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/core_0/",
+            "/sicbl/AAA/core_0/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(2)",
             "Break the overall score down into individual presentations",
-            "/measure/core_0/ccg/AAA/",
+            "/measure/core_0/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
@@ -889,25 +889,25 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "AAA: CCG 0/0/0",
-            "/ccg/AAA/measures/",
+            "/sicbl/AAA/measures/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/lpzomnibus/",
+            "/sicbl/AAA/lpzomnibus/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(2)",
             "Break it down into its constituent measures",
-            "/ccg/AAA/measures/?tags=lowpriority",
+            "/sicbl/AAA/measures/?tags=lowpriority",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(3)",
             "Break the overall score down into individual presentations",
-            "/measure/lpzomnibus/ccg/AAA/",
+            "/measure/lpzomnibus/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
@@ -948,26 +948,26 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".explanation li", 3)
 
     def test_measure_for_all_stps(self):
-        self._get("/measure/core_0/stp/")
+        self._get("/measure/core_0/icb/")
 
         panel_element = self._find_measure_panel("stp_E00")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "E00: STP 0/0",
-            "/stp/E00/measures/",
+            "/icb/E00/measures/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
             "Split the measure into charts for individual CCGs",
-            "/stp/E00/core_0/",
+            "/icb/E00/core_0/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(2)",
             "Break the overall score down into individual presentations",
-            "/measure/core_0/stp/E00/",
+            "/measure/core_0/icb/E00/",
         )
         self._verify_link(
             panel_element,
@@ -1047,7 +1047,7 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".inner li:nth-child(1)",
             "Compare all practices in this CCG on this measure",
-            "/ccg/AAA/lp_2/",
+            "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
@@ -1070,20 +1070,20 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 4)
 
     def test_measure_for_one_ccg(self):
-        self._get("/measure/lp_2/ccg/AAA/")
+        self._get("/measure/lp_2/sicbl/AAA/")
 
         panel_element = self._find_measure_panel("measure_lp_2")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "LP measure 2",
-            "/measure/lp_2/ccg/AAA/",
+            "/measure/lp_2/sicbl/AAA/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Split the measure into charts for individual practices",
-            "/ccg/AAA/lp_2/",
+            "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
@@ -1143,26 +1143,26 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 3)
 
     def test_measure_for_one_stp(self):
-        self._get("/measure/lp_2/stp/E00/")
+        self._get("/measure/lp_2/icb/E00/")
 
         panel_element = self._find_measure_panel("measure_lp_2")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "LP measure 2",
-            "/measure/lp_2/stp/E00/",
+            "/measure/lp_2/icb/E00/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
             "Split the measure into charts for individual CCGs",
-            "/stp/E00/lp_2/",
+            "/icb/E00/lp_2/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
             "Compare all STPs in England on this measure",
-            "/measure/lp_2/stp/",
+            "/measure/lp_2/icb/",
         )
         self._verify_link(
             panel_element,
@@ -1215,7 +1215,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".inner li", 4)
 
     def test_measure_for_practices_in_ccg(self):
-        self._get("/ccg/AAA/lp_2/")
+        self._get("/sicbl/AAA/lp_2/")
 
         panel_element = self._find_measure_panel("practice_P00000")
         self._verify_link(
@@ -1251,20 +1251,20 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_num_elements(panel_element, ".explanation li", 1)
 
     def test_measure_for_ccgs_in_stp(self):
-        self._get("/stp/E00/lp_2/")
+        self._get("/icb/E00/lp_2/")
 
         panel_element = self._find_measure_panel("ccg_AAA")
         self._verify_link(
             panel_element,
             ".measure-panel-title",
             "AAA: CCG 0/0/0",
-            "/ccg/AAA/measures/",
+            "/sicbl/AAA/measures/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/lp_2/ccg/AAA/",
+            "/measure/lp_2/sicbl/AAA/",
         )
         self._verify_num_elements(panel_element, ".explanation li", 1)
 
@@ -1276,13 +1276,13 @@ class MeasuresTests(SeleniumTestCase):
             panel_element,
             ".measure-panel-title",
             "111: CCG 1/1/1",
-            "/ccg/111/measures/",
+            "/sicbl/111/measures/",
         )
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
             "Break the overall score down into individual presentations",
-            "/measure/lp_2/ccg/111/",
+            "/measure/lp_2/sicbl/111/",
         )
         self._verify_num_elements(panel_element, ".explanation li", 1)
 
@@ -1380,7 +1380,7 @@ class MeasuresTests(SeleniumTestCase):
 
         # measure_for_practices_in_ccg
         ccg = p1.ccg
-        self._get("/ccg/{}/core_0/".format(ccg.code))
+        self._get("/sicbl/{}/core_0/".format(ccg.code))
         panel_element = self._find_measure_panel("practice_{}".format(p1.code))
         perf_element = panel_element.find_element_by_class_name("explanation")
         self.assertIn(p1_exp_text, perf_element.text)
@@ -1488,26 +1488,26 @@ class MeasuresTests(SeleniumTestCase):
         )
 
         # measure_for_one_ccg
-        self._get("/measure/core_0/ccg/{}/".format(c1.code))
+        self._get("/measure/core_0/sicbl/{}/".format(c1.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(c1_exp_text, perf_element.text)
 
-        self._get("/measure/core_0/ccg/{}/".format(c2.code))
+        self._get("/measure/core_0/sicbl/{}/".format(c2.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(c2_exp_text, perf_element.text)
 
-        self._get("/measure/core_0/ccg/{}/".format(c3.code))
+        self._get("/measure/core_0/sicbl/{}/".format(c3.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(c3_exp_text, perf_element.text)
 
         # measures_for_one_ccg
-        self._get("/ccg/{}/measures/".format(c1.code))
+        self._get("/sicbl/{}/measures/".format(c1.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
@@ -1520,7 +1520,7 @@ class MeasuresTests(SeleniumTestCase):
         self.assertIn(c1_exp_text, perf_element.text)
 
         # ccg_home_page
-        self._get("/ccg/{}/".format(c1.code))
+        self._get("/sicbl/{}/".format(c1.code))
         panel_element = self._find_measure_panel("top-measure-container")
         perf_element = panel_element.find_element_by_class_name("explanation")
         self.assertIn(c1_exp_text, perf_element.text)
@@ -1555,39 +1555,39 @@ class MeasuresTests(SeleniumTestCase):
         )
 
         # measure_for_one_stp
-        self._get("/measure/core_0/stp/{}/".format(s1.code))
+        self._get("/measure/core_0/icb/{}/".format(s1.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(s1_exp_text, perf_element.text)
 
-        self._get("/measure/core_0/stp/{}/".format(s2.code))
+        self._get("/measure/core_0/icb/{}/".format(s2.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(s2_exp_text, perf_element.text)
 
-        self._get("/measure/core_0/stp/{}/".format(s3.code))
+        self._get("/measure/core_0/icb/{}/".format(s3.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(s3_exp_text, perf_element.text)
 
         # measures_for_one_stp
-        self._get("/stp/{}/measures/".format(s1.code))
+        self._get("/icb/{}/measures/".format(s1.code))
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
         self.assertIn(s1_exp_text, perf_element.text)
 
         # measure_for_all_stps
-        self._get("/measure/core_0/stp/")
+        self._get("/measure/core_0/icb/")
         panel_element = self._find_measure_panel("stp_{}".format(s1.code))
         perf_element = panel_element.find_element_by_class_name("explanation")
         self.assertIn(s1_exp_text, perf_element.text)
 
         # stp_home_page
-        self._get("/stp/{}/".format(s1.code))
+        self._get("/icb/{}/".format(s1.code))
         panel_element = self._find_measure_panel("top-measure-container")
         perf_element = panel_element.find_element_by_class_name("explanation")
         self.assertIn(s1_exp_text, perf_element.text)
@@ -1690,7 +1690,7 @@ class MeasuresTests(SeleniumTestCase):
         )
         cost_saving = _get_cost_savings(mvs, rollup_by="stp_id")
 
-        self._get("/measure/core_0/stp/")
+        self._get("/measure/core_0/icb/")
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
@@ -1764,7 +1764,7 @@ class MeasuresTests(SeleniumTestCase):
         else:
             assert False, "Could not find CCG with cost saving!"
 
-        self._get("/ccg/{}/core_0/".format(c.code))
+        self._get("/sicbl/{}/core_0/".format(c.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
@@ -1793,7 +1793,7 @@ class MeasuresTests(SeleniumTestCase):
         else:
             assert False, "Could not find STP with cost saving!"
 
-        self._get("/stp/{}/core_0/".format(r.code))
+        self._get("/icb/{}/core_0/".format(r.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
@@ -1876,7 +1876,7 @@ class MeasuresTests(SeleniumTestCase):
         else:
             assert False, "Could not find CCG with cost saving!"
 
-        self._get("/ccg/{}/measures/".format(c.code))
+        self._get("/sicbl/{}/measures/".format(c.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
@@ -1930,7 +1930,7 @@ class MeasuresTests(SeleniumTestCase):
         else:
             assert False, "Could not find STP with cost saving!"
 
-        self._get("/stp/{}/measures/".format(r.code))
+        self._get("/icb/{}/measures/".format(r.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'

--- a/openprescribing/frontend/tests/functional/test_measures.py
+++ b/openprescribing/frontend/tests/functional/test_measures.py
@@ -94,7 +94,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lpzomnibus/",
         )
         self._verify_link(
@@ -127,7 +127,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/core_0/",
         )
         self._verify_link(
@@ -157,7 +157,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -312,13 +312,13 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all practices in this CCG on this measure",
+            "Compare all practices in this SICBL on this measure",
             "/sicbl/AAA/core_0/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/core_0/",
         )
         self._verify_link(
@@ -357,13 +357,13 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all practices in this CCG on this measure",
+            "Compare all practices in this SICBL on this measure",
             "/sicbl/AAA/lpzomnibus/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(4)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lpzomnibus/",
         )
         self._verify_link(
@@ -399,13 +399,13 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all practices in this CCG on this measure",
+            "Compare all practices in this SICBL on this measure",
             "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -447,7 +447,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/core_0/",
         )
         self._verify_link(
@@ -486,7 +486,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(4)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lpzomnibus/",
         )
         self._verify_link(
@@ -528,7 +528,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -696,7 +696,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/icb/E00/core_0/",
         )
         self._verify_link(
@@ -741,7 +741,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/icb/E00/lpzomnibus/",
         )
         self._verify_link(
@@ -783,7 +783,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/regional-team/Y01/core_0/",
         )
         self._verify_link(
@@ -828,7 +828,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(3)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/regional-team/Y01/lpzomnibus/",
         )
         self._verify_link(
@@ -960,7 +960,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/icb/E00/core_0/",
         )
         self._verify_link(
@@ -990,7 +990,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".explanation li:nth-child(1)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/regional-team/Y01/core_0/",
         )
         self._verify_link(
@@ -1016,7 +1016,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -1046,13 +1046,13 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
-            "Compare all practices in this CCG on this measure",
+            "Compare all practices in this SICBL on this measure",
             "/sicbl/AAA/lp_2/",
         )
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -1088,7 +1088,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(2)",
-            "Compare all CCGs in England on this measure",
+            "Compare all SICBLs in England on this measure",
             "/measure/lp_2/",
         )
         self._verify_link(
@@ -1155,7 +1155,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/icb/E00/lp_2/",
         )
         self._verify_link(
@@ -1191,7 +1191,7 @@ class MeasuresTests(SeleniumTestCase):
         self._verify_link(
             panel_element,
             ".inner li:nth-child(1)",
-            "Split the measure into charts for individual CCGs",
+            "Split the measure into charts for individual SICBLs",
             "/regional-team/Y01/lp_2/",
         )
         self._verify_link(
@@ -1302,7 +1302,7 @@ class MeasuresTests(SeleniumTestCase):
         perf_element = self.find_by_xpath(
             "//*[@id='measure_core_0']//strong[text()='Performance:']/.."
         )
-        exp_text = "Performance: If all CCGs in England had prescribed in line with the median, the NHS would have spent £{} less over the past 6 months. If they had prescribed in line with the best 10%, it would have spent £{} less.".format(
+        exp_text = "Performance: If all SICBLs in England had prescribed in line with the median, the NHS would have spent £{} less over the past 6 months. If they had prescribed in line with the best 10%, it would have spent £{} less.".format(
             _humanize(cost_saving_50), _humanize(cost_saving_10)
         )
         self.assertEqual(perf_element.text, exp_text)
@@ -1477,13 +1477,13 @@ class MeasuresTests(SeleniumTestCase):
         c2 = [c for c in cc if c.cost_saving_10 > 0 and c.cost_saving_50 < 0][0]
         c3 = [c for c in cc if c.cost_saving_10 > 0 and c.cost_saving_50 > 0][0]
 
-        c1_exp_text = "By prescribing better than the median, this CCG has saved the NHS £{} over the past 6 months.".format(
+        c1_exp_text = "By prescribing better than the median, this SICBL has saved the NHS £{} over the past 6 months.".format(
             _humanize(c1.cost_saving_50)
         )
-        c2_exp_text = "By prescribing better than the median, this CCG has saved the NHS £{} over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
+        c2_exp_text = "By prescribing better than the median, this SICBL has saved the NHS £{} over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
             _humanize(c2.cost_saving_50), _humanize(c2.cost_saving_10)
         )
-        c3_exp_text = "If it had prescribed in line with the median, this CCG would have spent £{} less over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
+        c3_exp_text = "If it had prescribed in line with the median, this SICBL would have spent £{} less over the past 6 months. If it had prescribed in line with the best 10%, it would have spent £{} less.".format(
             _humanize(c3.cost_saving_50), _humanize(c3.cost_saving_10)
         )
 
@@ -1679,7 +1679,7 @@ class MeasuresTests(SeleniumTestCase):
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all CCGs had prescribed at the median ratio or better, then NHS England would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all SICBLs had prescribed at the median ratio or better, then NHS England would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1762,14 +1762,14 @@ class MeasuresTests(SeleniumTestCase):
             if cost_saving > 0:
                 break
         else:
-            assert False, "Could not find CCG with cost saving!"
+            assert False, "Could not find SICBL with cost saving!"
 
         self._get("/sicbl/{}/core_0/".format(c.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all practices had prescribed at the median ratio or better, then this CCG would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all practices had prescribed at the median ratio or better, then this SICBL would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1798,7 +1798,7 @@ class MeasuresTests(SeleniumTestCase):
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all CCGs had prescribed at the median ratio or better, then this STP would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all SICBLs had prescribed at the median ratio or better, then this STP would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1827,7 +1827,7 @@ class MeasuresTests(SeleniumTestCase):
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if all CCGs had prescribed at the median ratio or better, then this Regional Team would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if all SICBLs had prescribed at the median ratio or better, then this Regional Team would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)
@@ -1874,14 +1874,14 @@ class MeasuresTests(SeleniumTestCase):
             if cost_saving > 0:
                 break
         else:
-            assert False, "Could not find CCG with cost saving!"
+            assert False, "Could not find SICBL with cost saving!"
 
         self._get("/sicbl/{}/measures/".format(c.code))
         # Use `contains()` to ensure that loading has finished by the time we access the element
         perf_summary_element = self.find_by_xpath(
             '//*[@id="perfsummary"][not(contains(text(), "Loading..."))]'
         )
-        exp_text = "Over the past 6 months, if this CCG had prescribed at the median ratio or better on all cost-saving measures below, then it would have spent £{} less.".format(
+        exp_text = "Over the past 6 months, if this SICBL had prescribed at the median ratio or better on all cost-saving measures below, then it would have spent £{} less.".format(
             _humanize(cost_saving)
         )
         self.assertIn(exp_text, perf_summary_element.text)

--- a/openprescribing/frontend/tests/test_api_measures.py
+++ b/openprescribing/frontend/tests/test_api_measures.py
@@ -207,7 +207,7 @@ class TestAPIMeasureViews(ApiTestBase):
         )
 
     def test_api_measure_by_ccg(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q&measure=cerazette&format=json"
         data = self._get_json(url)
         self.assertEqual(len(data["measures"][0]["data"]), 1)
@@ -224,26 +224,26 @@ class TestAPIMeasureViews(ApiTestBase):
         self.assertEqual(d["org_name"], "NHS BASSETLAW CCG")
 
     def test_api_two_ccgs_one_measure(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q,02Q&measure=cerazette&format=json"
         data = self._get_json(url)
         self.assertEqual(len(data["measures"][0]["data"]), 1)
 
     def test_api_two_measures_one_ccg(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q&measure=cerazette,cerazette2&format=json"
         data = self._get_json(url)
         self.assertEqual(len(data["measures"][0]["data"]), 1)
 
     def test_api_two_measures_two_ccgs(self):
         # This is invalid and should return an error
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q,XYZ&measure=cerazette,cerazette2&format=json"
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 400)
 
     def test_api_measure_by_ccg_excludes_closed(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q&measure=cerazette&format=json"
         pct = PCT.objects.get(pk="02Q")
         pct.close_date = datetime.date(2001, 1, 1)
@@ -252,7 +252,7 @@ class TestAPIMeasureViews(ApiTestBase):
         self.assertFalse(data["measures"])
 
     def test_api_all_measures_by_ccg(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?org=02Q&format=json"
         data = self._get_json(url)
         self.assertEqual(len(data["measures"][0]["data"]), 1)
@@ -264,7 +264,7 @@ class TestAPIMeasureViews(ApiTestBase):
         self.assertEqual("%.4f" % d["calc_value"], "0.5734")
 
     def test_api_all_measures_by_ccg_csv(self):
-        url = "/measure_by_ccg/?org=02Q&format=csv"
+        url = "/measure_by_sicbl/?org=02Q&format=csv"
         rows = self._rows_from_api(url)
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["measure"], "cerazette")
@@ -367,7 +367,7 @@ class TestAPIMeasureViews(ApiTestBase):
         self.assertEqual(response.status_code, 400)
 
     def test_api_measure_by_all_ccgs_aggregated(self):
-        url = "/api/1.0/measure_by_ccg/"
+        url = "/api/1.0/measure_by_sicbl/"
         url += "?measure=cerazette&aggregate=true&format=json"
         data = self._get_json(url)
         self.assertEqual(len(data["measures"][0]["data"]), 1)

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -173,7 +173,7 @@ class TestSpending(ApiTestBase):
 class TestSpendingByCCG(ApiTestBase):
     def _get(self, params):
         params["format"] = "csv"
-        url = "/api/1.0/spending_by_ccg/"
+        url = "/api/1.0/spending_by_sicbl/"
         return self.client.get(url, params)
 
     def _get_rows(self, params):

--- a/openprescribing/frontend/tests/test_bookmark_utils.py
+++ b/openprescribing/frontend/tests/test_bookmark_utils.py
@@ -33,34 +33,34 @@ from matrixstore.tests.decorators import copy_fixtures_to_matrixstore
 class IntroTextTest(unittest.TestCase):
     def test_nothing(self):
         stats = _makeContext(possible_top_savings_total=9000.1)
-        msg = bookmark_utils.getIntroText(stats, "CCG")
-        self.assertIn("We've no new information about this CCG", msg)
+        msg = bookmark_utils.getIntroText(stats, "SICBL")
+        self.assertIn("We've no new information about this SICBL", msg)
 
     def test_worst(self):
         stats = _makeContext(worst=[None])
-        msg = bookmark_utils.getIntroText(stats, "CCG")
-        self.assertNotIn("We've no new information about this CCG", msg)
+        msg = bookmark_utils.getIntroText(stats, "SICBL")
+        self.assertNotIn("We've no new information about this SICBL", msg)
         self.assertIn(
             "We've found one prescribing measure where this "
-            "CCG could be <span class='worse'>doing better",
+            "SICBL could be <span class='worse'>doing better",
             msg,
         )
 
     def test_worst_plural(self):
         stats = _makeContext(worst=[None, None])
-        msg = bookmark_utils.getIntroText(stats, "CCG")
+        msg = bookmark_utils.getIntroText(stats, "SICBL")
         self.assertIn(
             "We've found two prescribing measures where this "
-            "CCG could be <span class='worse'>doing better",
+            "SICBL could be <span class='worse'>doing better",
             msg,
         )
 
     def test_decline_plural(self):
         stats = _makeContext(declines=[None, None])
-        msg = bookmark_utils.getIntroText(stats, "CCG")
+        msg = bookmark_utils.getIntroText(stats, "SICBL")
         self.assertIn(
             "We've found two prescribing measures where this "
-            "CCG is <span class='worse'>getting worse",
+            "SICBL is <span class='worse'>getting worse",
             msg,
         )
 
@@ -669,11 +669,11 @@ class TruncateSubjectTestCase(unittest.TestCase):
                 "input": (
                     "Items for Abacavir + Levocabastine + Levacetylmethadol "
                     "Hydrochloride + 5-Hydroxytryptophan vs Frovatriptan + "
-                    "Alverine Citrate + Boceprevir by All CCGs"
+                    "Alverine Citrate + Boceprevir by All SICBLs"
                 ),
                 "expected": (
-                    "Your monthly update about Items for Abacavir + Levocabastine + L..."
-                    "by All CCGs"
+                    "Your monthly update about Items for Abacavir + Levocabastine +..."
+                    "by All SICBLs"
                 ),
             },
             {
@@ -691,7 +691,7 @@ class TruncateSubjectTestCase(unittest.TestCase):
                     "Items for Zopiclone + Zolpidem Tartrate + Lorazepam + "
                     "Chlordiazepoxide Hydrochloride + Diazepam + Clonazepam + "
                     "Temazepam vs patients on list by HEATHCOT MEDICAL PRACTICE "
-                    "and other practices in CCG"
+                    "and other practices in SICBL"
                 ),
                 "expected": (
                     "Your monthly update about Items for Zopiclone + Zolpidem "

--- a/openprescribing/frontend/tests/test_legacy_url_redirection.py
+++ b/openprescribing/frontend/tests/test_legacy_url_redirection.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from frontend.models import PCT, STP
+
+
+class TestLegacyUrlRedirection(TestCase):
+    def test_ccg_to_sicbl(self):
+        PCT.objects.create(code="000")
+        rsp = self.client.get("/ccg/000/")
+        self.assertEqual(rsp.url, "/sicbl/000/")
+
+    def test_by_ccg_to_by_sicbl(self):
+        PCT.objects.create(code="000")
+        rsp = self.client.get("/api/1.0/spending_by_ccg?format=csv&org=000")
+        self.assertEqual(rsp.url, "/api/1.0/spending_by_sicbl?format=csv&org=000")
+
+    def test_stp_to_icb(self):
+        STP.objects.create(code="000")
+        rsp = self.client.get("/stp/000/")
+        self.assertEqual(rsp.url, "/icb/000/")
+
+    def test_by_stp_to_by_icb(self):
+        PCT.objects.create(code="000")
+        rsp = self.client.get("/api/1.0/spending_by_stp?format=csv&org=000")
+        self.assertEqual(rsp.url, "/api/1.0/spending_by_icb?format=csv&org=000")
+
+    def test_stp_with_ons_code_to_icb(self):
+        STP.objects.create(code="000", ons_code="E00000000")
+        rsp = self.client.get("/stp/E00000000/")
+        self.assertEqual(rsp.url, "/icb/000/")

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -97,8 +97,8 @@ class TestSpendingViews(TestCase):
         urls = [
             "/practice/{}/concessions/".format(self.practice.code),
             "/pcn/{}/concessions/".format(self.pcn.code),
-            "/ccg/{}/concessions/".format(self.ccg.code),
-            "/stp/{}/concessions/".format(self.stp.code),
+            "/sicbl/{}/concessions/".format(self.ccg.code),
+            "/icb/{}/concessions/".format(self.stp.code),
             "/regional-team/{}/concessions/".format(self.regional_team.code),
             "/national/england/concessions/",
         ]

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -37,7 +37,7 @@ class TestAlertViews(TestCase):
         if entity_id == "all_england":
             url = "/national/england/"
         elif len(entity_id) == 3:
-            url = "/ccg/%s/" % entity_id
+            url = "/sicbl/%s/" % entity_id
             form_data["pct_id"] = entity_id
         else:
             url = "/practice/%s/" % entity_id
@@ -75,7 +75,7 @@ class TestAlertViews(TestCase):
     def test_ccg_email_sent(self):
         email = "a@a.com"
         response = self._post_org_signup("03V", email=email)
-        self.assertRedirects(response, "/ccg/03V/measures/")
+        self.assertRedirects(response, "/sicbl/03V/measures/")
         self.assertContains(response, "alerts about prescribing in NHS Corby.")
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(email, mail.outbox[0].to)
@@ -185,13 +185,13 @@ class TestFrontendHomepageViews(TestCase):
         self.assertEqual(len(ccgs), 1)
 
     def test_call_stp_homepage(self):
-        response = self.client.get("/stp/E01/")
+        response = self.client.get("/icb/E01/")
         doc = pq(response.content)
         ccgs = doc(".ccg-list li")
         self.assertEqual(len(ccgs), 1)
 
     def test_call_view_ccg_homepage(self):
-        response = self.client.get("/ccg/02Q/")
+        response = self.client.get("/sicbl/02Q/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "entity_home_page.html")
         self.assertEqual(response.context["measure"].id, "cerazette")
@@ -237,12 +237,12 @@ class TestFrontendHomepageViews(TestCase):
         self.assertTemplateUsed(response, "closed_entity_home_page.html")
 
     def test_call_view_stp_homepage_no_prescribing(self):
-        response = self.client.get("/stp/E55/")
+        response = self.client.get("/icb/E55/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "closed_entity_home_page.html")
 
     def test_call_view_ccg_homepage_no_prescribing(self):
-        response = self.client.get("/ccg/03X/")
+        response = self.client.get("/sicbl/03X/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "closed_entity_home_page.html")
 
@@ -375,7 +375,7 @@ class TestFrontendViews(TestCase):
         )
 
     def test_call_view_ccg_all(self):
-        response = self.client.get("/ccg/")
+        response = self.client.get("/sicbl/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "all_ccgs.html")
         doc = pq(response.content)
@@ -385,12 +385,12 @@ class TestFrontendViews(TestCase):
         self.assertEqual(len(ccgs), 2)
 
     def test_ccg_homepage_redirects_with_tags_query(self):
-        response = self.client.get("/ccg/03V/?tags=lowpriority")
+        response = self.client.get("/sicbl/03V/?tags=lowpriority")
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response["Location"], "/ccg/03V/measures/?tags=lowpriority")
+        self.assertEqual(response["Location"], "/sicbl/03V/measures/?tags=lowpriority")
 
     def test_call_single_measure_for_ccg(self):
-        response = self.client.get("/measure/cerazette/ccg/03V/")
+        response = self.client.get("/measure/cerazette/sicbl/03V/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "measure_for_one_entity.html")
 
@@ -427,7 +427,7 @@ class TestFrontendViews(TestCase):
         self.assertTemplateUsed(response, "measure_for_one_entity.html")
 
     def test_call_view_measure_ccg(self):
-        response = self.client.get("/ccg/03V/measures/")
+        response = self.client.get("/sicbl/03V/measures/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "measures_for_one_entity.html")
         doc = pq(response.content)
@@ -455,7 +455,7 @@ class TestFrontendViews(TestCase):
         self.assertEqual(title.text(), "1/ST Andrews Medical Practice")
 
     def test_call_view_measure_practices_in_ccg(self):
-        response = self.client.get("/ccg/03V/cerazette/")
+        response = self.client.get("/sicbl/03V/cerazette/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "measure_for_children_in_entity.html")
         doc = pq(response.content)
@@ -578,17 +578,17 @@ class TestPPUViews(TestCase):
         self.assertEqual(response.context["entity"].code, "P87629")
 
     def test_ccg_price_per_unit(self):
-        response = self.client.get("/ccg/03V/price_per_unit/")
+        response = self.client.get("/sicbl/03V/price_per_unit/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["entity"].code, "03V")
         self.assertEqual(response.context["date"].strftime("%Y-%m-%d"), "2014-11-01")
 
     def test_ccg_price_per_unit_returns_400_on_invalid_date(self):
-        response = self.client.get("/ccg/03V/price_per_unit/", {"date": "not-a-date"})
+        response = self.client.get("/sicbl/03V/price_per_unit/", {"date": "not-a-date"})
         self.assertEqual(response.status_code, 400)
 
     def test_price_per_unit_histogram_with_ccg(self):
-        response = self.client.get("/ccg/03V/0202010F0AAAAAA/price_per_unit/")
+        response = self.client.get("/sicbl/03V/0202010F0AAAAAA/price_per_unit/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["highlight_name"], "NHS Corby")
         self.assertEqual(response.context["date"].strftime("%Y-%m-%d"), "2014-11-01")

--- a/openprescribing/frontend/tests/test_views.py
+++ b/openprescribing/frontend/tests/test_views.py
@@ -380,7 +380,7 @@ class TestFrontendViews(TestCase):
         self.assertTemplateUsed(response, "all_ccgs.html")
         doc = pq(response.content)
         title = doc("h1")
-        self.assertEqual(title.text(), "All CCGs")
+        self.assertEqual(title.text(), "All SICBLs")
         ccgs = doc("a.ccg")
         self.assertEqual(len(ccgs), 2)
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1549,12 +1549,12 @@ def _url_template(view_name):
     the browser.
 
     >>> _url_template("measure_for_one_ccg")
-    '/measure/{measure}/ccg/{entity_code}/'
+    '/measure/{measure}/sicbl/{entity_code}/'
     """
 
     resolver = get_resolver()
 
-    # For the example above, `pattern` is "measure/%(measure)s/ccg/%(entity_code)s/"
+    # For the example above, `pattern` is "measure/%(measure)s/sicbl/%(entity_code)s/"
     pattern = resolver.reverse_dict[view_name][0][0][0]
     return "/" + pattern.replace("%(", "{").replace(")s", "}")
 

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1731,6 +1731,6 @@ def _entity_type_human(entity_type):
         "practice": "practice",
         "pcn": "PCN",
         "ccg": "SICBL",
-        "stp": "STP",
+        "stp": "ICB",
         "regional_team": "Regional Team",
     }[entity_type]

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1730,7 +1730,7 @@ def _entity_type_human(entity_type):
     return {
         "practice": "practice",
         "pcn": "PCN",
-        "ccg": "CCG",
+        "ccg": "SICBL",
         "stp": "STP",
         "regional_team": "Regional Team",
     }[entity_type]

--- a/openprescribing/media/js/src/analyse-chart.js
+++ b/openprescribing/media/js/src/analyse-chart.js
@@ -190,9 +190,9 @@ var analyseChart = {
       if (this.globalOptions.org === 'practice') {
         if (numOrgs) {
           var isPractice = (this.globalOptions.orgIds[0].id.length > 3);
-          summaryTab = (isPractice) ? 'Show vs others in CCG' : 'Show summary';
+          summaryTab = (isPractice) ? 'Show vs others in SICBL' : 'Show summary';
         } else {
-          summaryTab = 'Show for all CCGs';
+          summaryTab = 'Show for all SICBLs';
         }
       } else {
         var orgTypeName = formatters.getFriendlyOrgType(this.globalOptions.org);

--- a/openprescribing/media/js/src/analyse-form.js
+++ b/openprescribing/media/js/src/analyse-form.js
@@ -103,7 +103,7 @@ var queryForm = {
     if (this.globalOptions.org !== 'all') {
       $(this.el.orgIds).parent().fadeIn();
       if (this.globalOptions.org === 'practice') {
-        $(this.el.orgHelp).text('Hint: add a CCG to see all its practices');
+        $(this.el.orgHelp).text('Hint: add a SICBL to see all its practices');
         $(this.el.orgHelp).fadeIn();
       } else if (this.globalOptions.org === 'CCG') {
         $(this.el.orgHelp).text('Hint: leave blank to see national totals');

--- a/openprescribing/media/js/src/chart_formatters.js
+++ b/openprescribing/media/js/src/chart_formatters.js
@@ -15,8 +15,8 @@ var ORG_TYPES = {
     'title': 'PCN'
   },
   'stp': {
-    'name': 'STP',
-    'title': 'STP'
+    'name': 'ICB',
+    'title': 'ICB'
   },
   'regional_team': {
     'name': 'regional team',

--- a/openprescribing/media/js/src/chart_formatters.js
+++ b/openprescribing/media/js/src/chart_formatters.js
@@ -7,8 +7,8 @@ var ORG_TYPES = {
     'title': 'Practice'
   },
   'ccg': {
-    'name': 'CCG',
-    'title': 'CCG'
+    'name': 'SICBL',
+    'title': 'SICBL'
   },
   'pcn': {
     'name': 'PCN',
@@ -65,7 +65,7 @@ var formatters = {
       if (org === 'practice' && orgIds.length > 0) {
         str = this._getStringForIds(orgIds, true);
         if (_.any(_.map(orgIds, function(d) { return d.id.length > 3; }))) {
-          str += ' <br/>and other practices in CCG';
+          str += ' <br/>and other practices in SICBL';
         }
       } else {
         if (orgIds.length > 0) {

--- a/openprescribing/media/js/src/measure_utils.js
+++ b/openprescribing/media/js/src/measure_utils.js
@@ -427,7 +427,7 @@ var utils = {
     return {
       orgType: options.orgType,
       orgTypeHuman: options.orgTypeHuman,
-      comparisonOrgTypeHuman: options.orgType == 'practice' ? 'CCG' : options.orgTypeHuman,
+      comparisonOrgTypeHuman: options.orgType == 'practice' ? 'SICBL' : options.orgTypeHuman,
       measureUrl: measureUrl,
       measureDefinitionUrl: measureDefinitionUrl,
       isAggregateEntity: isAggregateEntity,

--- a/openprescribing/media/js/test/test_formatters.js
+++ b/openprescribing/media/js/test/test_formatters.js
@@ -36,13 +36,13 @@ describe('Formatters', function () {
             var str = formatters.getFriendlyOrgs('all', []);
             expect(str).to.equal('all practices in NHS England');
             str = formatters.getFriendlyOrgs('CCG', []);
-            expect(str).to.equal('all CCGs');
+            expect(str).to.equal('all SICBLs');
             str = formatters.getFriendlyOrgs('practice', []);
             expect(str).to.equal('all practices');
             str = formatters.getFriendlyOrgs('practice', [{'id': '03V'}, {'id': '11A'}]);
             expect(str).to.equal('practices in 03V + practices in 11A');
             str = formatters.getFriendlyOrgs('practice', [{'id': 'P12353'}]);
-            expect(str).to.equal('P12353 <br/>and other practices in CCG');
+            expect(str).to.equal('P12353 <br/>and other practices in SICBL');
         });
     });
 

--- a/openprescribing/media/js/test/test_measures.js
+++ b/openprescribing/media/js/test/test_measures.js
@@ -547,7 +547,7 @@ describe('Measures', function() {
       options = {
         orgId: '99P',
         orgType: 'ccg',
-        orgTypeHuman: 'CCG',
+        orgTypeHuman: 'SICBL',
         rollUpBy: 'org_id',
         globalYMax: { y: 50},
         globalYMin: { y: 0}
@@ -555,7 +555,7 @@ describe('Measures', function() {
       chartOptions = { dashOptions: { chart: {}, legend: {}}};
       var result = mu.getGraphOptions(d, options, true, chartOptions);
       expect(result.series.length).to.equal(4);
-      expect(result.series[0].name).to.equal('This CCG');
+      expect(result.series[0].name).to.equal('This SICBL');
       expect(result.series[2].name).to.equal('50th percentile nationally');
       expect(result.series[2].isNationalSeries).to.equal(true);
       expect(result.series[2].dashStyle).to.equal('longdash');

--- a/openprescribing/media/js/test/test_utils.js
+++ b/openprescribing/media/js/test/test_utils.js
@@ -388,7 +388,7 @@ describe('Utils', function () {
                              "2010-08-01", "2010-09-01", "2010-10-01", "2010-11-01",
                              "2010-12-01", "2011-01-01", "2011-02-01"]);
     });
-    it('should start in Aug 2013 for CCGs', function () {
+    it('should start in Aug 2013 for SICBLs', function () {
       var options = {
         org: 'CCG',
         data: {

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -107,15 +107,15 @@ urlpatterns = [
     path(r"pcn/", views.all_pcns, name="all_pcns"),
     path(r"pcn/<pcn_code>/", views.pcn_home_page, name="pcn_home_page"),
     # CCGs
-    path(r"ccg/", views.all_ccgs, name="all_ccgs"),
+    path(r"sicbl/", views.all_ccgs, name="all_ccgs"),
     path(
-        r"ccg/<ccg_code>/",
+        r"sicbl/<ccg_code>/",
         redirect_if_tags_query(views.ccg_home_page),
         name="ccg_home_page",
     ),
     # STPs
-    path(r"stp/", views.all_stps, name="all_stps"),
-    path(r"stp/<stp_code>/", views.stp_home_page, name="stp_home_page"),
+    path(r"icb/", views.all_stps, name="all_stps"),
+    path(r"icb/<stp_code>/", views.stp_home_page, name="stp_home_page"),
     # Regional teams
     path(r"regional-team/", views.all_regional_teams, name="all_regional_teams"),
     path(
@@ -142,7 +142,7 @@ urlpatterns = [
         name="practice_price_per_unit",
     ),
     path(
-        r"ccg/<code>/price_per_unit/",
+        r"sicbl/<code>/price_per_unit/",
         views.ccg_price_per_unit,
         name="ccg_price_per_unit",
     ),
@@ -158,7 +158,7 @@ urlpatterns = [
         name="price_per_unit_by_presentation_practice",
     ),
     path(
-        r"ccg/<entity_code>/<bnf_code>/price_per_unit/",
+        r"sicbl/<entity_code>/<bnf_code>/price_per_unit/",
         views.price_per_unit_by_presentation,
         name="price_per_unit_by_presentation",
     ),
@@ -176,7 +176,7 @@ urlpatterns = [
         kwargs={"entity_type": "practice"},
     ),
     path(
-        r"ccg/<code>/ghost_generics/",
+        r"sicbl/<code>/ghost_generics/",
         views.ghost_generics_for_entity,
         name="ccg_ghost_generics",
         kwargs={"entity_type": "CCG"},
@@ -197,13 +197,13 @@ urlpatterns = [
         kwargs={"entity_type": "pcn"},
     ),
     path(
-        r"ccg/<entity_code>/concessions/",
+        r"sicbl/<entity_code>/concessions/",
         views.spending_for_one_entity,
         name="spending_for_one_ccg",
         kwargs={"entity_type": "CCG"},
     ),
     path(
-        r"stp/<entity_code>/concessions/",
+        r"icb/<entity_code>/concessions/",
         views.spending_for_one_entity,
         name="spending_for_one_stp",
         kwargs={"entity_type": "stp"},
@@ -236,13 +236,13 @@ urlpatterns = [
         kwargs={"entity_type": "pcn"},
     ),
     path(
-        r"measure/<measure>/ccg/<entity_code>/",
+        r"measure/<measure>/sicbl/<entity_code>/",
         views.measure_for_one_entity,
         name="measure_for_one_ccg",
         kwargs={"entity_type": "ccg"},
     ),
     path(
-        r"measure/<measure>/stp/<entity_code>/",
+        r"measure/<measure>/icb/<entity_code>/",
         views.measure_for_one_entity,
         name="measure_for_one_stp",
         kwargs={"entity_type": "stp"},
@@ -270,12 +270,12 @@ urlpatterns = [
         name="measures_for_one_pcn",
     ),
     path(
-        r"ccg/<ccg_code>/measures/",
+        r"sicbl/<ccg_code>/measures/",
         views.measures_for_one_ccg,
         name="measures_for_one_ccg",
     ),
     path(
-        r"stp/<stp_code>/measures/",
+        r"icb/<stp_code>/measures/",
         views.measures_for_one_stp,
         name="measures_for_one_stp",
     ),
@@ -290,12 +290,12 @@ urlpatterns = [
         name="measure_for_practices_in_pcn",
     ),
     path(
-        r"ccg/<ccg_code>/<measure>/",
+        r"sicbl/<ccg_code>/<measure>/",
         views.measure_for_practices_in_ccg,
         name="measure_for_practices_in_ccg",
     ),
     path(
-        r"stp/<stp_code>/<measure>/",
+        r"icb/<stp_code>/<measure>/",
         views.measure_for_ccgs_in_stp,
         name="measure_for_ccgs_in_stp",
     ),
@@ -322,7 +322,7 @@ urlpatterns = [
         kwargs={"entity_type": "pcn"},
     ),
     path(
-        r"measure/<measure>/stp/",
+        r"measure/<measure>/icb/",
         views.measure_for_all_entities,
         name="measure_for_all_stps",
         kwargs={"entity_type": "stp"},

--- a/openprescribing/pipeline/management/commands/handle_orphan_practices.py
+++ b/openprescribing/pipeline/management/commands/handle_orphan_practices.py
@@ -110,7 +110,7 @@ class Command(BaseCommand):
 
             if self.dry_run:
                 self.stdout.write("-" * 80)
-                self.stdout.write("CCG: {} ({})".format(ccg, name))
+                self.stdout.write("SICBL: {} ({})".format(ccg, name))
                 self.stdout.write(
                     "Previous practice count: {}".format(len(prev_practices))
                 )
@@ -142,9 +142,9 @@ class Command(BaseCommand):
         new_ccg_name = self.ccg_to_name[new_ccg]
 
         if self.dry_run:
-            self.stdout.write("All practices currently in CCG are closed or dormant")
+            self.stdout.write("All practices currently in SICBL are closed or dormant")
             self.stdout.write(
-                "All active practices previously in CCG are now in {} ({})".format(
+                "All active practices previously in SICBL are now in {} ({})".format(
                     new_ccg, new_ccg_name
                 )
             )
@@ -155,7 +155,7 @@ class Command(BaseCommand):
             )
         else:
             practices = Practice.objects.filter(ccg_id=ccg).exclude(status_code="A")
-            reason = "CCG set by handle_orphan_practices"
+            reason = "SICBL set by handle_orphan_practices"
             practices.update(ccg_id=new_ccg, ccg_change_reason=reason)
 
     def handle_case_b(self, ccg, new_ccgs):
@@ -163,9 +163,9 @@ class Command(BaseCommand):
         name = self.ccg_to_name[ccg]
 
         if self.dry_run:
-            self.stdout.write("All practices currently in CCG are closed or dormant")
+            self.stdout.write("All practices currently in SICBL are closed or dormant")
             self.stdout.write(
-                "Active practices previously in CCG are now in multiple CCGs:"
+                "Active practices previously in SICBL are now in multiple SICBLs:"
             )
             for new_ccg, count in new_ccgs.most_common():
                 new_ccg_name = self.ccg_to_name[new_ccg]
@@ -173,8 +173,8 @@ class Command(BaseCommand):
 
         else:
             msg = """
-All active practices previously in CCG {} ({}) are now in multiple CCGs:
-Check whether inactive practices remaining in CCG should have moved.
+All active practices previously in SICBL {} ({}) are now in multiple SICBLs:
+Check whether inactive practices remaining in SICBL should have moved.
 See instructions in handle_orphan_practices.py.
             """.format(
                 ccg, name
@@ -190,11 +190,11 @@ See instructions in handle_orphan_practices.py.
 
         if self.dry_run:
             self.stdout.write(
-                "Some practices have left CCG and some currently in CCG are not active"
+                "Some practices have left SICBL and some currently in SICBL are not active"
             )
         else:
             msg = """
-Practices have left CCG {} ({}) and some remaining practices are not active.
+Practices have left SICBL {} ({}) and some remaining practices are not active.
 Check whether these inactive practices should have moved.
 See instructions in handle_orphan_practices.py.
             """.format(

--- a/openprescribing/pipeline/management/commands/outlier_reports.py
+++ b/openprescribing/pipeline/management/commands/outlier_reports.py
@@ -81,7 +81,19 @@ class MakeHtml:
     }
 
     REPORT_DATE_FORMAT = "%B %Y"
-    ALLCAPS = ["NHS", "PCN", "CCG", "SICBL", "BNF", "std", "STP", "(STP)", "NHS"]
+    ALLCAPS = [
+        "NHS",
+        "PCN",
+        "CCG",
+        "SICBL",
+        "BNF",
+        "std",
+        "STP",
+        "(STP)",
+        "ICB",
+        "(ICB)",
+        "NHS",
+    ]
     LOW_NUMBER_CLASS = "low_number"
 
     @staticmethod

--- a/openprescribing/pipeline/management/commands/outlier_reports.py
+++ b/openprescribing/pipeline/management/commands/outlier_reports.py
@@ -81,7 +81,7 @@ class MakeHtml:
     }
 
     REPORT_DATE_FORMAT = "%B %Y"
-    ALLCAPS = ["NHS", "PCN", "CCG", "BNF", "std", "STP", "(STP)", "NHS"]
+    ALLCAPS = ["NHS", "PCN", "CCG", "SICBL", "BNF", "std", "STP", "(STP)", "NHS"]
     LOW_NUMBER_CLASS = "low_number"
 
     @staticmethod

--- a/openprescribing/pipeline/tests/test_handle_orphan_practices.py
+++ b/openprescribing/pipeline/tests/test_handle_orphan_practices.py
@@ -62,13 +62,13 @@ class CommandTests(TestCase):
             practice.refresh_from_db()
             self.assertEqual(practice.ccg_id, "C06")
             self.assertEqual(
-                practice.ccg_change_reason, "CCG set by handle_orphan_practices"
+                practice.ccg_change_reason, "SICBL set by handle_orphan_practices"
             )
 
         self.assertEqual(notify_slack.call_count, 2)
         msgs = [c[0][0] for c in notify_slack.call_args_list]
-        self.assertIn("Practices have left CCG C01", msgs[0])
-        self.assertIn("All active practices previously in CCG C04", msgs[1])
+        self.assertIn("Practices have left SICBL C01", msgs[0])
+        self.assertIn("All active practices previously in SICBL C04", msgs[1])
 
     @mock.patch("pipeline.management.commands.handle_orphan_practices.notify_slack")
     def test_dry_run(self, notify_slack):

--- a/openprescribing/templates/_ccg_list.html
+++ b/openprescribing/templates/_ccg_list.html
@@ -1,6 +1,6 @@
 <div class="child-entity-list ccg-list">
   <p>
-    There are {{ ccgs|length }} CCGs in this {{ entity_type_human }}.
+    There are {{ ccgs|length }} SICBLs in this {{ entity_type_human }}.
     <a class="showall" href="#">&raquo; show them...</a>
   </p>
 

--- a/openprescribing/templates/_entity_heading.html
+++ b/openprescribing/templates/_entity_heading.html
@@ -11,7 +11,7 @@
 
     <p>Address: {{ entity.address_pretty }}</p>
     {% if entity.ccg %}
-      <p>Part of CCG:
+      <p>Part of SICBL:
         <a href="{% url 'ccg_home_page' entity.ccg.code %}">{{ entity.ccg.name }}</a>
       </p>
     {% endif %}

--- a/openprescribing/templates/_mailchimp_signup.html
+++ b/openprescribing/templates/_mailchimp_signup.html
@@ -55,4 +55,4 @@
 
 <br />
 
-<p>You can also sign up for personalised prescribing alerts from individual <a href="{% url 'all_ccgs' %}">CCG</a> or <a href="{% url 'all_practices' %}">practice</a> pages.</p>
+<p>You can also sign up for personalised prescribing alerts from individual <a href="{% url 'all_ccgs' %}">SICBL</a> or <a href="{% url 'all_practices' %}">practice</a> pages.</p>

--- a/openprescribing/templates/_measure_header.html
+++ b/openprescribing/templates/_measure_header.html
@@ -24,11 +24,11 @@
     {% endif %}
 
     {% if entity_type != 'ccg' %}
-      <li><a href="{% url 'measure_for_all_ccgs' measure.id %}">Compare all CCGs in England on this measure</a>.</li>
+      <li><a href="{% url 'measure_for_all_ccgs' measure.id %}">Compare all SICBLs in England on this measure</a>.</li>
     {% endif %}
 
     {% if ccg %}
-      <li>See <a href="{% url 'measures_for_one_ccg' ccg.code %}">how this CCG is doing on other standard measures</a>.</li>
+      <li>See <a href="{% url 'measures_for_one_ccg' ccg.code %}">how this SICBL is doing on other standard measures</a>.</li>
     {% endif %}
 
     {% if measure.analyse_url %}

--- a/openprescribing/templates/_measures_panel.html
+++ b/openprescribing/templates/_measures_panel.html
@@ -88,10 +88,10 @@
                   <li><a href="{{ measureForAllPracticesUrl }}">Split the measure into charts for individual practices</a></li>
                 {{/if}}
                 {{#if measureForAllCCGsUrl }}
-                  <li><a href="{{ measureForAllCCGsUrl }}">Split the measure into charts for individual CCGs</a></li>
+                  <li><a href="{{ measureForAllCCGsUrl }}">Split the measure into charts for individual SICBLs</a></li>
                 {{/if}}
                 {{#if measureForSiblingsUrl }}
-                  <li><a href="{{ measureForSiblingsUrl }}">Compare all practices in this CCG on this measure</a></li>
+                  <li><a href="{{ measureForSiblingsUrl }}">Compare all practices in this SICBL on this measure</a></li>
                 {{/if}}
                 {{#if measureUrl }}
                   <li><a href="{{ measureUrl }}">Compare all {{ comparisonOrgTypeHuman }}s in England on this measure</a></li>

--- a/openprescribing/templates/_ppu_data_table.html
+++ b/openprescribing/templates/_ppu_data_table.html
@@ -4,7 +4,7 @@
     <tr>
       <th>
         {% if by_presentation %}
-          {% if entity_type == 'CCG' %} CCG {% else %} Practice {% endif %}
+          {% if entity_type == 'CCG' %} SICBL {% else %} Practice {% endif %}
         {% else %}
           Presentation
         {% endif %}
@@ -16,7 +16,7 @@
         PPU <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Price per Unit" data-content="Mean price-per-unit achieved by {{ entity.cased_name}}"><span class="glyphicon glyphicon-question-sign"></span></a>
       </th>
       <th>
-        Target PPU <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Target price-per-unit" data-content="The price-per-unit achieved by the {% if entity.ccg %}practice{% else %}CCG{% endif %} at the best-value decile across the entire country"><span class="glyphicon glyphicon-question-sign"></span></a>
+        Target PPU <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Target price-per-unit" data-content="The price-per-unit achieved by the {% if entity.ccg %}practice{% else %}SICBL{% endif %} at the best-value decile across the entire country"><span class="glyphicon glyphicon-question-sign"></span></a>
       </th>
       <th>
         Quantity <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Quantity" data-content="Quantity of units prescribed in the month"><span class="glyphicon glyphicon-question-sign"></span></a>

--- a/openprescribing/templates/about.html
+++ b/openprescribing/templates/about.html
@@ -46,9 +46,9 @@ cross-platform testing.</p>
 
 <p><strong>BNF codes and names</strong> are also from the <a href="https://apps.nhsbsa.nhs.uk/infosystems/welcome">NHS Business Service Authority's Information Portal</a>, used under the terms of the Open Government Licence.</p>
 
-<p><strong>CCG to practice relations</strong>, and practice prescribing settings, are from <a href="https://digital.nhs.uk/organisation-data-service/data-downloads">NHS Digital's data downloads</a> (epraccur.csv), used under the terms of the Open Government Licence.</p>
+<p><strong>SICBL to practice relations</strong>, and practice prescribing settings, are from <a href="https://digital.nhs.uk/organisation-data-service/data-downloads">NHS Digital's data downloads</a> (epraccur.csv), used under the terms of the Open Government Licence.</p>
 
-<p><strong>CCG names and codes</strong> and CCG geographic boundaries are from the <a href="https://geoportal.statistics.gov.uk/geoportal/catalog/main/home.page">Office for National Statistics</a>, used under the terms of the Open Government Licence.</p>
+<p><strong>SICBL names and codes</strong> and SICBL geographic boundaries are from the <a href="https://geoportal.statistics.gov.uk/geoportal/catalog/main/home.page">Office for National Statistics</a>, used under the terms of the Open Government Licence.</p>
 
 <p><strong>Practice locations</strong> are based on <a href="https://digital.nhs.uk/organisation-data-service/data-downloads/national-statistics">data from NHS Digital/ONS</a>. Contains OS data © Crown copyright and database right 2016, Royal Mail data © Royal Mail copyright and database right 2016, National Statistics data © Crown copyright and database right 2016.</p>
 

--- a/openprescribing/templates/alert_example.html
+++ b/openprescribing/templates/alert_example.html
@@ -10,7 +10,7 @@
 <h1>Example monthly alert email</h1>
 <p>Each month, when the latest prescribing data is released (i.e. with
 a lag of 6 - 8 weeks), we will send you a customised email
-highlighting measures where the specified CCG or practice is an
+highlighting measures where the specified SICBL or practice is an
 outlier.  They look something like this:
 </p>
 

--- a/openprescribing/templates/all_ccgs.html
+++ b/openprescribing/templates/all_ccgs.html
@@ -8,7 +8,7 @@
 
 <h1>All SICBLs</h1>
 
-<p>Clinical commissioning groups (SICBLs) are NHS organisations that organise the delivery of NHS services in England. They are clinically led groups that include all of the GP groups in their geographical area.</p>
+<p>Sub-ICB Locations (SICBLs) are NHS organisations that organise the delivery of NHS services in England. They are clinically led groups that include all of the GP groups in their geographical area.</p>
 
 <p>Search for a SICBL by name or code, and see how this SICBL's GP prescribing compares with its peers across the NHS in England</p>
 

--- a/openprescribing/templates/all_ccgs.html
+++ b/openprescribing/templates/all_ccgs.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 {% load template_extras %}
 
-{% block title %}All CCGs{% endblock %}
+{% block title %}All SICBLs{% endblock %}
 {% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 
-<h1>All CCGs</h1>
+<h1>All SICBLs</h1>
 
-<p>Clinical commissioning groups (CCGs) are NHS organisations that organise the delivery of NHS services in England. They are clinically led groups that include all of the GP groups in their geographical area.</p>
+<p>Clinical commissioning groups (SICBLs) are NHS organisations that organise the delivery of NHS services in England. They are clinically led groups that include all of the GP groups in their geographical area.</p>
 
-<p>Search for a CCG by name or code, and see how this CCG's GP prescribing compares with its peers across the NHS in England</p>
+<p>Search for a SICBL by name or code, and see how this SICBL's GP prescribing compares with its peers across the NHS in England</p>
 
 <input class="form-control" id="search" placeholder="Search by name or code, e.g. Birmingham" />
 

--- a/openprescribing/templates/all_measures.html
+++ b/openprescribing/templates/all_measures.html
@@ -37,7 +37,7 @@
   </div>
 </form>
 
-<p>See prescribing by all CCGs for:</p>
+<p>See prescribing by all SICBLs for:</p>
 
 <ul>
 {% for measure in measures %}

--- a/openprescribing/templates/all_pcns.html
+++ b/openprescribing/templates/all_pcns.html
@@ -23,7 +23,7 @@
 
   <p>
     PCNs were formed in June 2019. We would love to be able to show you a list
-    of PCN dashboards here, just like we do for all practices, SICBLs, STPs and
+    of PCN dashboards here, just like we do for all practices, SICBLs, ICBs and
     Regional Teams. We have all the necessary <a
       href="https://github.com/ebmdatalab/openprescribing/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+created%3A%3C2019-07-18+in%3Atitle+PCN+">code</a>
     and infrastructure for this built already. Sadly, however, the NHS does not

--- a/openprescribing/templates/all_pcns.html
+++ b/openprescribing/templates/all_pcns.html
@@ -23,7 +23,7 @@
 
   <p>
     PCNs were formed in June 2019. We would love to be able to show you a list
-    of PCN dashboards here, just like we do for all practices, CCGs, STPs and
+    of PCN dashboards here, just like we do for all practices, SICBLs, STPs and
     Regional Teams. We have all the necessary <a
       href="https://github.com/ebmdatalab/openprescribing/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+created%3A%3C2019-07-18+in%3Atitle+PCN+">code</a>
     and infrastructure for this built already. Sadly, however, the NHS does not

--- a/openprescribing/templates/all_stps.html
+++ b/openprescribing/templates/all_stps.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% load template_extras %}
 
-{% block title %}All STPs{% endblock %}
+{% block title %}All ICBs{% endblock %}
 {% block active_class %}dashboards{% endblock %}
 
 {% block content %}
 
-<h1>All STPs</h1>
+<h1>All ICBs</h1>
 
 <ul class="list-unstyled" id="all-results">
 {% for stp in stps %}

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -16,7 +16,7 @@
 
 <h1>Search GP prescribing data</h1>
 
-<p>Search 700 million rows of prescribing data, and get prescribing information by practice, PCN, SICBL, STP or regional team. You can search for any numerator over any denominator.</p>
+<p>Search 700 million rows of prescribing data, and get prescribing information by practice, PCN, SICBL, ICB or regional team. You can search for any numerator over any denominator.</p>
 
 <p>Unsure how to create your own searches? <a target="_blank" href="{% url 'analyse' %}#numIds=0212000AA&denomIds=2.12">Try an example</a>, <a target="_blank" href="http://openprescribing.net/docs/analyse">read more</a> about how to use this tool, check our <a target="_blank" href="{% url 'faq' %}">FAQs</a> and read our <a href='https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/'> what is a BNF code blog</a>.</p>
 
@@ -84,7 +84,7 @@
                 <option value="practice">a practice or practices</option>
                 <option value="CCG">a CCG or SICBLs</option>
                 {% if pcns_enabled %}<option value="pcn">a PCN or PCNs</option>{% endif %}
-                <option value="stp">an STP or STPs</option>
+                <option value="stp">an ICB or ICBs</option>
                 <option value="regional_team">an NHS England Region</option>
             </select>
         </div>

--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -16,7 +16,7 @@
 
 <h1>Search GP prescribing data</h1>
 
-<p>Search 700 million rows of prescribing data, and get prescribing information by practice, PCN, CCG, STP or regional team. You can search for any numerator over any denominator.</p>
+<p>Search 700 million rows of prescribing data, and get prescribing information by practice, PCN, SICBL, STP or regional team. You can search for any numerator over any denominator.</p>
 
 <p>Unsure how to create your own searches? <a target="_blank" href="{% url 'analyse' %}#numIds=0212000AA&denomIds=2.12">Try an example</a>, <a target="_blank" href="http://openprescribing.net/docs/analyse">read more</a> about how to use this tool, check our <a target="_blank" href="{% url 'faq' %}">FAQs</a> and read our <a href='https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/'> what is a BNF code blog</a>.</p>
 
@@ -82,7 +82,7 @@
             <select style="width: 100%" id="org" class="form-select not-searchable">
                 <!-- <option value="all" selected>everyone</option> -->
                 <option value="practice">a practice or practices</option>
-                <option value="CCG">a CCG or CCGs</option>
+                <option value="CCG">a CCG or SICBLs</option>
                 {% if pcns_enabled %}<option value="pcn">a PCN or PCNs</option>{% endif %}
                 <option value="stp">an STP or STPs</option>
                 <option value="regional_team">an NHS England Region</option>

--- a/openprescribing/templates/api.html
+++ b/openprescribing/templates/api.html
@@ -22,7 +22,7 @@
 
 <p>Methods to calculate prescribing spending.</p>
 
-<p>Retrieve total spending and items by CCG or practice on a particular chemical, presentation or BNF section. (Spending is calculated using the <strong>actual_cost</strong> field in the HSCIC data, items using the <strong>total_items</strong> field.)</p>
+<p>Retrieve total spending and items by SICBL or practice on a particular chemical, presentation or BNF section. (Spending is calculated using the <strong>actual_cost</strong> field in the HSCIC data, items using the <strong>total_items</strong> field.)</p>
 
 
 
@@ -34,13 +34,13 @@
 
 <p>Total by BNF code by month: <code><a href="/api/1.0/spending/?code=0212">/api/1.0/spending/?code=0212</a></code>, <code><a href="/api/1.0/spending/?code=0212000AA">/api/1.0/spending/?code=0212000AA</a></code>, <code><a href="/api/1.0/spending/?code=0212000AAAAABAB">/api/1.0/spending/?code=0212000AAAAABAB</a></code></p>
 
-<h3>Spending by CCG</h3>
+<h3>Spending by SICBL</h3>
 
-<p>Queries the last five years of data and returns spending and items by CCG by month.</p>
+<p>Queries the last five years of data and returns spending and items by SICBL by month.</p>
 
-<p>Spending by CCG on a chemical: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA">/api/1.0/spending_by_sicbl/?code=0212000AA</a></code></p>
+<p>Spending by SICBL on a chemical: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA">/api/1.0/spending_by_sicbl/?code=0212000AA</a></code></p>
 
-<p>You can request individual CCGs by code: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V">/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V</a></code></p>
+<p>You can request individual SICBLs by code: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V">/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V</a></code></p>
 
 <h3>Spending by practice</h3>
 
@@ -56,13 +56,13 @@
 
 <p>You can request individual practices by code: <code><a href="/api/1.0/spending_by_practice/?code=0212000AA&org=H81068">/api/1.0/spending_by_practice/?code=0212000AA&org=H81068</a></code></p>
 
-<p>You can also request a CCG code to see spending by all <em>practices in that CCG</em>: <code><a href="/api/1.0/spending_by_practice/?code=0212000AA&org=99P">/api/1.0/spending_by_practice/?code=0212000AA&org=99P</a></code></p>
+<p>You can also request a SICBL code to see spending by all <em>practices in that SICBL</em>: <code><a href="/api/1.0/spending_by_practice/?code=0212000AA&org=99P">/api/1.0/spending_by_practice/?code=0212000AA&org=99P</a></code></p>
 
 <hr/>
 
 <h2>Information API</h2>
 
-<p>Methods to retrieve information about CCGs, practices, and BNF codes.</p>
+<p>Methods to retrieve information about SICBLs, practices, and BNF codes.</p>
 
 <h3>Drug details</h3>
 
@@ -78,35 +78,35 @@
 
 <h3>Organisation codes</h3>
 
-<p>Search for details about a CCG or practice by code or name.</p>
+<p>Search for details about a SICBL or practice by code or name.</p>
 
 <p>All organisations matching a code or name: <code><a href="/api/1.0/org_code/?q=Beaumont">/api/1.0/org_code/?q=Beaumont</a></code></p>
 
-<p>All CCGs matching a code or name: <code><a href="/api/1.0/org_code/?q=Gloucester&org_type=CCG">/api/1.0/org_code/?q=Gloucester&org_type=CCG</a></code></p>
+<p>All SICBLs matching a code or name: <code><a href="/api/1.0/org_code/?q=Gloucester&org_type=CCG">/api/1.0/org_code/?q=Gloucester&org_type=CCG</a></code></p>
 
 <p>All practices matching a code or name: <code><a href="/api/1.0/org_code/?q=Gloucester&org_type=practice">/api/1.0/org_code?q=Gloucester&org_type=practice</a></code></p>
 
 <p>All organisations exactly matching a code or name: <code><a href="/api/1.0/org_code/?exact=true&q=99H">/api/1.0/org_code/?exact=true&q=99H</a></code></p>
 
-<h3>List size and ASTRO-PUs by CCG or practice</h3>
+<h3>List size and ASTRO-PUs by SICBL or practice</h3>
 
-<p>Search for details about a CCG or practice by code or name. Returns values for all months available.</p>
+<p>Search for details about a SICBL or practice by code or name. Returns values for all months available.</p>
 
-<p>Total list size for all CCGs: <code><a href="/api/1.0/org_details/?org_type=ccg&keys=total_list_size">/api/1.0/org_details/?org_type=ccg&keys=total_list_size</a></code></p>
+<p>Total list size for all SICBLs: <code><a href="/api/1.0/org_details/?org_type=ccg&keys=total_list_size">/api/1.0/org_details/?org_type=ccg&keys=total_list_size</a></code></p>
 
-<p>Total list size for all practices by practice code, or CCG code: <code><a href="/api/1.0/org_details/?org_type=practice&org=99H&keys=total_list_size">/api/1.0/org_details/?org_type=practice&org=99H&keys=total_list_size</a></code></p>
+<p>Total list size for all practices by practice code, or SICBL code: <code><a href="/api/1.0/org_details/?org_type=practice&org=99H&keys=total_list_size">/api/1.0/org_details/?org_type=practice&org=99H&keys=total_list_size</a></code></p>
 
-<p>ASTRO-PU cost and items for practices by practice code, or CCG code: <code><a href="/api/1.0/org_details/?org_type=practice&org=99H&keys=astro_pu_items,astro_pu_cost">/api/1.0/org_details/?org_type=practice&org=99H&keys=astro_pu_items,astro_pu_cost</a></code></p>
+<p>ASTRO-PU cost and items for practices by practice code, or SICBL code: <code><a href="/api/1.0/org_details/?org_type=practice&org=99H&keys=astro_pu_items,astro_pu_cost">/api/1.0/org_details/?org_type=practice&org=99H&keys=astro_pu_items,astro_pu_cost</a></code></p>
 
 
-<h3>CCG boundaries</h3>
+<h3>SICBL boundaries</h3>
 
-<p>Search for the boundaries of a CCG, or location of a practice, by code. Returns GeoJSON.</p>
+<p>Search for the boundaries of a SICBL, or location of a practice, by code. Returns GeoJSON.</p>
 
-<p>Boundaries of all CCGs: <code><a href="/api/1.0/org_location/?org_type=ccg">/api/1.0/org_location/?org_type=ccg</a></code></p>
+<p>Boundaries of all SICBLs: <code><a href="/api/1.0/org_location/?org_type=ccg">/api/1.0/org_location/?org_type=ccg</a></code></p>
 
-<p>Boundaries of an individual CCG: <code><a href="/api/1.0/org_location/?org_type=ccg&q=99H">/api/1.0/org_location/?org_type=ccg&q=99H</a></code></p>
+<p>Boundaries of an individual SICBL: <code><a href="/api/1.0/org_location/?org_type=ccg&q=99H">/api/1.0/org_location/?org_type=ccg&q=99H</a></code></p>
 
-<p>Location (approximate) of a practice, or practices in a CCG, by code: <code><a href="/api/1.0/org_location/?q=99H,P87003">/api/1.0/org_location/?q=99H,P87003</a></code></p>
+<p>Location (approximate) of a practice, or practices in a SICBL, by code: <code><a href="/api/1.0/org_location/?q=99H,P87003">/api/1.0/org_location/?q=99H,P87003</a></code></p>
 
 {% endblock %}

--- a/openprescribing/templates/api.html
+++ b/openprescribing/templates/api.html
@@ -38,9 +38,9 @@
 
 <p>Queries the last five years of data and returns spending and items by CCG by month.</p>
 
-<p>Spending by CCG on a chemical: <code><a href="/api/1.0/spending_by_ccg/?code=0212000AA">/api/1.0/spending_by_ccg/?code=0212000AA</a></code></p>
+<p>Spending by CCG on a chemical: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA">/api/1.0/spending_by_sicbl/?code=0212000AA</a></code></p>
 
-<p>You can request individual CCGs by code: <code><a href="/api/1.0/spending_by_ccg/?code=0212000AA&org=03V">/api/1.0/spending_by_ccg/?code=0212000AA&org=03V</a></code></p>
+<p>You can request individual CCGs by code: <code><a href="/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V">/api/1.0/spending_by_sicbl/?code=0212000AA&org=03V</a></code></p>
 
 <h3>Spending by practice</h3>
 

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -98,7 +98,7 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
                 <li><a href="{% url 'all_practices' %}">Practices</a></li>
                 <li><a href="{% url 'all_pcns' %}">PCNs</a></li>
                 <li><a href="{% url 'all_ccgs' %}">SICBLs</a></li>
-                <li><a href="{% url 'all_stps' %}">STPs</a></li>
+                <li><a href="{% url 'all_stps' %}">ICBs</a></li>
                 <li><a href="{% url 'all_regional_teams' %}">Regional Teams</a></li>
                 <li><a href="{% url 'hospitals' %}">Hospitals</a></li>
                 <li><a href="{% url 'all_england' %}">All England</a></li>

--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -97,7 +97,7 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
               <ul class="dropdown-menu">
                 <li><a href="{% url 'all_practices' %}">Practices</a></li>
                 <li><a href="{% url 'all_pcns' %}">PCNs</a></li>
-                <li><a href="{% url 'all_ccgs' %}">CCGs</a></li>
+                <li><a href="{% url 'all_ccgs' %}">SICBLs</a></li>
                 <li><a href="{% url 'all_stps' %}">STPs</a></li>
                 <li><a href="{% url 'all_regional_teams' %}">Regional Teams</a></li>
                 <li><a href="{% url 'hospitals' %}">Hospitals</a></li>

--- a/openprescribing/templates/bnf_section.html
+++ b/openprescribing/templates/bnf_section.html
@@ -17,7 +17,7 @@
 
 <hr/>
 
-<p>High-level prescribing trends for {{ section.name }} (BNF section {{ section.number_str }}) across all GP practices in NHS England for the last five years. You can <a href="{% url 'analyse' %}#numIds={{ section.number_str }}">explore prescribing trends for this section by CCG</a>, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
+<p>High-level prescribing trends for {{ section.name }} (BNF section {{ section.number_str }}) across all GP practices in NHS England for the last five years. You can <a href="{% url 'analyse' %}#numIds={{ section.number_str }}">explore prescribing trends for this section by SICBL</a>, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
 
 <p><a href="{% url 'dmd_search' %}?q={{ section.bnf_code }}">View all matching dm+d items.</a></p>
 
@@ -43,7 +43,7 @@
 <h3>Download raw data</h3>
 <p>Download CSVs:
 <a href="{% url 'total_spending' %}?code={{ page_id }}&format=csv">all data on {{ section.name }}</a> or
-<a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ section.name }} by CCG</a>.
+<a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ section.name }} by SICBL</a>.
 </p>
 </div>
 

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -19,7 +19,7 @@
   Each month the OpenPrescribing team process data on primary care prescribing
   across NHS England and produce a
   <a href="{{ HOST }}{% url 'all_england' %}">national prescribing dashboard</a>
-  (as well as dashboards for every individual practice, SICBL, STP and regional
+  (as well as dashboards for every individual practice, SICBL, ICB and regional
   team).
 </p>
 

--- a/openprescribing/templates/bookmarks/email_for_all_england.html
+++ b/openprescribing/templates/bookmarks/email_for_all_england.html
@@ -19,7 +19,7 @@
   Each month the OpenPrescribing team process data on primary care prescribing
   across NHS England and produce a
   <a href="{{ HOST }}{% url 'all_england' %}">national prescribing dashboard</a>
-  (as well as dashboards for every individual practice, CCG, STP and regional
+  (as well as dashboards for every individual practice, SICBL, STP and regional
   team).
 </p>
 

--- a/openprescribing/templates/bookmarks/email_for_ncso_concessions.html
+++ b/openprescribing/templates/bookmarks/email_for_ncso_concessions.html
@@ -20,9 +20,9 @@
 {% if entity_type == 'practice' %}
 <p>
   We estimate that in {{ latest_month|date:"F Y" }} total price concessions for
-  products reported to only be available above Drug Tariff price at {{ entity_name }} will cost your CCG an
+  products reported to only be available above Drug Tariff price at {{ entity_name }} will cost your SICBL an
   additional <b>£{{ additional_cost|sigfigs:5|floatformat:"0"|intcomma }}</b>.
-  This is for information only; you should discuss with your CCG before
+  This is for information only; you should discuss with your SICBL before
   modifying a patient's medicine treatments based solely on Price Concessions.
 </p>
 {% else %}

--- a/openprescribing/templates/chemical.html
+++ b/openprescribing/templates/chemical.html
@@ -17,7 +17,7 @@
 
 <hr/>
 
-<p>High-level prescribing trends for {{ chemical.chem_name }} (BNF code {{ chemical.bnf_code }}) across all GP practices in NHS England for the last five years. You can see <a href="{% url 'analyse' %}#numIds={{ chemical.bnf_code }}&denomIds={% if bnf_para %}{{ bnf_para.number_str }}{% else %}{{ bnf_section.number_str }}{% endif %}">which CCGs prescribe most of this chemical</a> relative to its class, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
+<p>High-level prescribing trends for {{ chemical.chem_name }} (BNF code {{ chemical.bnf_code }}) across all GP practices in NHS England for the last five years. You can see <a href="{% url 'analyse' %}#numIds={{ chemical.bnf_code }}&denomIds={% if bnf_para %}{{ bnf_para.number_str }}{% else %}{{ bnf_section.number_str }}{% endif %}">which SICBLs prescribe most of this chemical</a> relative to its class, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
 
 <p><a href="{% url 'dmd_search' %}?q={{ chemical.bnf_code }}">View all matching dm+d items.</a></p>
 
@@ -30,7 +30,7 @@
 <p>
 Download CSV:
 <a href="{% url 'total_spending' %}?code={{ page_id }}&format=csv">all data on {{ chemical.chem_name }}</a> or
-<a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ chemical.chem_name }} by CCG</a>.
+<a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ chemical.chem_name }} by SICBL</a>.
 </p>
 </div>
 

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -97,7 +97,7 @@
 
         <p>
           This {{ entity_type_human }} page is a new feature. We have more data
-          for individual <a href="{% url 'all_ccgs' %}">CCGs</a> and
+          for individual <a href="{% url 'all_ccgs' %}">SICBLs</a> and
           <a href="{% url 'all_practices' %}">practices</a>, and for
           the <a href="{% url 'all_england' %}">whole of England</a>
           (such as our price-per-unit tool, ghost-branded generics, more email

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -27,13 +27,13 @@
 <p><a href="#prescquantity">What does quantity mean?</a></p>
 <p><a href="#actualcost">What is actual cost?</a></p>
 <p><a href="#bnfchange">How do you deal with BNF code changes?</a></p>
-<p><a href="#ccgchange">How do you determine CCG membership when GP practices have moved CCGs or CCGs have merged?</a></p>
+<p><a href="#ccgchange">How do you determine SICBL membership when GP practices have moved SICBLs or SICBLs have merged?</a></p>
 
 <h2>Analyse</h2>
 <p><a href="#analysetutorial">How do I use the analyse page?</a></p>
 <p><a href="#denominator">What denominator should I use?</a></p>
 
-<h2>CCG &amp; GP Dashboards</h2>
+<h2>SICBL &amp; GP Dashboards</h2>
 <p><a href="#measureinterpret">How do I interpret the measures?</a></p>
 <p><a href="#measurechose">How are the measures chosen?</a></p>
 <p><a href="#ghostgenerics">How do you calculate savings for ghost-branded generics?</a></p>
@@ -149,10 +149,10 @@
 <p>We have done this by mapping the old codes to the new codes, by using a map the NHS Business Services Authority provided us in a personal communication (after correcting for obvious typos etc.). You can read how we did this on <a href="https://github.com/ebmdatalab/openprescribing/pull/380/commits/7f968027263c62318403584e4ad5e0b96869bb7e">github</a>.</p>
 <p>You can read more about BNF codes and how they are structured <a href="https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/">here</a>.</p>
 
-<h3 id="ccgchange">"How do you determine CCG membership when GP practices have moved CCGs or CCGs have merged?</h3>
-<p>We use the current CCG membership of a practice in our analyses. If a GP Practice moved CCG, the data from before the move will be included in the data for their current CCG. Their former CCG will not include that practice's data. This means that when you look at our prescribing measures, you will be looking at the past prescribing of the current GP practices in that CCG.</p>
-<p>When CCGs merge, we create a new dashboard for the newly formed CCG and remove the old CCG dashboards. We use the prescribing data for the current practices in the new CCG in our measures. Any data for practices in the old CCGs that closed prior to the merger will be included in the new CCG's data</p>
-<p>Data from our analyse and trends pages also use current practice membership of a CCG when aggregating the data by CCG</p>
+<h3 id="ccgchange">"How do you determine SICBL membership when GP practices have moved SICBLs or SICBLs have merged?</h3>
+<p>We use the current SICBL membership of a practice in our analyses. If a GP Practice moved SICBL, the data from before the move will be included in the data for their current SICBL. Their former SICBL will not include that practice's data. This means that when you look at our prescribing measures, you will be looking at the past prescribing of the current GP practices in that SICBL.</p>
+<p>When SICBLs merge, we create a new dashboard for the newly formed SICBL and remove the old SICBL dashboards. We use the prescribing data for the current practices in the new SICBL in our measures. Any data for practices in the old SICBLs that closed prior to the merger will be included in the new SICBL's data</p>
+<p>Data from our analyse and trends pages also use current practice membership of a SICBL when aggregating the data by SICBL</p>
 
 <h2>Analyse</h2>
 <h3 id="analysetutorial">How do I use the analyse page?</h3>
@@ -167,16 +167,16 @@
 
 <p>Generating these STAR-PUs for each practice, each disease area, and each month, takes coder time, so we currently only have the STAR-PU for antibiotics.</p>
 
-<p>When using the data ourselves we tend to use more thoughtful approaches to try to "bake in" population prevalence or need for a particular condition, or to explore different prescribing patterns. For example, we often use whole classes of drug as the denominator in our analyses, as in the video walkthroughs; or we compare the use of one drug against the use of another. When looking at whether a practice is using a lot of Nexium (an expensive "proton pump inhibitor" pill for treating ulcers) we might look at "Nexium prescribing" versus "all proton pump inhibitor prescribing" (<a href="{% url 'analyse' %}#org=CCG&numIds=0103050E0BB&denomIds=1.3.5">example</a>).</p>
+<p>When using the data ourselves we tend to use more thoughtful approaches to try to "bake in" population prevalence or need for a particular condition, or to explore different prescribing patterns. For example, we often use whole classes of drug as the denominator in our analyses, as in the video walkthroughs; or we compare the use of one drug against the use of another. When looking at whether a practice is using a lot of Nexium (an expensive "proton pump inhibitor" pill for treating ulcers) we might look at "Nexium prescribing" versus "all proton pump inhibitor prescribing" (<a href="{% url 'analyse' %}#org=SICBL&numIds=0103050E0BB&denomIds=1.3.5">example</a>).</p>
 
 <p>Play around and <a href="mailto:{{ SUPPORT_TO_EMAIL }}" class="feedback-show">let us know</a> if you find anything interesting, or develop any interesting methods.</p>
 
-<h2>CCG &amp; GP Dashboards</h2>
+<h2>SICBL &amp; GP Dashboards</h2>
 
 <h3 id="measureinterpret">How should I interpret the measures?</h3>
 <p>We recommend reading NHS Digitals's <a href="https://digital.nhs.uk/practice-level-prescribing-summary">introduction to prescribing data</a>, including their <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a> (PDF) and <a href="http://content.digital.nhs.uk/media/10686/Download-glossary-of-terms-for-GP-prescribing---presentation-level/pdf/PLP_Presentation_Level_Glossary_April_2015.pdf">glossary of terms</a> (PDF).</p>
 
-<p>Just because a practice or CCG is an outlier for high or low use of a particular treatment, that doesn't necessarily mean they are good or bad prescribers. These are <em>measures</em> rather than <em>indicators</em>, and they need to be interpreted judiciously.</p>
+<p>Just because a practice or SICBL is an outlier for high or low use of a particular treatment, that doesn't necessarily mean they are good or bad prescribers. These are <em>measures</em> rather than <em>indicators</em>, and they need to be interpreted judiciously.</p>
 
 <p>For example, a practice that prescribes a lot of benzodiazepines may have a lower threshold for prescribing them, or may run a specialist service for people with substance misuse, or have one doctor with an interest in - and long list of - such patients.</p>
 <div class="alert alert-danger" role="alert" style="max-width: 800pxt">
@@ -184,12 +184,12 @@
 </div>
 
 <h3 id="measurechose">How are the measures chosen?</h3>
-<p>Our original measures were developed in discussion between Drs Jeff Aronson, Kamal Mahtani, <a href="https://www.bennett.ox.ac.uk/about-us/ben-goldacre/">Ben Goldacre</a> at the University of Oxford, and <a href="https://www.bennett.ox.ac.uk/about-us/richard-croker/">Richard Croker</a> from Devon CCG.  The Datalab team now create measures based on ideas for research, national guidelines, and from our users.  Please do <a href="mailto:{{ SUPPORT_TO_EMAIL }}" class="feedback-show">get in touch</a> if you have an idea for a possible new measure.</p>
+<p>Our original measures were developed in discussion between Drs Jeff Aronson, Kamal Mahtani, <a href="https://www.bennett.ox.ac.uk/about-us/ben-goldacre/">Ben Goldacre</a> at the University of Oxford, and <a href="https://www.bennett.ox.ac.uk/about-us/richard-croker/">Richard Croker</a> from Devon SICBL.  The Datalab team now create measures based on ideas for research, national guidelines, and from our users.  Please do <a href="mailto:{{ SUPPORT_TO_EMAIL }}" class="feedback-show">get in touch</a> if you have an idea for a possible new measure.</p>
 
 <h3 id="measurechose">How do you work out savings on individual presentations?</h3>
 
 <p>
-  There can be huge variation in the price a practice or CCG pay for a treatment, even for the same drug at the same dose. It is well known that branded and generic versions of the same treatment will have different prices; but different specific “brands” of “branded generic” may also have different prices; and there are many other similar sources of variation in price. Every month we estimate what could be saved if every organisation were prescribing as well as the best 10%, for each item prescribed. <a href="/price-per-unit-faq/">Read our detailed FAQ on the subject here</a>.</p>
+  There can be huge variation in the price a practice or SICBL pay for a treatment, even for the same drug at the same dose. It is well known that branded and generic versions of the same treatment will have different prices; but different specific “brands” of “branded generic” may also have different prices; and there are many other similar sources of variation in price. Every month we estimate what could be saved if every organisation were prescribing as well as the best 10%, for each item prescribed. <a href="/price-per-unit-faq/">Read our detailed FAQ on the subject here</a>.</p>
 
 <h3 id="ghostgenerics">How do you calculate savings for ghost-branded generics?</h3>
 <p>Ghost-branded generics are generic items which have unintentionally been prescribed with a manufacturer name. For example, Naratriptan 2.5mg Tablets is the correct generic name; a ghost-branded version is Naratriptan 2.5mg Tablets (Teva UK Limited). When an item is prescribed generically, the dispenser is reimbursed at the price in the Drug Tariff; but when a manufacturer is stated, the reimbursement price is usually more expensive.</p>
@@ -198,12 +198,12 @@
 
 <p>The prescribing data released by NHS BSA aggregates all generic and ghost-generic prescribing together, so it is not possible for us to break down the data precisely.</p>
 
-<p>In addition, the published Drug Tariff prices are not necessarily the ones used by BSA for reimbursement (see <a href="https://github.com/ebmdatalab/openprescribing/issues/1318">our technical notes here</a> for an explanation of this). Therefore, to estimate the size of the problem for individual practices or CCGs, we first have to estimate the Drug Tariff price for a generic, which we do by taking the median price paid for that generic item across the entire country. This gives us a price that <em>should</em> be paid for all prescriptions of that generic. We then compare this with the price that was used for reimbursement. This difference gives a reasonable estimate of the total possible savings if a generic were prescribed correctly. We only include savings of more than £5. Note that we use Net Ingredient Cost for our calculations; the true reimbursement cost will typically be 7% less due to bulk discounts.</p>
+<p>In addition, the published Drug Tariff prices are not necessarily the ones used by BSA for reimbursement (see <a href="https://github.com/ebmdatalab/openprescribing/issues/1318">our technical notes here</a> for an explanation of this). Therefore, to estimate the size of the problem for individual practices or SICBLs, we first have to estimate the Drug Tariff price for a generic, which we do by taking the median price paid for that generic item across the entire country. This gives us a price that <em>should</em> be paid for all prescriptions of that generic. We then compare this with the price that was used for reimbursement. This difference gives a reasonable estimate of the total possible savings if a generic were prescribed correctly. We only include savings of more than £5. Note that we use Net Ingredient Cost for our calculations; the true reimbursement cost will typically be 7% less due to bulk discounts.</p>
 
 <p>You can read more about the background of this issue <a href="https://www.bennett.ox.ac.uk/blog/2018/12/ghost-branded-generics-why-does-the-cost-of-generic-atorvastatin-vary/">on our blog</a>.</p>
 
 <h3 id="ghostgenericshow">How can I decrease our use of ghost-branded generics?</h3>
-<p>The spreadsheet download on ghost-branded generics page for each CCG or practice is sorted by total possible savings.  The practices and items appearing near the top of this list are likely to be prescribing the highest level of ghost-branded generics.  ePACT2 now carries data at an <em>AMPP</em> level for ghost-generics (termed "premium price generics"), meaning you can identify individual scripts which are at fault; PrescQIPP has also added ghost-generic reports and searches.</p>
+<p>The spreadsheet download on ghost-branded generics page for each SICBL or practice is sorted by total possible savings.  The practices and items appearing near the top of this list are likely to be prescribing the highest level of ghost-branded generics.  ePACT2 now carries data at an <em>AMPP</em> level for ghost-generics (termed "premium price generics"), meaning you can identify individual scripts which are at fault; PrescQIPP has also added ghost-generic reports and searches.</p>
 <p>In general, the fix will be dependent on your prescribing software. It should be possible to configure it so only true generics can be picked, at least for the most egregious items.</p>
 <p>We are currently gathering feedback from practices who have implemented such fixes, and will publish a summary on our blog in due course</p>.
 
@@ -217,7 +217,7 @@
   OpenPrescribing, and any practice with a current status of 
   <a href="https://www.bennett.ox.ac.uk/blog/2017/08/what-is-a-dormant-gp-practice-and-why-are-they-prescribing/">Dormant</a> 
   or Closed will be labelled as such. They will continue to be shown under the 
-  CCG they were last recorded under.
+  SICBL they were last recorded under.
 </p>
 
 <h2 id="longtermtrends"><a name="longtermtrends"></a>Long term trends</h2>

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -21,9 +21,9 @@
 
     <div class="row">
       <div class="col-lg-6 col-md-6 col-sm-6">
-        <h3>Look at your CCG</h3>
+        <h3>Look at your SICBL</h3>
         <p>We've identified standard <a href="https://openprescribing.net/measure/">prescribing measures</a>, and created dashboards for every Clinical Commissioning Group in the country.</p>
-        <a href="{% url 'all_ccgs' %}" class="btn btn-lg btn-info">Find a CCG &raquo;</a>
+        <a href="{% url 'all_ccgs' %}" class="btn btn-lg btn-info">Find a SICBL &raquo;</a>
       </div>
 
       <div class="col-lg-6 col-md-6 col-sm-6">

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -22,7 +22,7 @@
     <div class="row">
       <div class="col-lg-6 col-md-6 col-sm-6">
         <h3>Look at your SICBL</h3>
-        <p>We've identified standard <a href="https://openprescribing.net/measure/">prescribing measures</a>, and created dashboards for every Clinical Commissioning Group in the country.</p>
+        <p>We've identified standard <a href="https://openprescribing.net/measure/">prescribing measures</a>, and created dashboards for every ICB, SICBL, and practice in the country.</p>
         <a href="{% url 'all_ccgs' %}" class="btn btn-lg btn-info">Find a SICBL &raquo;</a>
       </div>
 

--- a/openprescribing/templates/measure_for_all_entities.html
+++ b/openprescribing/templates/measure_for_all_entities.html
@@ -65,7 +65,7 @@
                 <li><a href="{{ measureForAllPracticesUrl }}">Split the measure into charts for individual practices</a></li>
               {{/if}}
               {{#if measureForAllCCGsUrl }}
-                <li><a href="{{ measureForAllCCGsUrl }}">Split the measure into charts for individual CCGs</a></li>
+                <li><a href="{{ measureForAllCCGsUrl }}">Split the measure into charts for individual SICBLs</a></li>
               {{/if}}
               {{#if tagsFocus }}
                 <li>This is a compound measure. <a href="{{ tagsFocusUrl }}">Break it down into its constituent measures</a>.</li>

--- a/openprescribing/templates/outliers/toc_template.html
+++ b/openprescribing/templates/outliers/toc_template.html
@@ -61,8 +61,8 @@
                         </p>
                         <p>This report has been developed to automatically identify prescribing patterns at a chemical level which are furthest away from “typical prescribing” and can be classified as an “outlier”. We calculate the number of prescriptions
                             for each chemical in the <a href="https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/">BNF coding system</a> using the BNF subparagraph as a denominator, for prescriptions dispensed between {{ from_date }} and {{
-                            to_date }}. We then calculate the mean and standard deviation for each numerator and denominator pair across all practices/CCGs/PCNs/STPs. From this we can calculate the “z-score”, which is a measure of how many standard deviations
-                            a given practice/CCG/PCN/STP is from the population mean. We then rank your “z-scores” to find the top 5 results where prescribing is an outlier for prescribing higher than its peers and those where it is an outlier for prescribing
+                            to_date }}. We then calculate the mean and standard deviation for each numerator and denominator pair across all practices/SICBLs/PCNs/STPs. From this we can calculate the “z-score”, which is a measure of how many standard deviations
+                            a given practice/SICBL/PCN/STP is from the population mean. We then rank your “z-scores” to find the top 5 results where prescribing is an outlier for prescribing higher than its peers and those where it is an outlier for prescribing
                             lower than its peers.
                         </p>
                         <p>It is important to remember that this information was generated automatically and it is therefore likely that some of the behaviour is warranted. This report seeks only to collect information about where this variation may be warranted

--- a/openprescribing/templates/outliers/toc_template.html
+++ b/openprescribing/templates/outliers/toc_template.html
@@ -61,8 +61,8 @@
                         </p>
                         <p>This report has been developed to automatically identify prescribing patterns at a chemical level which are furthest away from “typical prescribing” and can be classified as an “outlier”. We calculate the number of prescriptions
                             for each chemical in the <a href="https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/">BNF coding system</a> using the BNF subparagraph as a denominator, for prescriptions dispensed between {{ from_date }} and {{
-                            to_date }}. We then calculate the mean and standard deviation for each numerator and denominator pair across all practices/SICBLs/PCNs/STPs. From this we can calculate the “z-score”, which is a measure of how many standard deviations
-                            a given practice/SICBL/PCN/STP is from the population mean. We then rank your “z-scores” to find the top 5 results where prescribing is an outlier for prescribing higher than its peers and those where it is an outlier for prescribing
+                            to_date }}. We then calculate the mean and standard deviation for each numerator and denominator pair across all practices/SICBLs/PCNs/ICBs. From this we can calculate the “z-score”, which is a measure of how many standard deviations
+                            a given practice/SICBL/PCN/ICB is from the population mean. We then rank your “z-scores” to find the top 5 results where prescribing is an outlier for prescribing higher than its peers and those where it is an outlier for prescribing
                             lower than its peers.
                         </p>
                         <p>It is important to remember that this information was generated automatically and it is therefore likely that some of the behaviour is warranted. This report seeks only to collect information about where this variation may be warranted

--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -33,11 +33,11 @@
     <div id="more-text"><a name="more-text"></a>
       <p>
         We have developed a new method that identifies very large cost-saving
-        opportunities for practices and CCGs in the NHS: between £100m and
+        opportunities for practices and SICBLs in the NHS: between £100m and
         £400m a year. This is more than any previous advice such as “always
         prescribe generically”. Our tool automatically identifies the drugs
         with the biggest cost savings opportunities for each individual
-        practice, or CCG, every month; and then helps them choose cheaper
+        practice, or SICBL, every month; and then helps them choose cheaper
         options. You can <a href="https://www.youtube.com/watch?v=o6QAgg9ZntI">view a YouTube video demonstration here</a>.
       </p>
       <p>
@@ -45,7 +45,7 @@
         prescribing advice (“always use the cheapest drug in class”) our method
         does not require that patients switch to completely different drugs.
         Our <a href="/price-per-unit-faq">full FAQ</a> gives the detail, but in
-        short: there can be huge variation in the price a practice or CCG pay
+        short: there can be huge variation in the price a practice or SICBL pay
         for a treatment, even for the same drug at the same dose. It is well
         known that branded and generic versions of the same treatment will have
         different prices; but different specific “brands” of “branded generic”
@@ -53,7 +53,7 @@
         sources of variation in price. Our tool automatically identifies all
         the biggest cost-saving opportunities by examining variation in the
         price-per-unit of all treatments, and then compares every practice or
-        CCG against the best 10% of most efficient prescribers, for every
+        SICBL against the best 10% of most efficient prescribers, for every
         treatment. This is a massive piece of computation run by our Bennett Institute at
         the University of Oxford, every month. The cost savings can be viewed
         using this tool, ranked in order of which drug has the biggest cost
@@ -91,7 +91,7 @@
         <span id="extended-info-link">{{ presentation.product_name }}</span> that are
         prescribed across the country.
         {% if entity %}
-          You can click the adjacent tab to view your own practice or CCG’s prescribing.
+          You can click the adjacent tab to view your own practice or SICBL’s prescribing.
         {% endif %}
       </p>
     {% endif %}

--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -191,7 +191,7 @@
       // When viewing at Presentation level, link back to practice-level
       var first_column = 'pct_name';
       var first_column_render = function(data, type, full, meta) {
-        return ' <a href="/ccg/'+full['pct']+'/price_per_unit/?date='+ full['date']+ '">'+full['pct_name']+'</a>';
+        return ' <a href="/sicbl/'+full['pct']+'/price_per_unit/?date='+ full['date']+ '">'+full['pct_name']+'</a>';
       }
     {% elif by_ccg %}
       // When viewing at CCG level, drill down to practices
@@ -201,7 +201,7 @@
           var url = '{% url "all_england_price_per_unit_by_presentation" "BNFCODE" %}'.replace(/BNFCODE/, data)
           var rendered = ' <a href="'+url+'?date='+ full['date']+ '">'+full['name']+'</a>';
         {% else %}
-          var rendered = ' <a href="/ccg/{{ entity.code }}/'+data+'/price_per_unit/?date='+ full['date']+ '">'+full['name']+'</a>';
+          var rendered = ' <a href="/sicbl/{{ entity.code }}/'+data+'/price_per_unit/?date='+ full['date']+ '">'+full['name']+'</a>';
         {% endif %}
         if (full['price_concession'] ) {
           rendered += ' <a class="info-link" role="button" data-toggle="popover" data-trigger="hover" title="Price concessions" data-content="Savings may not be achievable long term as this item was in the Price Concessions/NCSO for {{ date|date:"F Y"}}"><span class="glyphicon glyphicon-exclamation-sign text-danger"></span></a>'

--- a/openprescribing/templates/price_per_unit_faq.html
+++ b/openprescribing/templates/price_per_unit_faq.html
@@ -48,7 +48,7 @@
 <p>Once the patent expired, other manufacturers started produce the same drug at much cheaper price points.</p>
 <p>Any clinicians prescribing desogestrel by its brand name were unable to benefit from these cheaper prices, as a prescription for Cerazette must be dispensed as Cerazette, whereas a prescription for desogestrel could now be dispensed as any number of cheaper products.</p>
 <p>The reimbursement price of drugs is listed by the generic name in the Drug Tariff, and in England the price is set by the Secretary of State for Health.</p>
-<p>There are often considerable cost savings to the NHS for switching from branded to generic prescribing, and we have measures for some of these switches on our CCG and GP Practice dashboards. Examples include switching from prescribing <a href="https://openprescribing.net/measure/desogestrel/">Cerazette to generic desogestrel</a> or from <a href="https://openprescribing.net/measure/keppra/">Keppra to generic levetiracetam</a>.</p>
+<p>There are often considerable cost savings to the NHS for switching from branded to generic prescribing, and we have measures for some of these switches on our SICBL and GP Practice dashboards. Examples include switching from prescribing <a href="https://openprescribing.net/measure/desogestrel/">Cerazette to generic desogestrel</a> or from <a href="https://openprescribing.net/measure/keppra/">Keppra to generic levetiracetam</a>.</p>
 
 <h4>Branded Generics</h4>
 <p>Prescribing generically may not always be the lowest cost option. Once a patent has expired, other manufacturers can create their own branded products which are called ‘branded generics’. These branded generics sometimes have a lower list price in comparison to the price of the generic in the Drug Tariff. For more information about branded generics, <a href="#brandedgeneric">read this</a>.</p>
@@ -70,7 +70,7 @@
         <li>There may sometimes be a reasonable clinical justification for a specific patient to be prescribed a branded treatment in place of the generic equivalent.</li>
         <li>There may variation in local availability of a specific cheaper branded generic.</li>
         <li>Some variation may be due to pack size or “specials” (presentations made bespoke for individual patients).</li>
-        <li>Some of the money lost in the price paid for a dispensed presentation may be made up through a complex system of “rebates” paid by specific pharmaceutical companies to specific CCGs on specific products. These arrangements are not routinely disclosed.</li>
+        <li>Some of the money lost in the price paid for a dispensed presentation may be made up through a complex system of “rebates” paid by specific pharmaceutical companies to specific SICBLs on specific products. These arrangements are not routinely disclosed.</li>
         <li>Certain items have <a href="#packsize">different pack sizes.</a></li>
         <li>Some savings are only achievable with additional intervention. This includes, for example, savings from different brands of glucose test strips where the switch would also require procurement of a new meter to match the new brand.</li>
 </ul>

--- a/openprescribing/templates/research.html
+++ b/openprescribing/templates/research.html
@@ -64,7 +64,7 @@ p.has-pale-cyan-blue-background-color {
 
 
 
-<p>We publish research papers on variation in clinical practice in the NHS, across a wide range of medical fields. These papers typically include: 18 year national practice trends, corrected for population and inflation; graphs and atlases of current CCG and GP practice-level variation; 5 year GP practice-level decile trends; and regression analyses to describe factors associated with specific problematic or advantageous prescribing behaviours.<br></p>
+<p>We publish research papers on variation in clinical practice in the NHS, across a wide range of medical fields. These papers typically include: 18 year national practice trends, corrected for population and inflation; graphs and atlases of current SICBL and GP practice-level variation; 5 year GP practice-level decile trends; and regression analyses to describe factors associated with specific problematic or advantageous prescribing behaviours.<br></p>
 
 
 


### PR DESCRIPTION
This PR does not change any variable names, nor any magic strings used for identifying organisation type.  Doing so would be quite a big job with significant risk.  We know that refactoring organisation-related code is a high priority, if we ever come back to serious development on the project.

I'm confident that the measures code is well covered by tests.  I'm less confident in the organisation homepages and the analyse form, so these will need thorough manual testing on deploy.

As there are no database changes, rolling this PR back will be easy and quick.