### PR TITLE
Fix organisation type names in Analyse form

### DIFF
--- a/openprescribing/media/js/src/analyse-form.js
+++ b/openprescribing/media/js/src/analyse-form.js
@@ -334,7 +334,7 @@ var queryForm = {
       templateResult: function(result) {
         if (result.loading) return result.text;
         var str, section, name;
-        str = '<strong>' + result.type;
+        str = '<strong>' + _this.getDisplayType(result.type);
         if ('is_generic' in result) {
           str += (result.is_generic) ? ', generic' : ', branded';
         }
@@ -397,6 +397,25 @@ var queryForm = {
       orgType = 'CCG,practice';
     }
     return orgType;
+  },
+
+  typeNameMap: {
+    "practice": "Practice",
+    "pcn": "PCN",
+    "ccg": "Sub-ICB Location",
+    "stp": "ICB",
+    "regional_team": "Regional Team"
+  },
+
+  getDisplayType: function(type) {
+    var mapped = this.typeNameMap[type.toLowerCase()];
+    if (mapped) {
+      return mapped;
+    } else {
+      // We expect to get many other types here which are not organisation
+      // types so we want to pass these through untouched
+      return type;
+    }
   }
 
 };


### PR DESCRIPTION
Brian spotted that we were still using "CCG" where we meant "Sub-ICB Location". And aside from this the organisation type names were a bit of a mess of capitalistion.