### PR TITLE
Show price concession impact over full time range

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1019,7 +1019,7 @@ def spending_for_one_entity(request, entity_code, entity_type):
 
     current_month = _get_current_month()
     monthly_totals = ncso_spending_for_entity(
-        entity, entity_type, num_months=30, current_month=current_month
+        entity, entity_type, current_month=current_month
     )
     # In the very rare cases where we don't have data we just return a 404
     # rather than triggering an error


### PR DESCRIPTION
This used to be too slow to be practical, but improvements made since this feature was first deployed mean that it's only marginally slower to do the full available time range, and the results are much more useful.