### PR TITLE
Update all google things

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ flake8==4.0.1
     # via -r requirements.in
 fonttools==4.38.0
     # via matplotlib
-google-api-core[grpc]==1.31.5
+google-api-core[grpc]==2.11.0
     # via
     #   google-api-python-client
     #   google-cloud-bigquery
@@ -102,7 +102,7 @@ google-api-core[grpc]==1.31.5
     #   pandas-gbq
 google-api-python-client==2.68.0
     # via -r requirements.in
-google-auth==1.35.0
+google-auth==2.15.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -114,38 +114,44 @@ google-auth==1.35.0
     #   pydata-google-auth
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-google-auth-oauthlib==0.5.3
+google-auth-oauthlib==0.7.1
     # via
     #   pandas-gbq
     #   pydata-google-auth
-google-cloud-bigquery==2.34.4
+google-cloud-bigquery==3.4.0
     # via
     #   -r requirements.in
     #   pandas-gbq
-google-cloud-bigquery-storage==2.13.2
+google-cloud-bigquery-storage==2.16.2
     # via
     #   -r requirements.in
+    #   google-cloud-bigquery
     #   pandas-gbq
-google-cloud-core==1.7.3
+google-cloud-core==2.3.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-google-cloud-storage==2.1.0
+google-cloud-storage==2.6.0
     # via -r requirements.in
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==1.3.3
+google-resumable-media==2.4.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos==1.56.4
-    # via google-api-core
+googleapis-common-protos==1.57.0
+    # via
+    #   google-api-core
+    #   grpcio-status
 graphviz==0.20.1
     # via -r requirements.in
 grpcio==1.51.1
     # via
     #   google-api-core
     #   google-cloud-bigquery
+    #   grpcio-status
+grpcio-status==1.51.1
+    # via google-api-core
 gunicorn==20.0.4
     # via -r requirements.in
 html2text==2020.1.16
@@ -204,7 +210,6 @@ packaging==21.3
     # via
     #   build
     #   db-dtypes
-    #   google-api-core
     #   google-cloud-bigquery
     #   matplotlib
 pandas==1.5.2
@@ -213,7 +218,7 @@ pandas==1.5.2
     #   db-dtypes
     #   pandas-gbq
     #   seaborn
-pandas-gbq==0.17.9
+pandas-gbq==0.18.1
     # via -r requirements.in
 paramiko==2.12.0
     # via fabric3
@@ -229,13 +234,13 @@ proto-plus==1.22.1
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
-protobuf==3.20.1
+protobuf==4.21.10
     # via
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
-    #   google-cloud-storage
     #   googleapis-common-protos
+    #   grpcio-status
     #   proto-plus
 psycopg2-binary==2.9.5
     # via -r requirements.in
@@ -243,6 +248,7 @@ pyarrow==9.0.0
     # via
     #   -r requirements.in
     #   db-dtypes
+    #   google-cloud-bigquery
     #   pandas-gbq
 pyasn1==0.4.8
     # via
@@ -280,7 +286,6 @@ pytz==2022.6
     #   -r requirements.in
     #   django
     #   djangorestframework
-    #   google-api-core
     #   pandas
 pyvirtualdisplay==3.0
     # via -r requirements.in
@@ -314,11 +319,8 @@ six==1.16.0
     # via
     #   djangorestframework-csv
     #   fabric3
-    #   google-api-core
     #   google-auth
     #   google-auth-httplib2
-    #   google-cloud-core
-    #   google-resumable-media
     #   mock
     #   paramiko
     #   python-dateutil


### PR DESCRIPTION
There are so many interdependencies that trying to upgrade them in isolation is a nightmare.

This command gives us the primary list of packages:
```
grep ^google requirements.txt | sed -E 's/([^=]*).*/ -P \1 \\/'
```

Which we can use to form this command here, adding the `pandas-gbq` and `protobuf` packages:
```
pip-compile --resolver=backtracking -P pandas-gbq -P protobuf \
 -P google-api-core[grpc] \
 -P google-api-python-client \
 -P google-auth \
 -P google-auth-httplib2 \
 -P google-auth-oauthlib \
 -P google-cloud-bigquery \
 -P google-cloud-bigquery-storage \
 -P google-cloud-core \
 -P google-cloud-storage \
 -P google-crc32c \
 -P google-resumable-media \
 -P googleapis-common-protos
```

Surprisingly, the tests pass as is. Given that they involve talking to an actual BigQuery I think this means it genuinely is working. I suppose we're not doing anything particularly exotic with BQ so maybe it's not too surprising that the APIs haven't changed.