### PR TITLE
Cancel previous test runs when new commits pushed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The functional tests, which run against Browserstack, soon hit concurrency limits if you try to run too many at once and will start failing. Previously, if we merged N Dependabot PRs this would kick off N separate test runs against `main` which would lead to spurious failures. We want each subsequent commit to cancel the previous run so that only the tests on the final commit end up running to completion.