### PR TITLE
Parse ncso concessions current date from new html format

### DIFF
--- a/openprescribing/pipeline/test-data/pages/archived_pages/ncso-current.html
+++ b/openprescribing/pipeline/test-data/pages/archived_pages/ncso-current.html
@@ -1,0 +1,1534 @@
+<!-- 
+	NOTE: This file is representative of the format of the source page used for fetching
+	current NCSO concessions prior to March 2023.
+	It is here for reference only.
+-->
+
+<!doctype html>
+<html lang="en-GB" xmlns:fb="http://ogp.me/ns/fb#" xmlns:addthis="http://www.addthis.com/help/api-spec"  xmlns:og="http://ogp.me/ns#" class="no-js">
+	<head>
+		<meta charset="UTF-8">
+		<title>  Price Concessions and NCSO : PSNC Main site</title>
+		
+		<!-- dns prefetch -->
+		<link href="//www.google-analytics.com" rel="dns-prefetch">
+		
+		<!-- meta -->
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<meta name="viewport" content="width=device-width,initial-scale=1.0">
+		<meta name="author" content="PSNC">
+		<meta name="designer" content="Mark Williamson">
+		
+		<!-- Hide CPT from Google -->
+		
+		
+		<meta name="description" content="   QUICK LINKS BGMA best practice guidelines on notification of medicines shortages Price Concession and NCSO Archive REF: Drug Tariff Part II, Clause 8B and 9C November 2017 Latest information: November Price Concessions Update Drug Pack size Price Concession Amiloride 5mg tablets 28 £9.25 Amlodipine 5mg tablets 28 £3.75 Anastrozole 1mg tablets 28 £11.99 Atorvastatin...">
+		
+		<!--[if lte IE 6]>
+		<link rel="stylesheet" href="http://psnc.org.uk/wp-content/themes/psnc/css/ie6.css" media="screen, projection">
+		<![endif]-->
+		
+		<!--[if lt IE 7]>
+		<script src="http://ie7-js.googlecode.com/svn/version/2.1(beta4)/IE7.js"></script>
+		<![endif]-->
+		
+		<!-- icons -->
+		<link rel="shortcut icon" href="http://psnc.org.uk/wp-content/themes/psnc/favicon.ico" />
+		<link href="http://psnc.org.uk/wp-content/themes/psnc/img/icons/touch.png" rel="apple-touch-icon-precomposed">
+			
+		<!-- css + javascript -->
+		<link rel="dns-prefetch" href="//connect.facebook.net" />
+<link rel='dns-prefetch' href='//cdnjs.cloudflare.com' />
+<link rel='dns-prefetch' href='//connect.facebook.net' />
+<link rel='dns-prefetch' href='//s.w.org' />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/svg\/","svgExt":".svg","source":{"concatemoji":"\/\/psnc.org.uk\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.1"}};
+			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55358,56794,8205,9794,65039],[55358,56794,8203,9794,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='formidable-css'  href='//psnc.org.uk/wp-content/uploads/formidable/css/formidablepro.css?ver=11291615' media='all' />
+<link rel='stylesheet' id='mailchimpSF_main_css-css'  href='//psnc.org.uk/?mcsf_action=main_css&#038;ver=4.9.1' media='all' />
+<!--[if IE]>
+<link rel='stylesheet' id='mailchimpSF_ie_css-css'  href='//psnc.org.uk/wp-content/plugins/mailchimp/css/ie.css?ver=4.9.1' media='all' />
+<![endif]-->
+<link rel='stylesheet' id='popup-maker-site-css'  href='//psnc.org.uk/wp-content/plugins/popup-maker/assets/css/site.min.css?ver=1.6.6' media='all' />
+<link rel='stylesheet' id='printomatic-css-css'  href='//psnc.org.uk/wp-content/plugins/print-o-matic/css/style.css?ver=1.2' media='all' />
+<link rel='stylesheet' id='ssp-frontend-player-css'  href='//psnc.org.uk/wp-content/plugins/seriously-simple-podcasting/assets/css/player.css?ver=1.18.1' media='all' />
+<link rel='stylesheet' id='normalize-css'  href='//psnc.org.uk/wp-content/themes/psnc/normalize.css?ver=1.0' media='all' />
+<link rel='stylesheet' id='html5blank-css'  href='//psnc.org.uk/wp-content/themes/psnc/style.css?ver=1.0' media='all' />
+<link rel='stylesheet' id='bxslider-css'  href='//psnc.org.uk/wp-content/themes/psnc/css/jquery.bxslider.css?ver=1.0' media='all' />
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/conditionizr.js/2.2.0/conditionizr.min.js?ver=2.2.0'></script>
+<script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js?ver=2.6.2'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/jquery.bxSlider.js?ver=1.0.0'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/respond.min.js?ver=1.0.0'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/scripts.js?ver=1.0.0'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/print-o-matic/printomat.js?ver=1.8.5'></script>
+<link rel='https://api.w.org/' href='http://psnc.org.uk/wp-json/' />
+<link rel="alternate" type="application/json+oembed" href="http://psnc.org.uk/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fpsnc.org.uk%2Fdispensing-supply%2Fsupply-chain%2Fgeneric-shortages%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://psnc.org.uk/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fpsnc.org.uk%2Fdispensing-supply%2Fsupply-chain%2Fgeneric-shortages%2F&#038;format=xml" />
+<script type="text/javascript">document.documentElement.className += " js";</script>
+<!-- Stream WordPress user activity plugin v3.2.2 -->
+
+<link rel="alternate" type="application/rss+xml" title="Podcast RSS feed" href="http://psnc.org.uk/feed/podcast" />
+
+<script type="text/javascript">
+    var se_ajax_url = 'http://psnc.org.uk/wp-admin/admin-ajax.php';
+
+    jQuery(document).ready(function() {
+        jQuery('#se_search_element_id').suggest(se_ajax_url + '?action=se_special_container_lookup');
+    });
+</script>
+<meta property="og:site_name" content="PSNC Main site" />
+<meta property="og:type" content="website" />
+<meta property="og:locale" content="en_GB" />
+<meta property="og:url" content="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/" />
+<meta property="og:title" content="Price Concessions and NCSO" />
+<meta property="og:description" content="   QUICK LINKS BGMA best practice guidelines on notification of medicines shortages Price Concession and NCSO Archive REF: Drug Tariff Part II, Clause 8B and 9C November 2017 Latest information: November Price Concessions Update Drug Pack size Price Concession Amiloride 5mg tablets 28 £9.25 Amlodipine 5mg tablets 28 £3.75 Anastrozole 1mg tablets 28 £11.99 Atorvastatin&hellip;" />
+	<style id="pum-styles" type="text/css" media="all">
+	/* Popup Google Fonts */
+@import url('//fonts.googleapis.com/css?family=Acme|Montserrat');
+
+/* Popup Theme 199872: Framed Border */
+.pum-theme-199872, .pum-theme-framed-border { background-color: rgba( 255, 255, 255, 0.50 ) } 
+.pum-theme-199872 .pum-container, .pum-theme-framed-border .pum-container { padding: 18px; border-radius: 0px; border: 20px outset #dd3333; box-shadow: 1px 1px 3px 0px rgba( 2, 2, 2, 0.97 ) inset; background-color: rgba( 255, 251, 239, 1.00 ) } 
+.pum-theme-199872 .pum-title, .pum-theme-framed-border .pum-title { color: #000000; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
+.pum-theme-199872 .pum-content, .pum-theme-framed-border .pum-content { color: #2d2d2d; font-family: inherit } 
+.pum-theme-199872 .pum-content + .pum-close, .pum-theme-framed-border .pum-content + .pum-close { height: 20px; width: 20px; left: auto; right: -20px; bottom: auto; top: -20px; padding: 0px; color: #ffffff; font-family: Acme; font-size: 20px; line-height: 20px; border: 1px none #ffffff; border-radius: 0px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 0, 0, 0, 0.55 ) } 
+
+/* Popup Theme 199871: Cutting Edge */
+.pum-theme-199871, .pum-theme-cutting-edge { background-color: rgba( 0, 0, 0, 0.50 ) } 
+.pum-theme-199871 .pum-container, .pum-theme-cutting-edge .pum-container { padding: 18px; border-radius: 0px; border: 1px none #000000; box-shadow: 0px 10px 25px 0px rgba( 2, 2, 2, 0.50 ); background-color: rgba( 30, 115, 190, 1.00 ) } 
+.pum-theme-199871 .pum-title, .pum-theme-cutting-edge .pum-title { color: #ffffff; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: Sans-Serif; font-size: 26px; line-height: 28px } 
+.pum-theme-199871 .pum-content, .pum-theme-cutting-edge .pum-content { color: #ffffff; font-family: inherit } 
+.pum-theme-199871 .pum-content + .pum-close, .pum-theme-cutting-edge .pum-content + .pum-close { height: 24px; width: 24px; left: auto; right: 0px; bottom: auto; top: 0px; padding: 0px; color: #1e73be; font-family: inherit; font-size: 32px; line-height: 24px; border: 1px none #ffffff; border-radius: 0px; box-shadow: -1px 1px 1px 0px rgba( 2, 2, 2, 0.10 ); text-shadow: -1px 1px 1px rgba( 0, 0, 0, 0.10 ); background-color: rgba( 238, 238, 34, 1.00 ) } 
+
+/* Popup Theme 199870: Hello Box */
+.pum-theme-199870, .pum-theme-hello-box { background-color: rgba( 0, 0, 0, 0.75 ) } 
+.pum-theme-199870 .pum-container, .pum-theme-hello-box .pum-container { padding: 30px; border-radius: 80px; border: 14px solid #81d742; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.00 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
+.pum-theme-199870 .pum-title, .pum-theme-hello-box .pum-title { color: #2d2d2d; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: Montserrat; font-size: 32px; line-height: 36px } 
+.pum-theme-199870 .pum-content, .pum-theme-hello-box .pum-content { color: #2d2d2d; font-family: inherit } 
+.pum-theme-199870 .pum-content + .pum-close, .pum-theme-hello-box .pum-content + .pum-close { height: auto; width: auto; left: auto; right: -30px; bottom: auto; top: -30px; padding: 0px; color: #2d2d2d; font-family: inherit; font-size: 32px; line-height: 28px; border: 1px none #ffffff; border-radius: 28px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
+
+/* Popup Theme 199869: Enterprise Blue */
+.pum-theme-199869, .pum-theme-enterprise-blue { background-color: rgba( 0, 0, 0, 0.70 ) } 
+.pum-theme-199869 .pum-container, .pum-theme-enterprise-blue .pum-container { padding: 28px; border-radius: 5px; border: 1px none #000000; box-shadow: 0px 10px 25px 4px rgba( 2, 2, 2, 0.50 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
+.pum-theme-199869 .pum-title, .pum-theme-enterprise-blue .pum-title { color: #315b7c; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 34px; line-height: 36px } 
+.pum-theme-199869 .pum-content, .pum-theme-enterprise-blue .pum-content { color: #2d2d2d; font-family: inherit } 
+.pum-theme-199869 .pum-content + .pum-close, .pum-theme-enterprise-blue .pum-content + .pum-close { height: 28px; width: 28px; left: auto; right: 8px; bottom: auto; top: 8px; padding: 4px; color: #ffffff; font-family: inherit; font-size: 20px; line-height: 20px; border: 1px none #ffffff; border-radius: 42px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 49, 91, 124, 1.00 ) } 
+
+/* Popup Theme 199868: Light Box */
+.pum-theme-199868, .pum-theme-lightbox { background-color: rgba( 0, 0, 0, 0.60 ) } 
+.pum-theme-199868 .pum-container, .pum-theme-lightbox .pum-container { padding: 18px; border-radius: 3px; border: 8px solid #000000; box-shadow: 0px 0px 30px 0px rgba( 2, 2, 2, 1.00 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
+.pum-theme-199868 .pum-title, .pum-theme-lightbox .pum-title { color: #000000; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
+.pum-theme-199868 .pum-content, .pum-theme-lightbox .pum-content { color: #000000; font-family: inherit } 
+.pum-theme-199868 .pum-content + .pum-close, .pum-theme-lightbox .pum-content + .pum-close { height: 30px; width: 30px; left: auto; right: -24px; bottom: auto; top: -24px; padding: 0px; color: #ffffff; font-family: inherit; font-size: 24px; line-height: 26px; border: 2px solid #ffffff; border-radius: 30px; box-shadow: 0px 0px 15px 1px rgba( 2, 2, 2, 0.75 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 0, 0, 0, 1.00 ) } 
+
+/* Popup Theme 199867: Default Theme */
+.pum-theme-199867, .pum-theme-default-theme { background-color: rgba( 12, 12, 12, 0.50 ) } 
+.pum-theme-199867 .pum-container, .pum-theme-default-theme .pum-container { padding: 20px; border-radius: 50px; border: 1px none #000000; box-shadow: 1px 1px 3px 0px rgba( 2, 2, 2, 0.23 ); background-color: rgba( 249, 249, 249, 1.00 ) } 
+.pum-theme-199867 .pum-title, .pum-theme-default-theme .pum-title { color: #4f3388; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
+.pum-theme-199867 .pum-content, .pum-theme-default-theme .pum-content { color: #636363; font-family: inherit } 
+.pum-theme-199867 .pum-content + .pum-close, .pum-theme-default-theme .pum-content + .pum-close { height: auto; width: 30px; left: auto; right: 0px; bottom: auto; top: 0px; padding: 8px; color: #ffffff; font-family: inherit; font-size: 16px; line-height: 14px; border: 1px none #ffffff; border-radius: 25px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 79, 51, 136, 1.00 ) } 
+
+
+	
+		</style>
+<!-- START - Facebook Open Graph, Google+ and Twitter Card Tags 2.1.5 -->
+ <!-- Facebook Open Graph -->
+  <meta property="og:site_name" content="PSNC Main site"/>
+  <meta property="og:title" content="Price Concessions and NCSO"/>
+  <meta property="og:url" content="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/"/>
+  <meta property="og:type" content="article"/>
+  <meta property="og:description" content="  
+
+
+
+
+QUICK LINKS
+
+
+
+BGMA best practice guidelines on notification of medicines shortages
+
+
+Price Concession and NCSO Archive
+
+
+REF: Drug Tariff Part II, Clause 8B and 9C
+
+
+
+November 2017
+Latest information: November Price Concessions Update
+
+
+
+Drug
+Pack size
+Price Concess"/>
+ <!-- Google+ / Schema.org -->
+  <meta itemprop="name" content="Price Concessions and NCSO"/>
+  <meta itemprop="description" content="  
+
+
+
+
+QUICK LINKS
+
+
+
+BGMA best practice guidelines on notification of medicines shortages
+
+
+Price Concession and NCSO Archive
+
+
+REF: Drug Tariff Part II, Clause 8B and 9C
+
+
+
+November 2017
+Latest information: November Price Concessions Update
+
+
+
+Drug
+Pack size
+Price Concess"/>
+  <meta itemprop="image" content="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg"/>
+ <!-- Twitter Cards -->
+ <!-- SEO -->
+ <!-- Misc. tags -->
+<!-- END - Facebook Open Graph, Google+ and Twitter Card Tags 2.1.5 -->
+	
+
+		<script>
+		(function(){
+			// configure legacy, retina, touch requirements @ conditionizr.com
+			conditionizr();
+		})();
+		</script>
+		
+
+
+
+		<!-- analytics -->		
+		
+		<script type="text/javascript">
+
+		  var _gaq = _gaq || [];
+		  _gaq.push(
+			  ['_setAccount', 'UA-4143012-1'],
+			  ['_trackPageview']
+			);
+		
+		  (function() {
+		    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+		    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+		  })();
+		
+		</script>
+	</head>
+	<body class="page-template-default page page-id-100786 page-child parent-pageid-2106 generic-shortages" id="site-id-1">
+		
+		<!--[if lte IE 7]>
+            <div class="chromeframe" style="background:black;">You are using an outdated browser so elements on this page may not display as intended. <a href="http://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</div>
+        <![endif]-->
+		
+		
+	
+			<!-- header -->
+			<header class="header clear" role="banner" style="z-index:1000;">
+				
+				<!-- wrapper -->
+				<div class="wrapper clear" style="z-index:1000;">
+				
+					<!-- logo -->
+					<div class="logo three columns">
+						<a href="http://psnc.org.uk">
+							<!-- svg logo - toddmotto.com/mastering-svg-use-for-a-retina-web-fallbacks-with-png-script -->
+							<img src="http://psnc.org.uk/wp-content/themes/psnc/img/logo.png" alt="Logo" class="logo-img">
+						</a>
+					</div>
+					<!-- /logo -->
+					
+					<div class="site-title three columns">
+						<span>Pharmaceutical<br>Services<br>Negotiating<br>Committee</span>
+					</div>
+					<!-- /site-title -->
+					
+					<div class="pharmacy-logo four columns">
+						<img src="http://psnc.org.uk/wp-content/themes/psnc/img/pharmacy-logo.png" alt="Pharmacy - At the heart of our community">
+					</div>
+					<!-- /pharmacy-logo -->
+					
+					<div class="utility six columns">
+						<div class="share-login">
+														<!-- <a href="http://psnc.org.uk/login">Login</a> -->
+													</div>
+						<!-- /share-login -->
+						
+						<div class="quick-links-search">
+
+							<div class="quick-links">
+								<a href="#" class="dropdown icon-down-dir">Quick links</a>
+								<ul id="menu-hot-topics" class="menu clear"><li id="menu-item-298" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-298"><a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">Online Drug Tariff</a></li>
+<li id="menu-item-200469" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-200469"><a href="http://psnc.org.uk/latest-news/email-sign-up/">Sign up for our email newsletters</a></li>
+<li id="menu-item-100908" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item menu-item-100908"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions and NCSO</a></li>
+<li id="menu-item-13982" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13982"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Report generic medicine supply issue</a></li>
+<li id="menu-item-6952" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6952"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">Where to obtain external resources</a></li>
+<li id="menu-item-126664" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-126664"><a href="http://psnc.org.uk/wp-content/uploads/2013/07/NHS-England-Pharmacy-Contract-Manager-Network.pdf">NHS England local team email addresses</a></li>
+<li id="menu-item-63267" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-63267"><a href="https://www.digital.nhs.uk/Registration-Authorities-and-Smartcards/Service-provider-contact-details">Smartcard Registration Authority contacts</a></li>
+<li id="menu-item-134851" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-134851"><a href="http://psnc.org.uk/psncs-work/our-events/register-your-interest-in-our-webinar/">PSNC webinars</a></li>
+<li id="menu-item-209250" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209250"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/psnctalk-videos/">#PSNCtalk videos</a></li>
+</ul>							</div>
+							<!-- /quick-links -->
+							<!-- search -->
+<form class="search" method="get" action="http://psnc.org.uk" role="search">
+	<input class="search-input" type="text" name="s"  value="Search" onfocus="if (this.value == 'Search') {this.value = '';}" onblur="if (this.value == '') {this.value = 'Search';}">
+	<input type="hidden" value="all" name="post_type" id="searchOptionsAll">
+	<button class="search-submit icon-search" type="submit" role="button"></button>
+</form>
+<!-- /search -->						</div>	
+						<!-- /quick-links-search -->
+					</div>
+					<!-- /utility -->
+					
+				</div>
+				<!-- /wrapper -->
+					
+					<!-- main-nav -->
+					<!--[if lt IE 8]>
+					<style>
+					nav.main-nav ul li a { margin-top: expression(this.offsetHeight < this.parentNode.offsetHeight ? parseInt((this.parentNode.offsetHeight - this.offsetHeight) / 2) + "px" : "0");
+					}
+					</style>
+					<![endif]-->
+					
+					<div class="noscript-hide">
+						<ul class="menu-features">
+							
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="http://psnc.org.uk/contract-it/psnc-briefings-pharmacy-contract-and-it/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/MG_4216-6-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="http://psnc.org.uk/contract-it/psnc-briefings-pharmacy-contract-and-it/" title="PSNC Contract and IT Briefings">PSNC Contract and IT Briefings</a>
+																					</h2>
+										<p>Briefings published by PSNC covering topics such as opening hours, regulations, and NHS IT matters.</p>										<p class="menu-order">3										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="http://psnc.org.uk/latest-news/email-sign-up/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/heart-of-community_purple-200x200.png" class="attachment-square size-square wp-post-image" alt="" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="http://psnc.org.uk/latest-news/email-sign-up/" title="Sign up for PSNC&#8217;s emails">Sign up for PSNC&#8217;s emails</a>
+																					</h2>
+										<p>Join our mailing list for a weekly round-up of news and resources, plus price concession/NCSO alerts.</p>										<p class="menu-order">1										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/MG_4685-25-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/" title="Dispensing and Supply updates">Dispensing and Supply updates</a>
+																					</h2>
+										<p>Our monthly updates on dispensing news and guidance, plus a variety of factsheets.</p>										<p class="menu-order">4										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="/services-commissioning/community-pharmacy-forward-view/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square.png" class="attachment-square size-square wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square.png 166w, http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square-120x117.png 120w" sizes="(max-width: 166px) 100vw, 166px" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="/services-commissioning/community-pharmacy-forward-view/" title="Community Pharmacy Forward View">Community Pharmacy Forward View</a>
+																					</h2>
+										<p>Community pharmacy shares its vision on how the sector could be developed to better support patients and the NHS.</p>										<p class="menu-order">5										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="/the-healthcare-landscape"><img src="http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized.jpg" class="attachment-square size-square wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized.jpg 166w, http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized-120x117.jpg 120w" sizes="(max-width: 166px) 100vw, 166px" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="/the-healthcare-landscape" title="Healthcare Landscape">Healthcare Landscape</a>
+																					</h2>
+										<p>Find out what&#8217;s happening in the wider NHS.</p>										<p class="menu-order">6										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="/lpcs/lposs"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/LPOSS-cover-200x200.png" class="attachment-square size-square wp-post-image" alt="" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="/lpcs/lposs" title="LPOSS">LPOSS</a>
+																					</h2>
+										<p>The Local Pharmacy Organisation Support Services prospectus brings together all our resources and support options for LPCs.</p>										<p class="menu-order">7										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+															<!-- article -->
+								<li class="featured-menu-item">
+									<div class="featured-menu-item-image">
+																					<a href="/funding-and-statistics"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/Stats-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
+																				</div>
+									<!-- /image -->
+									
+									<div class="featured-menu-item-text">
+										<h2>
+																						<a href="/funding-and-statistics" title="Funding and Statistics">Funding and Statistics</a>
+																					</h2>
+										<p>Find out the latest on pharmacy funding and NHS statistics.</p>										<p class="menu-order">2										
+										
+									</div>
+									<!-- /text -->
+									
+								</li>
+								<!-- /li -->
+								
+								
+								
+														
+														
+														
+						</ul>
+					</div>
+					<!-- /noscript-hide -->
+					
+					<nav class="main-nav hideformobile" role="navigation">
+												<div class="wrapper clear">
+							<ul id="menu-main-navigation" class="menu root-menu"><li id="menu-item-248" class="menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-248"><a href="http://psnc.org.uk/psncs-work/">PSNC&#8217;s Work</a>
+<ul class="child-menu">
+	<li id="menu-item-1669" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1669"><a href="http://psnc.org.uk/psncs-work/about-psnc/">About PSNC</a>
+	<ul class="child-menu">
+		<li id="menu-item-1903" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1903"><a href="http://psnc.org.uk/psncs-work/about-psnc/psnc-members/">PSNC members</a></li>
+		<li id="menu-item-1904" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1904"><a href="http://psnc.org.uk/psncs-work/about-psnc/psnc-staff/">PSNC staff</a></li>
+		<li id="menu-item-1902" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1902"><a href="http://psnc.org.uk/psncs-work/psnc-vision-and-work-plan/">PSNC Vision &#038; work plan</a></li>
+		<li id="menu-item-20556" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-20556"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/">Communications &#038; lobbying</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1898"><a href="http://psnc.org.uk/psncs-work/the-latest-from-psnc/">The latest from PSNC</a>
+	<ul class="child-menu">
+		<li id="menu-item-218437" class="menu-item menu-item-type-post_type menu-item-object-our-latest-news menu-item-218437"><a href="http://psnc.org.uk/our-news/processes-for-2018-psnc-elections-announced/">2018 PSNC elections</a></li>
+		<li id="menu-item-1901" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1901"><a href="http://psnc.org.uk/psncs-work/the-latest-from-psnc/psnc-meetings/">PSNC meetings</a></li>
+		<li id="menu-item-28264" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28264"><a href="http://psnc.org.uk/psncs-work/psnc-briefings-psncs-work/">PSNC Briefings</a></li>
+		<li id="menu-item-90270" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-90270"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/community-pharmacy-in-201617-and-beyond/">Community pharmacy in 2016/17 &#038; beyond</a></li>
+	</ul>
+</li>
+	<li id="menu-item-209371" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-209371"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/">PSNC publications</a>
+	<ul class="child-menu">
+		<li id="menu-item-209370" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209370"><a href="http://psnc.org.uk/psncs-work/cpn/">Community Pharmacy News (CPN)</a></li>
+		<li id="menu-item-79637" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79637"><a href="http://psnc.org.uk/psncs-work/our-events/register-your-interest-in-our-webinar/">Webinars</a></li>
+		<li id="menu-item-124841" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-124841"><a href="http://psnc.org.uk/podcast">Podcasts</a></li>
+		<li id="menu-item-209251" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209251"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/psnctalk-videos/">#PSNCtalk videos</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1900" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1900"><a href="http://psnc.org.uk/psncs-work/website/">Website</a>
+	<ul class="child-menu">
+		<li id="menu-item-5144" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5144"><a href="/our-latest-news-category/psnc-news/">PSNC News</a></li>
+		<li id="menu-item-5145" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5145"><a href="http://psnc.org.uk/latest-news/email-sign-up/">Email newsletter sign up</a></li>
+		<li id="menu-item-79638" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79638"><a href="http://psnc.org.uk/psncs-work/feedback-to-psnc/">Feedback to PSNC</a></li>
+		<li id="menu-item-4660" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4660"><a href="http://psnc.org.uk/psncs-work/website/rss-feeds/">RSS feeds</a></li>
+		<li id="menu-item-255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-255"><a href="http://psnc.org.uk/psncs-work/website/privacy-cookies/">Privacy &#038; cookies</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-16135" class="menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16135"><a href="http://psnc.org.uk/funding-and-statistics/">Funding and Statistics</a>
+<ul class="child-menu">
+	<li id="menu-item-16192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16192"><a href="http://psnc.org.uk/funding-and-statistics/pharmacy-funding/">Pharmacy funding</a>
+	<ul class="child-menu">
+		<li id="menu-item-135262" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135262"><a href="http://psnc.org.uk/funding-and-statistics/cpcf-funding-changes-201617-and-201718/">Funding changes 2016/17 &#038; 2017/18</a></li>
+		<li id="menu-item-16223" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16223"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/">Funding distribution</a></li>
+		<li id="menu-item-16236" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16236"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/indicative-income-tables/">Income tables</a></li>
+		<li id="menu-item-16225" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16225"><a href="http://psnc.org.uk/funding-and-statistics/pharmacy-funding/margins-survey/">Margins survey</a></li>
+		<li id="menu-item-16226" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16226"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/summary-of-funding-changes/">Summary of changes</a></li>
+	</ul>
+</li>
+	<li id="menu-item-16227" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-16227"><a>Topical funding issues</a>
+	<ul class="child-menu">
+		<li id="menu-item-16228" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16228"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/branded-generics/">Branded generics</a></li>
+		<li id="menu-item-16229" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16229"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/dispensing-at-a-loss/">Dispensing at a loss</a></li>
+		<li id="menu-item-16230" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16230"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/it-and-eps-allowances/">IT/EPS allowances</a></li>
+		<li id="menu-item-16231" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16231"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/pre-registration-training-grant/">Pre-reg training grant</a></li>
+		<li id="menu-item-16232" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16232"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/vat/">VAT</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1585" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1585"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/">NHS statistics</a>
+	<ul class="child-menu">
+		<li id="menu-item-5563" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5563"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/eps-statistics/">EPS statistics</a></li>
+		<li id="menu-item-80572" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-80572"><a href="http://psnc.org.uk/services-commissioning/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu statistics</a></li>
+		<li id="menu-item-5565" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5565"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/mur-statistics/">MUR statistics</a></li>
+		<li id="menu-item-5564" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5564"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/nms-statistics/">NMS statistics</a></li>
+		<li id="menu-item-124592" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-124592"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/summary-care-record-scr-home/scr-overview/scr-statistics/">SCR statistics</a></li>
+		<li id="menu-item-210538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-210538"><a href="http://psnc.org.uk/services-commissioning/essential-services/quality-payments/quality-payments-scheme-statistics/">Quality Payments Statistics</a></li>
+	</ul>
+</li>
+	<li id="menu-item-16233" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-16233"><a>Other resources</a>
+	<ul class="child-menu">
+		<li id="menu-item-5087" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5087"><a href="/our-latest-news-category/funding-and-statistics/">News</a></li>
+		<li id="menu-item-5107" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5107"><a href="http://psnc.org.uk/funding-and-statistics/psnc-briefings-funding-and-statistics/">PSNC Briefings</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-247" class="menu-pharmacy-contract-and-funding menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-247"><a href="http://psnc.org.uk/contract-it/">Contract and IT</a>
+<ul class="child-menu">
+	<li id="menu-item-1599" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1599"><a href="http://psnc.org.uk/contract-it/the-pharmacy-contract/">Contractual Framework</a>
+	<ul class="child-menu">
+		<li id="menu-item-135097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135097"><a href="http://psnc.org.uk/contract-it/cpcf-changes-201617-and-201718/">CPCF changes 2016/17 &#038; 2017/18</a></li>
+		<li id="menu-item-1578" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1578"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/">Market entry</a></li>
+		<li id="menu-item-1594" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1594"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/distance-selling-pharmacies/">Distance selling pharmacies</a></li>
+		<li id="menu-item-10141" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10141"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/relocations-which-do-not-result-in-significant-change/">Relocations</a></li>
+		<li id="menu-item-10142" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10142"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/rural-issues/">Rural issues</a></li>
+		<li id="menu-item-10143" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10143"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/pharmaceutical-needs-assessment/">PNAs</a></li>
+		<li id="menu-item-10135" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10135"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/essential-small-pharmacies/">Essential Small Pharmacies</a></li>
+		<li id="menu-item-1945" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1945"><a href="http://psnc.org.uk/services-commissioning/essential-services/">Essential Services</a></li>
+		<li id="menu-item-1947" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1947"><a href="http://psnc.org.uk/services-commissioning/advanced-services/">Advanced Services</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1583" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1583"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/">Regulatory matters</a>
+	<ul class="child-menu">
+		<li id="menu-item-995" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-995"><a href="http://psnc.org.uk/contract-it/the-pharmacy-contract/contract-monitoring/">Contract monitoring</a></li>
+		<li id="menu-item-3946" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3946"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/dda/">The Equality Act 2010</a></li>
+		<li id="menu-item-10136" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10136"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/fitness-to-practice/">Fitness to Practise</a></li>
+		<li id="menu-item-10139" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10139"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/performance-panels/">Performance panels</a></li>
+		<li id="menu-item-10140" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10140"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/responsible-pharmacist/">Responsible Pharmacist</a></li>
+		<li id="menu-item-10134" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10134"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/direction-of-prescriptions/">Direction of prescriptions</a></li>
+		<li id="menu-item-10133" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10133"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/dbs-checks/">DBS checks</a></li>
+		<li id="menu-item-135154" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135154"><a href="http://psnc.org.uk/contract-it/pharmacy-mergers-consolidations/">Pharmacy consolidations (mergers)</a></li>
+		<li id="menu-item-135056" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135056"><a href="http://psnc.org.uk/contract-it/pharmacy-access-scheme-phas/">Pharmacy Access Scheme</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1977" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1977"><a href="http://psnc.org.uk/contract-it/pharmacy-it/">Community pharmacy IT</a>
+	<ul class="child-menu">
+		<li id="menu-item-136230" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-136230"><a href="http://psnc.org.uk/contract-it/pharmacy-it/nhs-mail/">NHSmail</a></li>
+		<li id="menu-item-108748" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108748"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/">EHR home</a></li>
+		<li id="menu-item-2169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2169"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS home</a></li>
+		<li id="menu-item-17186" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17186"><a href="http://psnc.org.uk/dispensing-supply/eps/patient-nomination-of-a-dispensing-site/">EPS nomination</a></li>
+		<li id="menu-item-17188" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17188"><a href="http://psnc.org.uk/dispensing-supply/eps/contingency-arrangements/">EPS Business Continuity</a></li>
+		<li id="menu-item-152131" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152131"><a href="http://psnc.org.uk/contract-it/pharmacy-it/information-governance-and-cybersecurity/">IG &#038; cybersecurity</a></li>
+		<li id="menu-item-10255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10255"><a href="http://psnc.org.uk/contract-it/pharmacy-it/smartcards/">Smartcards</a></li>
+		<li id="menu-item-108749" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108749"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/summary-care-record-scr-home/">SCR home</a></li>
+		<li id="menu-item-5559" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5559"><a href="http://psnc.org.uk/contract-it/pharmacy-it/pharmacy-system-suppliers/">System suppliers</a></li>
+	</ul>
+</li>
+	<li id="menu-item-8769" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-8769"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/">Clinical Governance</a>
+	<ul class="child-menu">
+		<li id="menu-item-18116" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18116"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/clinical-audit/">Clinical audit</a></li>
+		<li id="menu-item-8770" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8770"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/cppq/">Community Pharmacy Patient Questionnaire (CPPQ)</a></li>
+		<li id="menu-item-18117" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18117"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/complaints/">NHS complaints procedure</a></li>
+		<li id="menu-item-8768" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8768"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/patient-safety-incident-reporting/">Patient safety incident reporting</a></li>
+		<li id="menu-item-8772" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8772"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/practice-leaflet-requirements/">Practice leaflet requirements</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-244" class="menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children menu-item-244"><a href="http://psnc.org.uk/dispensing-supply/">Dispensing and Supply</a>
+<ul class="child-menu">
+	<li id="menu-item-2212" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2212"><a href="http://psnc.org.uk/dispensing-supply/dispensing-process/">The dispensing process</a>
+	<ul class="child-menu">
+		<li id="menu-item-671" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-671"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/">Receiving a prescription</a></li>
+		<li id="menu-item-670" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-670"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/">Is this item allowed?</a></li>
+		<li id="menu-item-668" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-668"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/">Dispensing a prescription</a></li>
+		<li id="menu-item-667" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-667"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/">Controlled Drugs</a></li>
+		<li id="menu-item-672" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-672"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS main page</a></li>
+		<li id="menu-item-17189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17189"><a href="http://psnc.org.uk/dispensing-supply/eps/overview-of-eps-functionality/">Using EPS</a></li>
+	</ul>
+</li>
+	<li id="menu-item-7479" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-7479"><a href="http://psnc.org.uk/dispensing-supply/endorsement-payment/">Endorsement &#038; payment</a>
+	<ul class="child-menu">
+		<li id="menu-item-3569" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3569"><a href="http://psnc.org.uk/dispensing-supply/endorsement/">Item endorsement &#038; pricing</a></li>
+		<li id="menu-item-664" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-664"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-submission/">Prescription submission</a></li>
+		<li id="menu-item-17185" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17185"><a href="http://psnc.org.uk/dispensing-supply/eps/endorsing-and-submission/">EPS endorsing &#038; submitting</a></li>
+		<li id="menu-item-663" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-663"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/monthly-payments/">Monthly payments</a></li>
+		<li id="menu-item-662" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-662"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-pricing-accuracy/">Prescription pricing accuracy</a></li>
+	</ul>
+</li>
+	<li id="menu-item-2120" class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current-menu-parent current-page-parent current_page_parent current_page_ancestor menu-item-has-children menu-item-2120"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/">Supply chain &#038; shortages</a>
+	<ul class="child-menu">
+		<li id="menu-item-2122" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2122"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/distribution-of-medicines/">Distribution of medicines</a></li>
+		<li id="menu-item-2121" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2121"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer contingency arrangements</a></li>
+		<li id="menu-item-100911" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item menu-item-100911"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions &#038; NCSO</a></li>
+		<li id="menu-item-673" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-673"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/">Branded supply issues</a></li>
+		<li id="menu-item-2123" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2123"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Appliance issues</a></li>
+		<li id="menu-item-13983" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13983"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/">Supply issue feedback forms</a></li>
+	</ul>
+</li>
+	<li id="menu-item-2231" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2231"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/">Resources</a>
+	<ul class="child-menu">
+		<li id="menu-item-2233" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2233"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/quick-reference-guides/">Quick reference guides</a></li>
+		<li id="menu-item-2232" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2232"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff</a></li>
+		<li id="menu-item-7534" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7534"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">External resources</a></li>
+		<li id="menu-item-108797" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108797"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/primary-care-support-england-pcse/">Primary Care Support England (PCSE)</a></li>
+		<li id="menu-item-5618" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5618"><a href="/our-latest-news-category/dispensing-and-supply/">News</a></li>
+		<li id="menu-item-5130" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5130"><a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-249" class="menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-249"><a href="http://psnc.org.uk/services-commissioning/">Services and Commissioning</a>
+<ul class="child-menu">
+	<li id="menu-item-979" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-979"><a href="http://psnc.org.uk/services-commissioning/essential-services/">Essential Services</a>
+	<ul class="child-menu">
+		<li id="menu-item-986" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-986"><a href="http://psnc.org.uk/services-commissioning/essential-services/essential-service-dispensing-of-medicines/">Dispensing Medicines</a></li>
+		<li id="menu-item-1829" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1829"><a href="http://psnc.org.uk/services-commissioning/essential-services/dispensing-of-appliances/">Dispensing Appliances</a></li>
+		<li id="menu-item-987" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-987"><a href="http://psnc.org.uk/services-commissioning/essential-services/repeat-dispensing/">Repeat Dispensing/eRD</a></li>
+		<li id="menu-item-1828" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1828"><a href="http://psnc.org.uk/services-commissioning/essential-services/disposal-of-unwanted-medicines/">Unwanted Medicines</a></li>
+		<li id="menu-item-1832" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1832"><a href="http://psnc.org.uk/services-commissioning/essential-services/public-health/">Public Health (Promotion of Healthy Lifestyles)</a></li>
+		<li id="menu-item-1830" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1830"><a href="http://psnc.org.uk/services-commissioning/essential-services/signposting/">Signposting</a></li>
+		<li id="menu-item-1831" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1831"><a href="http://psnc.org.uk/services-commissioning/essential-services/support-for-self-care/">Self Care</a></li>
+	</ul>
+</li>
+	<li id="menu-item-978" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-978"><a href="http://psnc.org.uk/services-commissioning/advanced-services/">Advanced Services</a>
+	<ul class="child-menu">
+		<li id="menu-item-61796" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-61796"><a href="http://psnc.org.uk/services-commissioning/advanced-services/flu-vaccination-service/">Flu Vaccination Service</a></li>
+		<li id="menu-item-984" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-984"><a href="http://psnc.org.uk/services-commissioning/advanced-services/murs/">MUR</a></li>
+		<li id="menu-item-983" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-983"><a href="http://psnc.org.uk/services-commissioning/advanced-services/nms/">NMS</a></li>
+		<li id="menu-item-2486" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2486"><a href="http://psnc.org.uk/services-commissioning/advanced-services/aurs/">AUR</a></li>
+		<li id="menu-item-2485" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2485"><a href="http://psnc.org.uk/services-commissioning/advanced-services/sac/">SAC</a></li>
+		<li id="menu-item-135096" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135096"><a href="http://psnc.org.uk/services-commissioning/urgent-medicine-supply-service/">NHS Urgent Medicine Supply Advanced Service (NUMSAS)</a></li>
+	</ul>
+</li>
+	<li id="menu-item-993" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-993"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/">Local Services</a>
+	<ul class="child-menu">
+		<li id="menu-item-136273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-136273"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/healthy-living-pharmacies/">Healthy Living Pharmacies</a></li>
+		<li id="menu-item-18500" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18500"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/">Service specifications &#038; resources</a></li>
+		<li id="menu-item-90597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-90597"><a href="http://psnc.org.uk/services-commissioning/essential-facts-stats-and-quotes/">Essential facts, stats &#038; quotes</a></li>
+		<li id="menu-item-2198" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2198"><a href="http://psnc.org.uk/services-commissioning/services-database/">Services Database</a></li>
+		<li id="menu-item-5772" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5772"><a href="http://psnc.org.uk/services-commissioning/pharmoutcomes/">PharmOutcomes</a></li>
+		<li id="menu-item-53437" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53437"><a href="http://psnc.org.uk/services-commissioning/commissioners-portal/">Commissioners Portal</a></li>
+	</ul>
+</li>
+	<li id="menu-item-52550" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-52550"><a>Other resources</a>
+	<ul class="child-menu">
+		<li id="menu-item-135155" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135155"><a href="http://psnc.org.uk/services-commissioning/essential-services/quality-payments/">Quality Payments</a></li>
+		<li id="menu-item-79879" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79879"><a href="http://psnc.org.uk/services-commissioning/antibiotic-resistance-2/">Antibiotic resistance</a></li>
+		<li id="menu-item-2886" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2886"><a href="http://psnc.org.uk/services-commissioning/working-with-gps/">Working with GPs</a></li>
+		<li id="menu-item-5774" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5774"><a href="http://psnc.org.uk/services-commissioning/working-with-hospital-colleagues/">Working with hospital colleagues</a></li>
+		<li id="menu-item-5619" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5619"><a href="/our-latest-news-category/services-commissioning/">News</a></li>
+		<li id="menu-item-5122" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5122"><a href="http://psnc.org.uk/services-commissioning/psnc-briefings-services-and-commissioning/">PSNC Briefings</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-2370" class="menu-the-healthcare-landscape menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2370"><a href="http://psnc.org.uk/the-healthcare-landscape/">The Healthcare Landscape</a>
+<ul class="child-menu">
+	<li id="menu-item-5047" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-5047"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/">Healthcare who&#8217;s who</a>
+	<ul class="child-menu">
+		<li id="menu-item-5046" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5046"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/nhs-england/">NHS England</a></li>
+		<li id="menu-item-5050" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5050"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/clinical-commissioning-groups-ccg/">Clinical Commissioning Groups</a></li>
+		<li id="menu-item-5049" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5049"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/local-authorities-local-government/">Local Authorities (local government)</a></li>
+		<li id="menu-item-5045" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5045"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/local-professional-networks/">Local Professional Networks</a></li>
+		<li id="menu-item-5048" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5048"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/public-health-england/">Public Health England</a></li>
+	</ul>
+</li>
+	<li id="menu-item-62175" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62175"><a>Health &#038; care policy</a>
+	<ul class="child-menu">
+		<li id="menu-item-16051" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16051"><a href="http://psnc.org.uk/the-healthcare-landscape/the-nhs-five-year-forward-view-5yfv/">The NHS Five-Year Forward View (5YFV)</a></li>
+		<li id="menu-item-62196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62196"><a href="http://psnc.org.uk/the-healthcare-landscape/urgent-and-emergency-care/">Urgent &#038; emergency care</a></li>
+		<li id="menu-item-62192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62192"><a href="http://psnc.org.uk/the-healthcare-landscape/better-care-fund/">Better Care Fund</a></li>
+		<li id="menu-item-100351" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-100351"><a href="http://psnc.org.uk/the-healthcare-landscape/sustainability-and-transformation-plans/">Sustainability &#038; Transformation Partnerships</a></li>
+		<li id="menu-item-152133" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152133"><a href="http://psnc.org.uk/contract-it/pharmacy-it/policy-the-nhs-and-it/">NHS &#038; IT</a></li>
+	</ul>
+</li>
+	<li id="menu-item-62177" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62177"><a>Current initiatives</a>
+	<ul class="child-menu">
+		<li id="menu-item-62185" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62185"><a href="http://psnc.org.uk/the-healthcare-landscape/prime-ministers-challenge-fund/">Prime Minister’s GP Access Fund</a></li>
+		<li id="menu-item-62189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62189"><a href="http://psnc.org.uk/the-healthcare-landscape/new-models-of-care-vanguard-sites/">Vanguard sites</a></li>
+		<li id="menu-item-16052" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16052"><a href="http://psnc.org.uk/the-healthcare-landscape/co-commissioning-of-primary-care-services/">Co-commissioning of primary care services</a></li>
+		<li id="menu-item-63206" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-63206"><a href="http://psnc.org.uk/the-healthcare-landscape/nhs-diabetes-prevention-programme/">NHS Diabetes Prevention Programme</a></li>
+	</ul>
+</li>
+	<li id="menu-item-62201" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62201"><a>Other resources</a>
+	<ul class="child-menu">
+		<li id="menu-item-135153" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135153"><a href="http://psnc.org.uk/the-healthcare-landscape/the-pharmacy-integration-fund-phif/">Pharmacy Integration Fund</a></li>
+		<li id="menu-item-5620" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5620"><a href="/our-latest-news-category/the-healthcare-landscape/">News</a></li>
+		<li id="menu-item-5065" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5065"><a href="http://psnc.org.uk/the-healthcare-landscape/psnc-briefings-the-healthcare-landscape/">PSNC Briefings</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-2471" class="menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2471"><a href="http://psnc.org.uk/lpcs/">LPCs</a>
+<ul class="child-menu">
+	<li id="menu-item-2476" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2476"><a href="http://psnc.org.uk/lpcs/about-lpcs/">About LPCs</a>
+	<ul class="child-menu">
+		<li id="menu-item-2483" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2483"><a href="/lpconline">LPC sites</a></li>
+		<li id="menu-item-152179" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152179"><a href="http://psnc.org.uk/lpcs/lpcs-in-the-spotlight/">LPCs in the Spotlight</a></li>
+	</ul>
+</li>
+	<li id="menu-item-53508" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-53508"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/">Communications &#038; lobbying</a>
+	<ul class="child-menu">
+		<li id="menu-item-53507" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53507"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/communications-and-pr/working-with-commissioners/">Working with commissioners</a></li>
+		<li id="menu-item-53509" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53509"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/communications-and-pr/working-with-commissioners/thinkpharmacy/">Think Pharmacy</a></li>
+		<li id="menu-item-183161" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-183161"><a href="http://psnc.org.uk/lpcs/healthcare-together/">Healthcare Together</a></li>
+	</ul>
+</li>
+	<li id="menu-item-4664" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-4664"><a href="http://psnc.org.uk/lpcs/lpc-members-area/">LPC Members&#8217; Area</a>
+	<ul class="child-menu">
+		<li id="menu-item-7116" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7116"><a href="http://psnc.org.uk/lpcs/about-lpcs/lpc-events/">LPC events</a></li>
+		<li id="menu-item-7115" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7115"><a href="http://psnc.org.uk/lpcs/lpc-members-area/lpc-member-changes/">LPC member changes</a></li>
+		<li id="menu-item-79936" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79936"><a href="http://psnc.org.uk/lpcs/lpc-members-area/psnc-leadership-academy/">PSNC Leadership Academy</a></li>
+	</ul>
+</li>
+	<li id="menu-item-5621" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-5621"><a href="/our-latest-news-category/latest-lpc-news/">LPC News</a>
+	<ul class="child-menu">
+		<li id="menu-item-11775" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-11775"><a href="http://psnc.org.uk/lpcs/lposs/">Local Pharmacy Organisation Support Services (LPOSS)</a></li>
+		<li id="menu-item-199483" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-199483"><a href="http://psnc.org.uk/podcast">Podcasts</a></li>
+		<li id="menu-item-9150" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9150"><a href="http://psnc.org.uk/lpcs/psnc-briefings/">PSNC Briefings</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+</ul>						</div>
+						<!-- /wrapper -->
+					</nav>
+					<!-- /main-nav -->
+					
+					
+					<!-- mobile-nav -->
+											<script type="text/javascript">
+							jQuery(document).ready(function(){
+								jQuery('.main-nav.mobileelement').hide();
+								jQuery(".show-hide.main-menu a").click(function(){
+									jQuery('.main-nav.mobileelement').slideToggle("fast");
+									jQuery(this).toggleClass("open");
+									return false;
+								});
+							});
+						</script>
+						<div class="show-hide main-menu mobileelement sixteen columns clear"><a href="#">Main menu</a></div>				
+										
+					<nav class="main-nav mobileelement" role="navigation">
+												<div class="wrapper clear">
+							<ul id="menu-main-navigation-1" class="menu root-menu"><li class="menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-248"><a href="http://psnc.org.uk/psncs-work/">PSNC&#8217;s Work</a></li>
+<li class="menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16135"><a href="http://psnc.org.uk/funding-and-statistics/">Funding and Statistics</a></li>
+<li class="menu-pharmacy-contract-and-funding menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-247"><a href="http://psnc.org.uk/contract-it/">Contract and IT</a></li>
+<li class="menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children menu-item-244"><a href="http://psnc.org.uk/dispensing-supply/">Dispensing and Supply</a></li>
+<li class="menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-249"><a href="http://psnc.org.uk/services-commissioning/">Services and Commissioning</a></li>
+<li class="menu-the-healthcare-landscape menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2370"><a href="http://psnc.org.uk/the-healthcare-landscape/">The Healthcare Landscape</a></li>
+<li class="menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2471"><a href="http://psnc.org.uk/lpcs/">LPCs</a></li>
+</ul>						</div>
+						<!-- /wrapper -->
+						
+					</nav>
+					<!-- /mobile-nav -->
+			
+			</header>
+			<!-- /header -->			
+			
+			
+			
+			
+	<div role="main" class="wrapper clear">		<div class="sidebar-nav four columns">
+						<nav>
+				<ul>
+					<li class="hideformobile"><a href="http://psnc.org.uk" class="back-home">Home</a></li>
+					<!-- mobile navigation toggle -->
+					<li class="mobileelement toggle">
+						<script type="text/javascript">
+							jQuery(document).ready(function($){
+								if ($(window).width() < 500) {
+									$(".sidebar-nav ul li.page_item").hide();
+									$(".sidebar-nav ul li a.parent-page").hide();
+									$(".show-hide.sidebar a").click(function(){
+										$('.sidebar-nav ul li.page_item').slideToggle("fast");
+										$(this).toggleClass("open");
+										return false;
+									});
+								}
+							});
+						</script>
+						<div class="show-hide sidebar mobileelement"><a href="#">Show/Hide all pages in Dispensing and Supply section</a></div>
+					</li>
+					<li class="pagenav"><a href="http://psnc.org.uk/dispensing-supply" class="parent-page">Dispensing and Supply</a><ul><li class="page_item page-item-218273"><a href="http://psnc.org.uk/dispensing-supply/digitisation-of-the-prescription-submission-fp34c-form-referred-back-items/">Digitisation of the Prescription Submission (FP34C) Form &#038; Referred Back Items</a></li>
+<li class="page_item page-item-589 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/">Dispensing a prescription</a>
+<ul class='children'>
+	<li class="page_item page-item-2292"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/appliances/">Appliances</a></li>
+	<li class="page_item page-item-333"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/medicinal-products/">Medicinal products</a></li>
+	<li class="page_item page-item-2298"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/quantity/">Quantity</a></li>
+	<li class="page_item page-item-547 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/special-containers/">Special containers (including dispensing of oral liquid antibiotics requiring reconstitution)</a>
+	<ul class='children'>
+		<li class="page_item page-item-2304"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/special-containers/special-container-database/">Special Container Database</a></li>
+	</ul>
+</li>
+	<li class="page_item page-item-2301"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/split-pack-dispensing/">Split pack dispensing</a></li>
+	<li class="page_item page-item-1442"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/unlicensed-specials-and-imports/">Unlicensed specials and imports</a></li>
+</ul>
+</li>
+<li class="page_item page-item-593 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/">Dispensing Controlled Drugs</a>
+<ul class='children'>
+	<li class="page_item page-item-1744"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/controlled-drug-prescription-forms-validity/">Controlled Drug prescription forms and validity</a></li>
+	<li class="page_item page-item-1718"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/controlled-drug-resources-faqs/">Controlled Drug resources and FAQs</a></li>
+	<li class="page_item page-item-327"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/instalment-dispensing/">Instalment dispensing</a></li>
+	<li class="page_item page-item-1732"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/methadone-dispensing/">Methadone dispensing (FP10 and FP10MDA)</a></li>
+</ul>
+</li>
+<li class="page_item page-item-2139 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/">Drug Tariff resources</a>
+<ul class='children'>
+	<li class="page_item page-item-823"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/quick-reference-guides/">Quick reference guides</a></li>
+	<li class="page_item page-item-827"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff</a></li>
+	<li class="page_item page-item-5830"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">Where to obtain external resources</a></li>
+</ul>
+</li>
+<li class="page_item page-item-7358"><a href="http://psnc.org.uk/dispensing-supply/endorsement-payment/">Endorsement and payment</a></li>
+<li class="page_item page-item-386"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS home</a></li>
+<li class="page_item page-item-285 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/">Is this item allowed?</a>
+<ul class='children'>
+	<li class="page_item page-item-2290"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/common-disallowed-appliances-list/">Common Disallowed Appliances List</a></li>
+	<li class="page_item page-item-20682"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/fp10database/">Dispensing on an FP10 database</a></li>
+</ul>
+</li>
+<li class="page_item page-item-600 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/endorsement/">Item endorsement and pricing</a>
+<ul class='children'>
+	<li class="page_item page-item-363"><a href="http://psnc.org.uk/dispensing-supply/endorsement/endorsement-guidance/">Endorsement guidance</a></li>
+	<li class="page_item page-item-797 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/">Fees and allowances</a>
+	<ul class='children'>
+		<li class="page_item page-item-72"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/bb/">Broken bulk</a></li>
+		<li class="page_item page-item-402"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/consumables-containers/">Consumables and container allowance</a></li>
+		<li class="page_item page-item-56"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/oop/">Out of pocket expenses</a></li>
+	</ul>
+</li>
+	<li class="page_item page-item-405"><a href="http://psnc.org.uk/dispensing-supply/endorsement/discount-deduction/">How discount deduction works</a></li>
+	<li class="page_item page-item-2309"><a href="http://psnc.org.uk/dispensing-supply/endorsement/how-the-price-change-mechanism-works/">How the price change mechanism works</a></li>
+</ul>
+</li>
+<li class="page_item page-item-2215 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/">Prescription payment and pricing accuracy</a>
+<ul class='children'>
+	<li class="page_item page-item-90120"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/common-issues-that-can-lead-to-pricing-errors/">Common issues that can lead to pricing errors</a></li>
+	<li class="page_item page-item-605"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/monthly-payments/">Monthly payments</a></li>
+	<li class="page_item page-item-14954"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-payment-and-pricing-accuracy-factsheets/">Prescription payment and pricing accuracy factsheets</a></li>
+	<li class="page_item page-item-607"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-pricing-accuracy/">Prescription pricing accuracy</a></li>
+	<li class="page_item page-item-602"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-submission/">Prescription submission</a></li>
+</ul>
+</li>
+<li class="page_item page-item-3660"><a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing and Supply</a></li>
+<li class="page_item page-item-375 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/">Receiving a prescription</a>
+<ul class='children'>
+	<li class="page_item page-item-2280 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/is-this-prescription-form-valid/">Is this prescription form valid?</a>
+	<ul class='children'>
+		<li class="page_item page-item-7592"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/is-this-prescription-form-valid/period-of-validity/">How long is a prescription valid for?</a></li>
+	</ul>
+</li>
+	<li class="page_item page-item-2283"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/how-to-identify-prescriber-codes/">Prescriber codes</a></li>
+	<li class="page_item page-item-368 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/">What does the patient pay?</a>
+	<ul class='children'>
+		<li class="page_item page-item-384"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/exemptions/">Exemptions from the prescription charge</a></li>
+		<li class="page_item page-item-12946"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/prescription-charge-card/">Prescription Charge Card and Multi Charge Card</a></li>
+		<li class="page_item page-item-381"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/refunds/">Prescription charge refund procedure</a></li>
+	</ul>
+</li>
+	<li class="page_item page-item-2285"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/who-can-prescribe-what/">Who can prescribe what?</a></li>
+</ul>
+</li>
+<li class="page_item page-item-2106 page_item_has_children current_page_ancestor current_page_parent"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/">Supply chain and shortages</a>
+<ul class='children'>
+	<li class="page_item page-item-227 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/">Branded medicine shortages</a>
+	<ul class='children'>
+		<li class="page_item page-item-1467"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/branded-shortages-list/">Branded supply problems</a></li>
+	</ul>
+</li>
+	<li class="page_item page-item-598"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/distribution-of-medicines/">Distribution of medicines</a></li>
+	<li class="page_item page-item-1473"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer contingency arrangements</a></li>
+	<li class="page_item page-item-100786 current_page_item"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions and NCSO</a></li>
+	<li class="page_item page-item-6739 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/">Supply issue feedback forms</a>
+	<ul class='children'>
+		<li class="page_item page-item-1910"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-a-branded-medicine/">Problems obtaining a branded medicine?</a></li>
+		<li class="page_item page-item-3115"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Problems obtaining a generic medicine?</a></li>
+		<li class="page_item page-item-229"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Problems obtaining an appliance?</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class="page_item page-item-2032"><a href="http://psnc.org.uk/dispensing-supply/dispensing-process/">The dispensing process</a></li>
+</ul></li>					
+					
+				</ul>
+			</nav>
+		</div>
+		<!-- /sidebar-nav -->
+		
+		
+		<div class="page-content twelve columns">
+		
+			<div class="breadcrumb fifteen columns"><a href='http://psnc.org.uk'>Home</a> > <a href=http://psnc.org.uk/dispensing-supply/supply-chain/>Dispensing and Supply</a> > Price Concessions and NCSO </div><div class="one column"><div class='printomatic pom-default ' id='id5989'  data-print_target='.page-content'></div> </div><br />
+		
+			<h1 class="mobileelement" style="margin:0.5em 0 0 0; clear: left; float: left; width: 100%;">Price Concessions and NCSO</h1>
+
+			<!-- post thumbnail -->
+							<img src="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image-250x96.jpg 250w, http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />						<!-- /post thumbnail -->
+			
+			
+			<div class="banner-ad page">
+						</div>
+			<!-- /banner-ad -->
+			
+						<h1 class="hideformobile">Price Concessions and NCSO</h1>
+
+	
+						
+						
+			
+						<!-- article -->
+						<article id="post-100786" class="post-100786 page type-page status-publish has-post-thumbnail hentry">
+						
+							<!-- AddThis Sharing Buttons above --><p><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/"><img class="alignnone wp-image-100869" src="http://psnc.org.uk/wp-content/uploads/2016/05/button-final.png" alt="button final" width="280" height="42" srcset="http://psnc.org.uk/wp-content/uploads/2016/05/button-final.png 420w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final-250x38.png 250w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final-120x18.png 120w" sizes="(max-width: 280px) 100vw, 280px" /></a>  <a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/"><img class="alignnone wp-image-100868" src="http://psnc.org.uk/wp-content/uploads/2016/05/button-final1.png" alt="button final1" width="280" height="42" srcset="http://psnc.org.uk/wp-content/uploads/2016/05/button-final1.png 420w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final1-250x38.png 250w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final1-120x18.png 120w" sizes="(max-width: 280px) 100vw, 280px" /></a></p>
+<table class="alignright" style="height: 211px;" border="0" width="308">
+<tbody>
+<tr style="height: 65px;">
+<td class="lastcol" style="height: 65px; width: 298px; background-color: #659200;">
+<h3 style="text-align: center;"><span style="color: #ffffff;">QUICK LINKS</span></h3>
+</td>
+</tr>
+<tr style="height: 48px;">
+<td style="width: 298px; height: 48px;"><a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/237071/dh_063440_1_.pdf">BGMA best practice guidelines on notification of medicines shortages</a></td>
+</tr>
+<tr style="height: 24px;">
+<td class="lastcol" style="height: 24px; width: 298px;"><a title="NCSO/ Price Concession Archive" href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">Price Concession and NCSO Archive</a></td>
+</tr>
+<tr style="height: 24px;">
+<td class="lastcol lastrow" style="height: 24px; width: 298px;"><a title="Online Drug Tariff" href="http://www.ppa.org.uk/ppa/edt_intro.htm" target="_blank" rel="noopener noreferrer">REF: Drug Tariff Part II, Clause 8B and 9C</a></td>
+</tr>
+</tbody>
+</table>
+<h1>November 2017</h1>
+<p><span style="color: #ff0000;"><strong>Latest information:</strong></span> <a href="http://psnc.org.uk/our-news/november-price-concession-update/">November Price Concessions Update</a></p>
+<table style="width: 476px;">
+<tbody>
+<tr>
+<td style="width: 304px;"><strong>Drug</strong></td>
+<td style="width: 61px;"><strong>Pack size</strong></td>
+<td style="width: 97px;"><strong>Price Concession</strong></td>
+</tr>
+<tr>
+<td style="width: 304px;">Amiloride 5mg tablets</td>
+<td style="width: 61px;">28</td>
+<td style="width: 97px;">£9.25</td>
+</tr>
+</tbody>
+</table>
+
+<table style="width: 476px;">
+<tbody>
+<tr>
+<td style="width: 304px;"><strong>Drug</strong></td>
+<td style="width: 61px;"><strong>Pack size</strong></td>
+<td style="width: 97px;"><strong>Price Concession</strong></td>
+</tr>
+<tr>
+<td style="width: 304px;">Amlodipine 5mg tablets (new)</td>
+<td style="width: 61px;">28</td>
+<td style="width: 97px;">£3.75</td>
+</tr>
+</tbody>
+</table>
+<p><strong>The price concession only applies to the month that it is granted.</strong></p>
+<p><strong style="line-height: 1.5;">PSNC cannot provide details of generic products that are suspected of being affected by generic supply problems unless and until the Department of Health grants a concession.</strong><strong>Please note negotiations are still ongoing regarding a number of products.</strong></p>
+<p>Updates on price concessions will be shown on this page or you can <a href="http://psnc.org.uk/latest-news/email-sign-up/" target="_blank" rel="noopener noreferrer">sign up</a> to receive price concession alerts and updates by email.</p>
+<hr />
+<p>All drugs listed in Part VIII of the Drug Tariff are eligible for price concessions and ‘No Cheaper Stock Obtainable’ (NCSO) status.</p>
+<p>Occasionally there are shortages of these products, for example, if there are manufacturing problems or a change in demand, resulting in pharmacy contractors having to dispense an equivalent product that is only available above the set Drug Tariff price.</p>
+<p>When this happens, PSNC is able to apply to the Department of Health for either a price concession or NCSO status for that particular month.</p>
+<h2>What is a price concession?</h2>
+<p>The Department of Health could consider setting a price concession for products listed in Part VIIIA and Part VIIIB where they are available above the set Drug Tariff reimbursement price. Pharmacy contractors will be automatically reimbursed based on the set price rather than the Drug Tariff listed price. There is no need for any endorsement.</p>
+<p>Applications are made in month and once the price concession has been announced, it only lasts for the month in which it is granted. Where problems persist into the following month a new application is made. It is possible that a new concession will be granted by the Department of Health for subsequent months; however, these are subject to application and are not guaranteed.</p>
+<p>The Department of Health set price concessions using information derived from manufacturers and wholesalers.  Where contractors are unable to purchase products at the set prices, they may wish to challenge suppliers for an explanation of why their prices are so high.  Where contractors are unable to secure products at or near the concessionary price, PSNC would like to receive copies of invoices for monitoring of prices.  Please email these to <a href="mailto:info@psnc.org.uk" target="_blank" rel="noopener noreferrer">info@psnc.org.uk</a> or fax to 0207 278 1127  for the attention of the Dispensing and Supply Team.</p>
+<h2>Reporting generic supply issues</h2>
+<div>
+<p>If you have problems obtaining a Part VIII product at the set Drug Tariff price, please report the issue using our <a title="Problems obtaining a generic medicine" href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">online feedback form</a>. PSNC will investigate the extent of the problem and where necessary discuss the issue with the Department of Health.</p>
+<p>Please note, PSNC is unable to provide details of generic products that are suspected of being affected by generic supply problems unless and until the Department of Health grants a concession.</p>
+<p>Contractors will be alerted to any updates through our website and via our e-news email.  You can subscribe to our mailing list by <a title="Newsletter Sign Up" href="http://psnc.org.uk/latest-news/email-sign-up/">clicking here</a>.</p>
+<p>Sometimes a price concession or NCSO is granted late in the month, this is due to changing stock levels within the month.  Contractors are advised to procure as economically as is possible for their individual businesses.</p>
+<hr />
+<h2>FAQs</h2>
+<p><strong>Q. How long do price concessions or NCSOs last?</strong></p>
+<div>
+<p>A. If price concessions or NCSOs are granted, it is valid until the end of the month in which it was granted. PSNC needs to apply/re-apply for concessions on a monthly basis. If there is an on-going supply problem, it is possible that a new concession will be granted by the Department of Health the following month; however, this is not guaranteed.</p>
+<p><strong>Q. Why do contractors need to report generic shortages each month? If a price concession or NCSO is granted in one month and is still a problem in the next month why doesn&#8217;t the price roll over?</strong></p>
+<div>
+<p>A. Price concessions  and NCSOs only apply for the month in which they are granted. Because the market fluctuates on a regular basis in terms of stock levels and prices it would not be appropriate to roll the price over from one month to the next.</p>
+<p>PSNC regularly monitors the market through contractor reports and communications with wholesalers. Where appropriate, we apply to the Department of Health for price concessions on products which aren&#8217;t available at Drug Tariff price.  As stock levels and prices can vary across the country, we rely on contractor reports to help feed into our market surveillance and our discussions with the Department of Health. It is also important to note that the Department may not act on something unless contractors have reported it.</p>
+</div>
+<p><strong>Q. Why aren’t price concessions or NCSOs granted on the first day of each month?</strong></p>
+<div>
+<p>A. If there is a supply issue, PSNC needs to make a fresh concession application at the start of each month. The Department of Health then take time to undertake checks and make a decision. In some cases, there is a need for negotiation between PSNC and the Department of Health on an individual product’s circumstances; this can take time.</p>
+<p>PSNC would like to see changes to the arrangements that would allow contractors to have certainty over what they will be reimbursed, much earlier in the month, a point which we have raised with the Department of Health.</p>
+<p><strong>Q. If a medicine is granted a price concession or NCSO , are all strengths of the product covered by the price concession or NCSO ?</strong></p>
+<div>
+<p>A. No, concessions are granted to specific strengths of a product so contractors must check the latest list so they know which strengths have been granted a concession.</p>
+<p><strong>Q. What happens if a price concession is announced after the date that I have sent my EPS claim message to the Pricing Authority for an EPSR2 prescription?</strong></p>
+<div>
+<p>A. Price concessions, once granted, apply for the whole ‘dispensing month’. For example a price concession announced on August 30th applies to the entirety of your August ‘prescription bundle’.</p>
+<p>Your August prescription bundle is made up of all your paper prescriptions which are sent to the Pricing Authority by the 5th September and all the EPS prescriptions which fall into the August dispensing month (see below). Prescriptions for any one dispensing month are not priced until the Pricing Authority receives both the electronic and paper prescriptions as the FP34C submission document is needed from the paper bundle to calculate the advance payment for the contractor.</p>
+<p>How a dispensing month is determined for electronic prescriptions is outlined below:</p>
+<p><img src="http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table.png" sizes="(max-width: 590px) 100vw, 590px" srcset="http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table.png 896w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-250x129.png 250w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-700x363.png 700w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-120x62.png 120w" alt="eps timing mini table" width="590" height="306" /></p>
+<p><strong>Q. I have received a prescription for &#8217;28 x 5mg tablets&#8217;; however, there is currently a supply issue with that strength and we can only purchase it above Drug Tariff price. The 2.5mg strength is available and works out at the same Drug Tariff price so can I dispense &#8217;56 x 2.5mg tablets&#8217; instead?</strong></p>
+<div>
+<p>A. No. Reimbursement will be based on the prescribed strength and quantity (Please note that the ‘PC’ endorsement is not a sufficient endorsement in this situation).  If contractors believe it is in the patients best interest to ‘double up’ to support patient care, contractors are advised to return the prescription to the prescriber so they can make a clinical decision and if necessary amend the prescription to ensure correct reimbursement.</p>
+<div>
+<p><strong>Q. I have been told by my wholesaler that a Part VIIIA licensed generic product is unavailable. There is not an alternative proprietary product available but a specials manufacturer can prepare this product for me. Can a price concession or NCSO  be requested?</strong></p>
+<div>
+<p>A. No. The Department of Health’s view is that the prescription should be referred back to the prescriber so that they have the opportunity to prescribe an alternative licensed product and/or are aware of the changes in liability caused by an unlicensed product being given to the patient. If the prescriber believes that the product should be specially manufactured, the prescription should be amended to specify “unlicensed special” within the product description. If the prescriber has stated the name of the specials manufacturer, the Pricing Authority will pay based on the endorsed invoice price for the specially manufactured product rather than the Drug Tariff Price. Remember that if the prescriber makes a hand written amendment or includes additional product information that does not appear in the product description (i.e. to provide a certain brand), the prescription must be included in the red separator.</p>
+<p>It is helpful to inform the PSNC Dispensing and Supply Team about the shortage. If there is a long term supply problem, PSNC can make an application to the Department of Health to remove the product from the Drug Tariff.</p>
+<p><a title="Unlicensed specials and imports" href="http://www.psnc.org.uk/dispensing-supply/dispensing-a-prescription/unlicensed-specials-and-imports/">More information on the dispensing of unlicensed medicines is available in this section of our site.</a></p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<p>&nbsp;</p>
+<div>
+<p><strong>Q. I have received a prescription for a Part VIIIB unlicensed medicine but cannot obtain it at the Part VIIIB price, what should I do?</strong></p>
+<div>
+<p>A. Unless there are exceptional circumstances pharmacy contractors should be able to purchase the products in Part VIIIB at or below the Drug Tariff price. Pharmacy contractors will need to ensure they have considered a range of suppliers and where they are still having difficulties, pharmacy contractors should contact PSNC who will then be able to investigate the situation and apply to the DH for a price concession or NCSO if appropriate.</p>
+<h2 class="trigger">What is NCSO status?</h2><div class="toggle_container"></p>
+<p>No Cheaper Stock Obtainable (NCSO) status, is granted for products listed in Part VIIIA &amp; Part VIIIB of the Drug Tariff where pharmacy contractors have been unable to purchase product at the set Drug Tariff reimbursement price.</p>
+<p>Where a NCSO is granted, the reimbursement price is based upon the appropriate prescription endorsement rather than the fixed Drug Tariff price. However, it is essential that contractors <a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/#endorsing">endorse the prescription fully</a>.</p>
+<p>Applications are made in month and once the NCSO status has been announced, it only lasts for the month in which it is granted. Where problems persist into the following month, a new application may be made. It is possible that a new concession will be granted by the Department of Health for subsequent months; however, these are subject to application and are not guaranteed.</p>
+<h2>NCSO endorsing guide</h2>
+<div>
+<p>Given the number of products in short supply at present, contractors may want to consider undertaking an additional check during their end of month prescription submission process, to ensure that all prescriptions have been endorsed correctly, where necessary. Key things to consider:</p>
+<ul>
+<li>The NCSO is granted at different times during the month; have staff been giving consideration to whether the concession needs to be claimed for all products on the NCSO list?</li>
+<li>Where staff have endorsed to claim the NCSO, does the endorsement include all of the necessary information? In checks PSNC has undertaken on endorsing practice, the most common omission is the initial for the dispenser (any authorised staff member can add the initial, it doesn’t need to be the pharmacist. The initials can be computer generated).</li>
+<li>If the Pricing Authority do not have a price on their system for the endorsed brand or supplier, the endorsement must also include the price paid (before discount and ex VAT). An indication of which suppliers are listed on the NHS RxS system for a particular product is available through the <a href="http://dmd.medicines.org.uk/" target="_blank" rel="noopener noreferrer">Dictionary of Medicines and Devices</a> browser.</li>
+<li>The Pricing Authority will only reimburse based on an NCSO endorsement where a prescription has been submitted in the month that the NCSO has been granted. Care should be taken to ensure that prescriptions dispensed in a particular month are submitted with that month’s prescription bundle.</li>
+</ul>
+<p>For further information,  see our guidance on NCSOs:  <a href="http://www.psnc.org.uk/wp-content/uploads/2013/05/NCSO_Endorsement_Guidance_and_FAQs_May_13.pdf">NCSO Endorsement Guidance and FAQs (May 13)</a>.</p>
+<h2>NCSO Endorsement FAQs</h2>
+<p><strong>Q. Do I need to include the name of the supplier or is just the price acceptable for NCSO endorsements?</strong></p>
+<p>A. It is essential to endorse the following:</p>
+<ul>
+<li>NCSO</li>
+<li>Pharmacist initials</li>
+<li>Date</li>
+<li>Supplier, manufacturer or brand name;</li>
+<li>Pack size</li>
+<li>Price if appropriate</li>
+</ul>
+<p>If this information is missing, even if a price has been endorsed, the NCSO claim will not be accepted by the Pricing Authority.</p>
+<p><strong>Q. Does it need to be the pharmacist that initials the NCSO endorsement?</strong></p>
+<p>A. No, it can be any staff member who has been authorised by the pharmacy owner. It doesn’t need to be the pharmacist.</p>
+<p><strong>Q. Is it acceptable to provide a fully computer-generated NCSO endorsement or do any parts of this endorsement need to be handwritten?</strong></p>
+<p>A. It is acceptable for the NCSO endorsement (including the date and initials of the staff member making the endorsement) to be computer-generated.</p>
+<p><strong>Q. Can I endorse ‘NCSO’ for any item I am unable to purchase at the Drug Tariff Part VIII price?</strong></p>
+<p>A. No. No Cheaper Stock Obtainable (NCSO) products are items for which in the opinion of the Secretary of State for Health and the Welsh Ministers there is no product available to contractors at the price in Part VIII of the Drug Tariff. In this scenario the Pricing Authority will only reimburse based on a full NCSO endorsement against those items which have been granted this status.</p>
+<p><strong>Q. Can I endorse that I have given a branded product against a prescription for the Part VIIIA generic item and be reimbursed for doing so?</strong></p>
+<div>
+<p>Contractors will only be reimbursed for a branded equivalent if the NCSO has been granted for that product in that dispensing month, and the prescription has been endorsed fully to claim the concession (see endorsing guidance above).</p>
+</div>
+<p></div>
+<p>&nbsp;</p>
+</div>
+</div>
+</div>
+<!-- AddThis Sharing Buttons below --><div class="addthis_toolbox addthis_default_style" addthis:url='http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/' ><a class="addthis_button_twitter"></a><a class="addthis_button_facebook"></a><a class="addthis_button_linkedin"></a><a class="addthis_button_email"></a><a class="addthis_button_compact"></a><a class="addthis_counter addthis_bubble_style"></a></div>							
+							<br class="clear">
+							
+													
+						</article>
+						<!-- /article -->	
+						
+										
+						
+				
+				
+		</div>
+		<!-- /page-content -->
+		
+		<hr>
+	
+		<div class="page-news-releases sixteen columns">
+			
+			<!-- Conditional news items. Structure:
+				1. Checks if is a main site section OR an ancestor of the section parent
+				2. Sets the correct arguments to query the correct taxonomy
+				3. Opens a div to enable specific colouring
+				4. <h2> Title
+				5. Content
+			 -->
+							<div class="ds-news">
+				<h2>Latest Dispensing and Supply news</h2>
+				<p class="view-more"><a href="http://psnc.org.uk/our-latest-news-category/dispensing-and-supply/" >View more Dispensing and Supply news ></a></p>
+						<!-- End conditional news items -->
+					<div style="clear:both; height:10px; width:100%;"></div>
+					<div class="slider4col">
+											
+								
+								<!-- article -->
+								<article id="post-233323"  class="news-box">
+									<!-- post thumbnail -->
+									<div class="news-thumb clear">
+																			<a href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/" title="Drug shortages featured in national press">
+											<img src="http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image-250x95.jpg 250w, http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />										</a>
+																			</div>
+									<!-- /post thumbnail -->
+									<!-- post title -->
+									<h3>
+										<a href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/" title="Drug shortages featured in national press">Drug shortages featured in national press</a>
+									</h3>
+									<!-- /post title -->
+									<p>The front cover of this morning&#8217;s (Thursday 7th December) The Times featured an article raising concerns about patients not being able...<a class="view-article" href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/"></a></p>																	</article>
+								<!-- /article -->
+								
+																
+														
+							
+												
+								
+								<!-- article -->
+								<article id="post-225998"  class="news-box">
+									<!-- post thumbnail -->
+									<div class="news-thumb clear">
+																			<a href="http://psnc.org.uk/our-news/november-price-concession-update/" title="November Price Concession Update">
+											<img src="http://psnc.org.uk/wp-content/uploads/2015/09/Drug-Tariff-300x115.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" />										</a>
+																			</div>
+									<!-- /post thumbnail -->
+									<!-- post title -->
+									<h3>
+										<a href="http://psnc.org.uk/our-news/november-price-concession-update/" title="November Price Concession Update">November Price Concession Update</a>
+									</h3>
+									<!-- /post title -->
+									<p>Update as of 5th December: We continue to press DH and they have confirmed November price concessions are still under consideration....<a class="view-article" href="http://psnc.org.uk/our-news/november-price-concession-update/"></a></p>																	</article>
+								<!-- /article -->
+								
+																
+														
+							
+												
+								
+								<!-- article -->
+								<article id="post-226039"  class="news-box">
+									<!-- post thumbnail -->
+									<div class="news-thumb clear">
+																			<a href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/" title="NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year">
+											<img src="http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image-250x95.jpg 250w, http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />										</a>
+																			</div>
+									<!-- /post thumbnail -->
+									<!-- post title -->
+									<h3>
+										<a href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/" title="NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year">NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year</a>
+									</h3>
+									<!-- /post title -->
+									<p>NHS England has today issued guidance to GPs and CCGs to &#8220;remove ineffective, unsafe and low clinical value treatments, such...<a class="view-article" href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/"></a></p>																	</article>
+								<!-- /article -->
+								
+																
+														
+							
+												
+								
+								<!-- article -->
+								<article id="post-225989"  class="news-box">
+									<!-- post thumbnail -->
+									<div class="news-thumb clear">
+																			<a href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/" title="MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)">
+											<img src="http://psnc.org.uk/wp-content/uploads/2013/07/MHRA-for-website-300x115.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" />										</a>
+																			</div>
+									<!-- /post thumbnail -->
+									<!-- post title -->
+									<h3>
+										<a href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/" title="MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)">MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)</a>
+									</h3>
+									<!-- /post title -->
+									<p>CLDA number: CLDA (17) A/05 Date issued: 28th November 2017 The Medicines and Healthcare products Regulatory Agency (MHRA) has issued...<a class="view-article" href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/"></a></p>																	</article>
+								<!-- /article -->
+								
+																
+														
+												</div>
+					<!-- /slider4col -->
+			
+				</div>
+				<!-- end specific news item wrap -->
+		
+		</div>
+		<!-- /home-news-releases -->
+	
+	</div>
+	<!-- /wrapper -->
+
+		<!-- footer -->
+		<footer class="footer" role="contentinfo" >
+			
+			<div class="wrapper clear">
+				
+				<div id="text-2" class="four columns clear widget_text"><h3 class="widgettitle">Contact PSNC</h3>			<div class="textwidget"><p>Tel: 0203 1220 810<br />
+Fax: 0207 278 1127</p>
+<p><a title="Ask PSNC" href="http://askpsnc.org.uk">info@psnc.org.uk</a></p>
+<p>PSNC<br />
+14 Hosier Lane<br />
+London<br />
+EC1A 9LQ<br />
+&nbsp;<br />
+<a title="Contact PSNC" href="http://psnc.org.uk/psncs-work/contact-us/">How to find us</a><br />
+&nbsp;<br />
+<span style="color: #ffffff;"><a href="https://twitter.com/PSNCNews" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @PSNCNews</a></span><br />
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
+</div>
+		</div><div id="frm_show_form-2" class="four columns clear widget_frm_show_form"><div class="frm_form_widget"><h3 class="widgettitle">Newsletter Sign Up</h3><div class="frm_forms " id="frm_form_12_container" >
+<form enctype="multipart/form-data" method="post" class="frm-show-form  frm_pro_form " id="form_uzb6jm"  >
+<div class="frm_form_fields ">
+<fieldset>
+<legend class="frm_hidden">PSNC Newsletter Mailing List Signup</legend>
+
+<input type="hidden" name="frm_action" value="create" />
+<input type="hidden" name="form_id" value="12" />
+<input type="hidden" name="frm_hide_fields_12" id="frm_hide_fields_12" value="" />
+<input type="hidden" name="form_key" value="uzb6jm" />
+<input type="hidden" name="item_meta[0]" value="" />
+<input type="hidden" id="frm_submit_entry_12" name="frm_submit_entry_12" value="8ef29656de" /><input type="hidden" name="_wp_http_referer" value="/dispensing-supply/supply-chain/generic-shortages/" /><input type="text" class="frm_hidden frm_verify" id="frm_verify_12" name="frm_verify" value=""  />
+
+<div id="frm_field_153_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">First Name
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_qnm432" name="item_meta[153]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<div id="frm_field_154_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">Surname
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_jur1w2" name="item_meta[154]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<div id="frm_field_151_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">Email
+        <span class="frm_required">*</span>
+    </label>
+    <input type="email" id="field_rskaik" name="item_meta[151]" value=""  data-reqmsg="This field cannot be blank." data-invmsg="Email is invalid"  />
+
+    <div class="frm_description">Please ensure your email address is correct</div>
+    
+</div>
+<div id="frm_field_155_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">Your organisation
+        <span class="frm_required">*</span>
+    </label>
+    		<select name="item_meta[155]" id="field_nj9ai2"  data-reqmsg="This field cannot be blank."  >
+			<option value=""  selected="selected"> </option>
+				<option value="Community Pharmacy" >Community Pharmacy</option>
+				<option value="Local Pharmaceutical Committee" >Local Pharmaceutical Committee</option>
+				<option value="Other" >Other</option>
+			</select>
+	
+    
+    
+</div>
+<div id="frm_field_157_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">What is the name of your pharmacy?
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_dj4y8h" name="item_meta[157]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<div id="frm_field_162_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">What is your position in the pharmacy?
+        <span class="frm_required">*</span>
+    </label>
+    		<select name="item_meta[162]" id="field_5ss0gx"  data-reqmsg="This field cannot be blank."  >
+			<option value=""  selected="selected"> </option>
+				<option value="Pharmacist" >Pharmacist</option>
+				<option value="Pharmacy Owner" >Pharmacy Owner</option>
+				<option value="Pharmacy Manager" >Pharmacy Manager</option>
+				<option value="Area Manager" >Area Manager</option>
+				<option value="Technician" >Technician</option>
+				<option value="Dispensing Assistant" >Dispensing Assistant</option>
+				<option value="Other" >Other</option>
+			</select>
+	
+    
+    
+</div>
+<div id="frm_field_158_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">What is your pharmacy F-code or ODS code?
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_iqdesw" name="item_meta[158]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    <div class="frm_description">The F-Code or ODS code is the the unique code issued to your pharmacy which identifies you to NHS Prescription Services.  You can find this on any pricing authority statement or your prescription submission document (FP34c).</div>
+    
+</div>
+<div id="frm_field_1715_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label for="field_55kyc" class="frm_primary_label">Which LPC do you work for?
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_55kyc" name="item_meta[1715]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<div id="frm_field_163_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">Please tell us the name of your organisation
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_7gipyc" name="item_meta[163]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<div id="frm_field_161_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+    <label  class="frm_primary_label">What is your position?
+        <span class="frm_required">*</span>
+    </label>
+    <input type="text" id="field_uxyr36" name="item_meta[161]" value=""  data-reqmsg="This field cannot be blank."  />
+
+    
+    
+</div>
+<input type="hidden" name="item_key" value="" />
+<div class="frm_submit">
+
+<input type="submit" value="Submit"  class="frm_final_submit" formnovalidate="formnovalidate" />
+<img class="frm_ajax_loading" src="http://psnc.org.uk/wp-content/plugins/formidable/images/ajax_loader.gif" alt="Sending"/>
+
+</div></fieldset>
+</div>
+</form>
+</div>
+</div></div><div id="text-5" class="four columns clear widget_text"><h3 class="widgettitle">Visit your LPC&#8217;s website</h3>			<div class="textwidget"><a href="http://www.lpc-online.org.uk" target="new"><img class="aligncenter" src="http://psnc.org.uk/wp-content/uploads/2013/08/LPC-Widget-Purple.png" width="171" height="234" /></a></div>
+		</div><div id="text-7" class="four columns clear widget_text"><h3 class="widgettitle">Keep in touch</h3>			<div class="textwidget"><p><a href="http://psnc.org.uk/psncs-work/website/feedback-on-our-site/">Website feedback form</a><br />
+<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Report Generic Medicine Supply Issue</a><br />
+<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-a-branded-medicine/">Report Branded Medicine Supply Issue</a><br />
+<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Report Appliance Supply Issue</a></p>
+<p><a href="/psncs-work/website/rss-feeds"><img src="/wp-content/uploads/2013/06/RSS-icon-small.png" /></a> <a href="/psncs-work/website/rss-feeds"> RSS Feeds</a></p>
+<hr />
+<h4><a href="http://archive.psnc.org.uk/">Archive PSNC Site</a></h4>
+</div>
+		</div>				
+				<hr class="hrwhite">
+				
+				<div class="footer-credits">
+					<p>Copyright &copy; 2017 PSNC &bull; Site designed and built by <a href="http://www.jellyhaus.com" target="_blank">Jellyhaus</a></p>
+				</div>
+
+			
+			</div>
+			<!-- /wrapper -->
+			
+		</footer>
+		<!-- /footer -->
+		
+		<div id="pum-200470" class="pum pum-overlay pum-theme-199867 pum-theme-default-theme popmake-overlay auto_open click_open" data-popmake="{&quot;id&quot;:200470,&quot;slug&quot;:&quot;psnc-newsletters&quot;,&quot;theme_id&quot;:199867,&quot;cookies&quot;:[{&quot;event&quot;:&quot;on_popup_close&quot;,&quot;settings&quot;:{&quot;name&quot;:&quot;pum-200470&quot;,&quot;key&quot;:&quot;&quot;,&quot;time&quot;:&quot;1 month&quot;,&quot;path&quot;:1}}],&quot;triggers&quot;:[{&quot;type&quot;:&quot;auto_open&quot;,&quot;settings&quot;:{&quot;delay&quot;:&quot;1000&quot;,&quot;cookie&quot;:{&quot;name&quot;:[&quot;pum-200470&quot;]}}},{&quot;type&quot;:&quot;click_open&quot;,&quot;settings&quot;:{&quot;extra_selectors&quot;:&quot;&quot;,&quot;cookie&quot;:{&quot;name&quot;:null}}}],&quot;mobile_disabled&quot;:true,&quot;tablet_disabled&quot;:null,&quot;meta&quot;:{&quot;display&quot;:{&quot;size&quot;:&quot;medium&quot;,&quot;responsive_min_width&quot;:&quot;&quot;,&quot;responsive_max_width&quot;:&quot;&quot;,&quot;custom_width&quot;:&quot;640&quot;,&quot;custom_height&quot;:&quot;380&quot;,&quot;animation_type&quot;:&quot;fade&quot;,&quot;animation_speed&quot;:&quot;350&quot;,&quot;animation_origin&quot;:&quot;center top&quot;,&quot;position_bottom&quot;:&quot;0&quot;,&quot;location&quot;:&quot;center top&quot;,&quot;position_right&quot;:&quot;0&quot;,&quot;position_top&quot;:&quot;100&quot;,&quot;position_left&quot;:&quot;0&quot;,&quot;overlay_zindex&quot;:&quot;1999999998&quot;,&quot;zindex&quot;:&quot;1999999999&quot;,&quot;responsive_min_width_unit&quot;:&quot;px&quot;,&quot;responsive_max_width_unit&quot;:&quot;px&quot;,&quot;custom_width_unit&quot;:&quot;px&quot;,&quot;custom_height_unit&quot;:&quot;px&quot;},&quot;close&quot;:{&quot;text&quot;:&quot;&quot;,&quot;button_delay&quot;:&quot;0&quot;},&quot;click_open&quot;:{&quot;extra_selectors&quot;:&quot;&quot;}}}" role="dialog" aria-hidden="true" aria-labelledby="pum_popup_title_200470">
+
+	<div id="popmake-200470" class="pum-container popmake theme-199867 pum-responsive pum-responsive-medium responsive size-medium">
+
+				
+
+				            <div id="pum_popup_title_200470" class="pum-title popmake-title">
+				Do you receive PSNC's email newsletters?			</div>
+		
+
+		
+
+				<div class="pum-content popmake-content">
+			<table class="popup">
+<tbody>
+<tr>
+<td><img class="wp-image-200480 size-full alignnone" src="http://psnc.org.uk/wp-content/uploads/2017/07/Newsletter-promo.png" alt="" width="528" height="260" /></td>
+<td style="vertical-align: top;">
+<p>&nbsp;</p>
+<p>PSNC sends regular emails to help ensure community pharmacy teams don&#8217;t miss any key information, guidance and resources.</p>
+<p>&nbsp;</p>
+<p><strong><a href="http://psnc.org.uk/latest-news/email-sign-up/" target="_blank" rel="noopener noreferrer">Sign up now</a></strong></p></td>
+</tr>
+</tbody>
+</table>
+<p>&nbsp;</p>
+		</div>
+
+
+				
+
+				            <button type="button" class="pum-close popmake-close" aria-label="Close">
+			X            </button>
+		
+	</div>
+
+</div>
+		<script language="javascript" type="text/javascript">
+			var print_data = {"id5989":{"pom_site_css":"http:\/\/psnc.org.uk\/wp-content\/themes\/psnc\/style.css","pom_custom_css":"","pom_html_top":"<img src=\"http:\/\/psnc.org.uk\/wp-content\/themes\/psnc\/img\/print-header.png\" alt=\"Logo\">\r\n<script>\r\nvar value = new Date();\r\nvar month = value.getMonth() + 1;\r\nvar div = document.getElementsByClassName('page-content')[0];\r\ndiv.innerHTML = '<h2>Printed On : ' + value.getDate() + \"\/\" +  month + \"\/\" + value.getFullYear() + '<\/h2>' + div.innerHTML;\r\n<\/script>","pom_html_bottom":"","pom_do_not_print":".news-box","pom_pause_time":"1500","pom_close_after_print":"1"}};
+		</script>
+		<script type="text/javascript">
+/* <![CDATA[ */
+jQuery(document).ready(function () {
+jQuery(".toggle_container").hide();
+jQuery(".trigger").click(function(){jQuery(this).toggleClass("active").next().toggle();
+return false;
+});
+});
+/* ]]> */
+</script>
+<script data-cfasync="false" type="text/javascript">
+var addthis_config = {"data_track_clickback":true,"ui_atversion":300,"ignore_server_config":true};
+var addthis_share = {};
+</script>
+                <!-- AddThis Settings Begin -->
+                <script data-cfasync="false" type="text/javascript">
+                    var addthis_product = "wpp-5.3.6";
+                    var wp_product_version = "wpp-5.3.6";
+                    var wp_blog_version = "4.9.1";
+                    var addthis_plugin_info = {"info_status":"enabled","cms_name":"WordPress","plugin_name":"Share Buttons by AddThis","plugin_version":"5.3.6","anonymous_profile_id":"wp-25948061bcf65a107d5bba98136ece52","plugin_mode":"WordPress","select_prefs":{"addthis_per_post_enabled":true,"addthis_above_enabled":false,"addthis_below_enabled":true,"addthis_sidebar_enabled":false,"addthis_mobile_toolbar_enabled":false,"addthis_above_showon_home":true,"addthis_above_showon_posts":true,"addthis_above_showon_pages":true,"addthis_above_showon_archives":true,"addthis_above_showon_categories":true,"addthis_above_showon_excerpts":true,"addthis_below_showon_home":false,"addthis_below_showon_posts":true,"addthis_below_showon_pages":true,"addthis_below_showon_archives":false,"addthis_below_showon_categories":false,"addthis_below_showon_excerpts":false,"addthis_sidebar_showon_home":true,"addthis_sidebar_showon_posts":true,"addthis_sidebar_showon_pages":true,"addthis_sidebar_showon_archives":true,"addthis_sidebar_showon_categories":true,"addthis_mobile_toolbar_showon_home":true,"addthis_mobile_toolbar_showon_posts":true,"addthis_mobile_toolbar_showon_pages":true,"addthis_mobile_toolbar_showon_archives":true,"addthis_mobile_toolbar_showon_categories":true,"sharing_enabled_on_post_via_metabox":true},"page_info":{"template":false,"post_type":""}};
+                    if (typeof(addthis_config) == "undefined") {
+                        var addthis_config = {"data_track_clickback":true,"ui_atversion":300,"ignore_server_config":true};
+                    }
+                    if (typeof(addthis_share) == "undefined") {
+                        var addthis_share = {};
+                    }
+                    if (typeof(addthis_layers) == "undefined") {
+                        var addthis_layers = {};
+                    }
+                </script>
+                <script
+                    data-cfasync="false"
+                    type="text/javascript"
+                    src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-570e3e0a2d839861 "
+                    async="async"
+                >
+                </script>
+                <script data-cfasync="false" type="text/javascript">
+                    (function() {
+                        var at_interval = setInterval(function () {
+                            if(window.addthis) {
+                                clearInterval(at_interval);
+                                addthis.layers(addthis_layers);
+                            }
+                        },1000)
+                    }());
+                </script>
+                <link rel='stylesheet' id='addthis_output-css'  href='//psnc.org.uk/wp-content/plugins/addthis/css/output.css?ver=4.9.1' media='all' />
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/core.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.11.4'></script>
+<script type='text/javascript'>
+jQuery(document).ready(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"dd\/mm\/yy","firstDay":1,"isRTL":false});});
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/footer-scripts.js?ver=1.0.0'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/suggest.min.js?ver=1.1-20110113'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var FB_WP=FB_WP||{};FB_WP.queue={_methods:[],flushed:false,add:function(fn){FB_WP.queue.flushed?fn():FB_WP.queue._methods.push(fn)},flush:function(){for(var fn;fn=FB_WP.queue._methods.shift();){fn()}FB_WP.queue.flushed=true}};window.fbAsyncInit=function(){FB.init({"xfbml":true});if(FB_WP && FB_WP.queue && FB_WP.queue.flush){FB_WP.queue.flush()}}
+/* ]]> */
+</script>
+<script type="text/javascript">(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(d.getElementById(id)){return}js=d.createElement(s);js.id=id;js.src="http:\/\/connect.facebook.net\/en_GB\/all.js";fjs.parentNode.insertBefore(js,fjs)}(document,"script","facebook-jssdk"));</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/popup-maker/assets/js/mobile-detect.min.js?ver=1.3.3'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/position.min.js?ver=1.11.4'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var pum_vars = {"ajaxurl":"http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php","restapi":"http:\/\/psnc.org.uk\/wp-json\/pum\/v1","rest_nonce":null,"default_theme":"199867","debug_mode":"","disable_open_tracking":""};
+var pum_debug_vars = {"debug_mode_enabled":"Popup Maker Debug Mode Enabled","debug_started_at":"Debug started at:","debug_more_info":"For more information on how to use this information visit http:\/\/docs.wppopupmaker.com\/?utm_medium=js-debug-info&utm_campaign=ContextualHelp&utm_source=browser-console&utm_content=more-info","global_info":"Global Information","localized_vars":"Localized variables","popups_initializing":"Popups Initializing","popups_initialized":"Popups Initialized","single_popup_label":"Popup: #","theme_id":"Theme ID: ","label_method_call":"Method Call:","label_method_args":"Method Arguments:","label_popup_settings":"Settings","label_triggers":"Triggers","label_cookies":"Cookies","label_delay":"Delay:","label_conditions":"Conditions","label_cookie":"Cookie:","label_settings":"Settings:","label_selector":"Selector:","label_mobile_disabled":"Mobile Disabled:","label_tablet_disabled":"Tablet Disabled:","label_display_settings":"Display Settings:","label_close_settings":"Close Settings:","label_event_before_open":"Event: Before Open","label_event_after_open":"Event: After Open","label_event_open_prevented":"Event: Open Prevented","label_event_setup_close":"Event: Setup Close","label_event_close_prevented":"Event: Close Prevented","label_event_before_close":"Event: Before Close","label_event_after_close":"Event: After Close","label_event_before_reposition":"Event: Before Reposition","label_event_after_reposition":"Event: After Reposition","label_event_checking_condition":"Event: Checking Condition","triggers":{"click_open":{"name":"Click Open","modal_title":"Click Trigger Settings","settings_column":"<strong>Extra Selectors<\/strong>: {{data.extra_selectors}}"},"auto_open":{"name":"Auto Open","modal_title":"Auto Open Settings","settings_column":"<strong>Delay<\/strong>: {{data.delay}}"}},"cookies":{"on_popup_open":{"name":"On Popup Open","modal_title":"On Popup Open Settings"},"on_popup_close":{"name":"On Popup Close","modal_title":"On Popup Close Settings"},"manual":{"name":"Manual JavaScript","modal_title":"Click Trigger Settings"}}};
+var ajaxurl = "http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php";
+var popmake_default_theme = "199867";
+/* ]]> */
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/popup-maker/assets/js/site.min.js?defer&#038;ver=1.6.6' defer='defer'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/wp-embed.min.js?ver=4.9.1'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var frm_js = {"ajax_url":"http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php","images_url":"http:\/\/psnc.org.uk\/wp-content\/plugins\/formidable\/images","loading":"Loading\u2026","remove":"Remove","offset":"4","nonce":"ef6521c829","id":"ID","no_results":"No results match","file_spam":"That file looks like Spam.","empty_fields":"Please complete the preceding required fields before uploading a file."};
+/* ]]> */
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/formidable/js/formidable.min.js?ver=2.05.06'></script>
+
+<script type="text/javascript">
+/*<![CDATA[*/
+var frmrules={"155":{"fieldId":"155","fieldKey":"nj9ai2","fieldType":"select","inputType":"select","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":["157","162","158","1715","163","161","161"],"showHide":"show","anyAll":"any","conditions":[]},"157":{"fieldId":"157","fieldKey":"dj4y8h","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"all","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"162":{"fieldId":"162","fieldKey":"5ss0gx","fieldType":"select","inputType":"select","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"158":{"fieldId":"158","fieldKey":"iqdesw","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"1715":{"fieldId":"1715","fieldKey":"55kyc","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Local Pharmaceutical Committee"}],"status":"complete"},"163":{"fieldId":"163","fieldKey":"7gipyc","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Other"}],"status":"complete"},"161":{"fieldId":"161","fieldKey":"uxyr36","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Other"},{"fieldId":"155","operator":"==","value":"Local Pharmaceutical Committee"}],"status":"complete"}};
+if(typeof __FRMRULES == 'undefined'){__FRMRULES=frmrules;}
+else{__FRMRULES=jQuery.extend({},__FRMRULES,frmrules);}var frmHide=["157","162","158","1715","163","161"];if(typeof __frmHideOrShowFields == "undefined"){__frmHideOrShowFields=frmHide;}else{__frmHideOrShowFields=jQuery.extend(__frmHideOrShowFields,frmHide);}/*]]>*/
+</script>
+<div id="fb-root"></div><!--wp_footer-->		
+	
+	</body>
+</html>

--- a/openprescribing/pipeline/test-data/pages/ncso-current.html
+++ b/openprescribing/pipeline/test-data/pages/ncso-current.html
@@ -1,45 +1,48 @@
+
 <!doctype html>
-<html lang="en-GB" xmlns:fb="http://ogp.me/ns/fb#" xmlns:addthis="http://www.addthis.com/help/api-spec"  xmlns:og="http://ogp.me/ns#" class="no-js">
-	<head>
-		<meta charset="UTF-8">
-		<title>  Price Concessions and NCSO : PSNC Main site</title>
+<html lang="en-GB" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://ogp.me/ns/fb#" class="no-js">
+<head>
+<meta charset="UTF-8">
 		
-		<!-- dns prefetch -->
-		<link href="//www.google-analytics.com" rel="dns-prefetch">
-		
-		<!-- meta -->
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<meta name="viewport" content="width=device-width,initial-scale=1.0">
-		<meta name="author" content="PSNC">
-		<meta name="designer" content="Mark Williamson">
-		
-		<!-- Hide CPT from Google -->
-		
-		
-		<meta name="description" content="   QUICK LINKS BGMA best practice guidelines on notification of medicines shortages Price Concession and NCSO Archive REF: Drug Tariff Part II, Clause 8B and 9C November 2017 Latest information: November Price Concessions Update Drug Pack size Price Concession Amiloride 5mg tablets 28 £9.25 Amlodipine 5mg tablets 28 £3.75 Anastrozole 1mg tablets 28 £11.99 Atorvastatin...">
-		
-		<!--[if lte IE 6]>
-		<link rel="stylesheet" href="http://psnc.org.uk/wp-content/themes/psnc/css/ie6.css" media="screen, projection">
-		<![endif]-->
-		
-		<!--[if lt IE 7]>
-		<script src="http://ie7-js.googlecode.com/svn/version/2.1(beta4)/IE7.js"></script>
-		<![endif]-->
-		
-		<!-- icons -->
-		<link rel="shortcut icon" href="http://psnc.org.uk/wp-content/themes/psnc/favicon.ico" />
-		<link href="http://psnc.org.uk/wp-content/themes/psnc/img/icons/touch.png" rel="apple-touch-icon-precomposed">
-			
-		<!-- css + javascript -->
-		<link rel="dns-prefetch" href="//connect.facebook.net" />
-<link rel='dns-prefetch' href='//cdnjs.cloudflare.com' />
-<link rel='dns-prefetch' href='//connect.facebook.net' />
+<!-- dns prefetch -->
+<link href="//www.google-analytics.com" rel="dns-prefetch">
+
+<!-- meta -->
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+
+	<!-- This site is optimized with the Yoast SEO plugin v19.9 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Price Concessions - PSNC Website</title>
+	<link rel="canonical" href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" />
+	<meta property="og:locale" content="en_GB" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Price Concessions - PSNC Website" />
+	<meta property="og:description" content="QUICK LINKS Price concession webinar now available on demand How the price concession system operates Price Concession Archive Price concession archive spreadsheet What is a price concession? When community pharmacies cannot source a drug at or below the reimbursement price as set out in the Drug Tariff, the Department of Health and Social Care (DHSC) [...]" />
+	<meta property="og:url" content="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" />
+	<meta property="og:site_name" content="PSNC Website" />
+	<meta property="article:modified_time" content="2023-03-15T12:39:53+00:00" />
+	<meta property="og:image" content="https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg" />
+	<meta property="og:image:width" content="463" />
+	<meta property="og:image:height" content="252" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:label1" content="Estimated reading time" />
+	<meta name="twitter:data1" content="14 minutes" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/","url":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/","name":"Price Concessions - PSNC Website","isPartOf":{"@id":"https://psnc.org.uk/#website"},"primaryImageOfPage":{"@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/#primaryimage"},"image":{"@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/#primaryimage"},"thumbnailUrl":"https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg","datePublished":"2020-02-28T14:05:23+00:00","dateModified":"2023-03-15T12:39:53+00:00","breadcrumb":{"@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/#breadcrumb"},"inLanguage":"en-GB","potentialAction":[{"@type":"ReadAction","target":["https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/"]}]},{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/#primaryimage","url":"https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg","contentUrl":"https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg","width":463,"height":252},{"@type":"BreadcrumbList","@id":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://psnc.org.uk/"},{"@type":"ListItem","position":2,"name":"Funding &#038; Reimbursement","item":"https://psnc.org.uk/funding-and-reimbursement/"},{"@type":"ListItem","position":3,"name":"Reimbursement","item":"https://psnc.org.uk/funding-and-reimbursement/reimbursement/"},{"@type":"ListItem","position":4,"name":"Price Concessions"}]},{"@type":"WebSite","@id":"https://psnc.org.uk/#website","url":"https://psnc.org.uk/","name":"PSNC Website","description":"Pharmaceutical Services Negotiating Committee (PSNC)","publisher":{"@id":"https://psnc.org.uk/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://psnc.org.uk/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-GB"},{"@type":"Organization","@id":"https://psnc.org.uk/#organization","name":"PSNC","url":"https://psnc.org.uk/","logo":{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://psnc.org.uk/#/schema/logo/image/","url":"https://psnc.org.uk/wp-content/uploads/2022/04/image-proxy.jpg","contentUrl":"https://psnc.org.uk/wp-content/uploads/2022/04/image-proxy.jpg","width":1139,"height":728,"caption":"PSNC"},"image":{"@id":"https://psnc.org.uk/#/schema/logo/image/"}}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//cdn.jsdelivr.net' />
+<link rel='dns-prefetch' href='//static.addtoany.com' />
 <link rel='dns-prefetch' href='//s.w.org' />
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/svg\/","svgExt":".svg","source":{"concatemoji":"\/\/psnc.org.uk\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.1"}};
-			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55358,56794,8205,9794,65039],[55358,56794,8203,9794,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"\/\/psnc.org.uk\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.0.3"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode,e=(p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0),i.toDataURL());return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([129777,127995,8205,129778,127999],[129777,127995,8203,129778,127999])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
 img.wp-smiley,
 img.emoji {
 	display: inline !important;
@@ -47,1007 +50,1342 @@ img.emoji {
 	box-shadow: none !important;
 	height: 1em !important;
 	width: 1em !important;
-	margin: 0 .07em !important;
+	margin: 0 0.07em !important;
 	vertical-align: -0.1em !important;
 	background: none !important;
 	padding: 0 !important;
 }
 </style>
-<link rel='stylesheet' id='formidable-css'  href='//psnc.org.uk/wp-content/uploads/formidable/css/formidablepro.css?ver=11291615' media='all' />
-<link rel='stylesheet' id='mailchimpSF_main_css-css'  href='//psnc.org.uk/?mcsf_action=main_css&#038;ver=4.9.1' media='all' />
+	<link rel='stylesheet' id='flick-css'  href='//psnc.org.uk/wp-content/plugins/mailchimp/css/flick/flick.css?ver=6.0.3' media='all' />
+<link rel='stylesheet' id='mailchimpSF_main_css-css'  href='//psnc.org.uk/?mcsf_action=main_css&#038;ver=6.0.3' media='all' />
 <!--[if IE]>
-<link rel='stylesheet' id='mailchimpSF_ie_css-css'  href='//psnc.org.uk/wp-content/plugins/mailchimp/css/ie.css?ver=4.9.1' media='all' />
+<link rel='stylesheet' id='mailchimpSF_ie_css-css'  href='//psnc.org.uk/wp-content/plugins/mailchimp/css/ie.css?ver=6.0.3' media='all' />
 <![endif]-->
-<link rel='stylesheet' id='popup-maker-site-css'  href='//psnc.org.uk/wp-content/plugins/popup-maker/assets/css/site.min.css?ver=1.6.6' media='all' />
-<link rel='stylesheet' id='printomatic-css-css'  href='//psnc.org.uk/wp-content/plugins/print-o-matic/css/style.css?ver=1.2' media='all' />
-<link rel='stylesheet' id='ssp-frontend-player-css'  href='//psnc.org.uk/wp-content/plugins/seriously-simple-podcasting/assets/css/player.css?ver=1.18.1' media='all' />
-<link rel='stylesheet' id='normalize-css'  href='//psnc.org.uk/wp-content/themes/psnc/normalize.css?ver=1.0' media='all' />
+<link rel='stylesheet' id='formidable-css'  href='//psnc.org.uk/wp-content/plugins/formidable/css/formidableforms1.css?ver=12141534' media='all' />
+<link rel='stylesheet' id='wp-block-library-css'  href='//psnc.org.uk/wp-includes/css/dist/block-library/style.min.css?ver=6.0.3' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+</style>
+<link rel='stylesheet' id='cookie-law-info-css'  href='//psnc.org.uk/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-public.css?ver=3.0.7' media='all' />
+<link rel='stylesheet' id='cookie-law-info-gdpr-css'  href='//psnc.org.uk/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-gdpr.css?ver=3.0.7' media='all' />
+<link rel='stylesheet' id='ctf_styles-css'  href='//psnc.org.uk/wp-content/plugins/custom-twitter-feeds/css/ctf-styles.min.css?ver=2.0.3' media='all' />
+<link rel='stylesheet' id='printomatic-css-css'  href='//psnc.org.uk/wp-content/plugins/print-o-matic/css/style.css?ver=2.0' media='all' />
 <link rel='stylesheet' id='html5blank-css'  href='//psnc.org.uk/wp-content/themes/psnc/style.css?ver=1.0' media='all' />
-<link rel='stylesheet' id='bxslider-css'  href='//psnc.org.uk/wp-content/themes/psnc/css/jquery.bxslider.css?ver=1.0' media='all' />
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
-<script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/conditionizr.js/2.2.0/conditionizr.min.js?ver=2.2.0'></script>
-<script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js?ver=2.6.2'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/jquery.bxSlider.js?ver=1.0.0'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/respond.min.js?ver=1.0.0'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/scripts.js?ver=1.0.0'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/print-o-matic/printomat.js?ver=1.8.5'></script>
-<link rel='https://api.w.org/' href='http://psnc.org.uk/wp-json/' />
-<link rel="alternate" type="application/json+oembed" href="http://psnc.org.uk/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fpsnc.org.uk%2Fdispensing-supply%2Fsupply-chain%2Fgeneric-shortages%2F" />
-<link rel="alternate" type="text/xml+oembed" href="http://psnc.org.uk/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fpsnc.org.uk%2Fdispensing-supply%2Fsupply-chain%2Fgeneric-shortages%2F&#038;format=xml" />
-<script type="text/javascript">document.documentElement.className += " js";</script>
-<!-- Stream WordPress user activity plugin v3.2.2 -->
-
-<link rel="alternate" type="application/rss+xml" title="Podcast RSS feed" href="http://psnc.org.uk/feed/podcast" />
-
+<link rel='stylesheet' id='psnc-style-css'  href='//psnc.org.uk/wp-content/themes/psnc/assets/css/style.css?ver=6.0.3' media='all' />
+<link rel='stylesheet' id='addtoany-css'  href='//psnc.org.uk/wp-content/plugins/add-to-any/addtoany.min.css?ver=1.16' media='all' />
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery.min.js?ver=3.6.0' id='jquery-core-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.3.2' id='jquery-migrate-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/mailchimp/js/scrollTo.js?ver=1.5.8' id='jquery_scrollto-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/jquery.form.min.js?ver=4.3.0' id='jquery-form-js'></script>
+<script type='text/javascript' id='mailchimpSF_main_js-js-extra'>
+/* <![CDATA[ */
+var mailchimpSF = {"ajax_url":"https:\/\/psnc.org.uk\/"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/mailchimp/js/mailchimp.js?ver=1.5.8' id='mailchimpSF_main_js-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/core.min.js?ver=1.13.1' id='jquery-ui-core-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/mailchimp/js/datepicker.js?ver=6.0.3' id='datepicker-js'></script>
+<script type='text/javascript' id='addtoany-core-js-before'>
+window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_localize = {
+	Share: "Share",
+	Save: "Save",
+	Subscribe: "Subscribe",
+	Email: "Email",
+	Bookmark: "Bookmark",
+	ShowAll: "Show All",
+	ShowLess: "Show less",
+	FindServices: "Find service(s)",
+	FindAnyServiceToAddTo: "Instantly find any service to add to",
+	PoweredBy: "Powered by",
+	ShareViaEmail: "Share via email",
+	SubscribeViaEmail: "Subscribe via email",
+	BookmarkInYourBrowser: "Bookmark in your browser",
+	BookmarkInstructions: "Press Ctrl+D or \u2318+D to bookmark this page",
+	AddToYourFavorites: "Add to your favourites",
+	SendFromWebOrProgram: "Send from any email address or email program",
+	EmailProgram: "Email program",
+	More: "More&#8230;",
+	ThanksForSharing: "Thanks for sharing!",
+	ThanksForFollowing: "Thanks for following!"
+};
+</script>
+<script type='text/javascript' async src='//static.addtoany.com/menu/page.js' id='addtoany-core-js'></script>
+<script type='text/javascript' async src='//psnc.org.uk/wp-content/plugins/add-to-any/addtoany.min.js?ver=1.1' id='addtoany-jquery-js'></script>
+<script type='text/javascript' id='cookie-law-info-js-extra'>
+/* <![CDATA[ */
+var Cli_Data = {"nn_cookie_ids":[],"cookielist":[],"non_necessary_cookies":[],"ccpaEnabled":"","ccpaRegionBased":"","ccpaBarEnabled":"","strictlyEnabled":["necessary","obligatoire"],"ccpaType":"gdpr","js_blocking":"1","custom_integration":"","triggerDomRefresh":"","secure_cookies":""};
+var cli_cookiebar_settings = {"animate_speed_hide":"500","animate_speed_show":"500","background":"#FFF","border":"#b1a6a6c2","border_on":"","button_1_button_colour":"#61a229","button_1_button_hover":"#4e8221","button_1_link_colour":"#fff","button_1_as_button":"1","button_1_new_win":"","button_2_button_colour":"#333","button_2_button_hover":"#292929","button_2_link_colour":"#444","button_2_as_button":"","button_2_hidebar":"","button_3_button_colour":"#dedfe0","button_3_button_hover":"#b2b2b3","button_3_link_colour":"#333333","button_3_as_button":"1","button_3_new_win":"","button_4_button_colour":"#dedfe0","button_4_button_hover":"#b2b2b3","button_4_link_colour":"#333333","button_4_as_button":"1","button_7_button_colour":"#61a229","button_7_button_hover":"#4e8221","button_7_link_colour":"#fff","button_7_as_button":"1","button_7_new_win":"","font_family":"inherit","header_fix":"","notify_animate_hide":"1","notify_animate_show":"","notify_div_id":"#cookie-law-info-bar","notify_position_horizontal":"right","notify_position_vertical":"bottom","scroll_close":"","scroll_close_reload":"","accept_close_reload":"","reject_close_reload":"","showagain_tab":"","showagain_background":"#fff","showagain_border":"#000","showagain_div_id":"#cookie-law-info-again","showagain_x_position":"100px","text":"#333333","show_once_yn":"","show_once":"10000","logging_on":"","as_popup":"","popup_overlay":"1","bar_heading_text":"","cookie_bar_as":"banner","popup_showagain_position":"bottom-right","widget_position":"left"};
+var log_object = {"ajax_url":"https:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/cookie-law-info/legacy/public/js/cookie-law-info-public.js?ver=3.0.7' id='cookie-law-info-js'></script>
+<link rel="https://api.w.org/" href="https://psnc.org.uk/wp-json/" /><link rel="alternate" type="application/json" href="https://psnc.org.uk/wp-json/wp/v2/pages/100786" /><link rel="alternate" type="application/json+oembed" href="https://psnc.org.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://psnc.org.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F&#038;format=xml" />
 <script type="text/javascript">
-    var se_ajax_url = 'http://psnc.org.uk/wp-admin/admin-ajax.php';
+        jQuery(function($) {
+            $('.date-pick').each(function() {
+                var format = $(this).data('format') || 'mm/dd/yyyy';
+                format = format.replace(/yyyy/i, 'yy');
+                $(this).datepicker({
+                    autoFocusNextInput: true,
+                    constrainInput: false,
+                    changeMonth: true,
+                    changeYear: true,
+                    beforeShow: function(input, inst) { $('#ui-datepicker-div').addClass('show'); },
+                    dateFormat: format.toLowerCase(),
+                });
+            });
+            d = new Date();
+            $('.birthdate-pick').each(function() {
+                var format = $(this).data('format') || 'mm/dd';
+                format = format.replace(/yyyy/i, 'yy');
+                $(this).datepicker({
+                    autoFocusNextInput: true,
+                    constrainInput: false,
+                    changeMonth: true,
+                    changeYear: false,
+                    minDate: new Date(d.getFullYear(), 1-1, 1),
+                    maxDate: new Date(d.getFullYear(), 12-1, 31),
+                    beforeShow: function(input, inst) { $('#ui-datepicker-div').removeClass('show'); },
+                    dateFormat: format.toLowerCase(),
+                });
+
+            });
+
+        });
+    </script>
+
+<link rel="alternate" type="application/rss+xml" title="Podcast RSS feed" href="https://psnc.org.uk/feed/podcast" />
+
+<script type="text/javascript">document.documentElement.className += " js";</script>
+<script type="text/javascript">
+    var se_ajax_url = 'https://psnc.org.uk/wp-admin/admin-ajax.php';
 
     jQuery(document).ready(function() {
         jQuery('#se_search_element_id').suggest(se_ajax_url + '?action=se_special_container_lookup');
     });
 </script>
-<meta property="og:site_name" content="PSNC Main site" />
-<meta property="og:type" content="website" />
-<meta property="og:locale" content="en_GB" />
-<meta property="og:url" content="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/" />
-<meta property="og:title" content="Price Concessions and NCSO" />
-<meta property="og:description" content="   QUICK LINKS BGMA best practice guidelines on notification of medicines shortages Price Concession and NCSO Archive REF: Drug Tariff Part II, Clause 8B and 9C November 2017 Latest information: November Price Concessions Update Drug Pack size Price Concession Amiloride 5mg tablets 28 £9.25 Amlodipine 5mg tablets 28 £3.75 Anastrozole 1mg tablets 28 £11.99 Atorvastatin&hellip;" />
-	<style id="pum-styles" type="text/css" media="all">
-	/* Popup Google Fonts */
-@import url('//fonts.googleapis.com/css?family=Acme|Montserrat');
-
-/* Popup Theme 199872: Framed Border */
-.pum-theme-199872, .pum-theme-framed-border { background-color: rgba( 255, 255, 255, 0.50 ) } 
-.pum-theme-199872 .pum-container, .pum-theme-framed-border .pum-container { padding: 18px; border-radius: 0px; border: 20px outset #dd3333; box-shadow: 1px 1px 3px 0px rgba( 2, 2, 2, 0.97 ) inset; background-color: rgba( 255, 251, 239, 1.00 ) } 
-.pum-theme-199872 .pum-title, .pum-theme-framed-border .pum-title { color: #000000; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
-.pum-theme-199872 .pum-content, .pum-theme-framed-border .pum-content { color: #2d2d2d; font-family: inherit } 
-.pum-theme-199872 .pum-content + .pum-close, .pum-theme-framed-border .pum-content + .pum-close { height: 20px; width: 20px; left: auto; right: -20px; bottom: auto; top: -20px; padding: 0px; color: #ffffff; font-family: Acme; font-size: 20px; line-height: 20px; border: 1px none #ffffff; border-radius: 0px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 0, 0, 0, 0.55 ) } 
-
-/* Popup Theme 199871: Cutting Edge */
-.pum-theme-199871, .pum-theme-cutting-edge { background-color: rgba( 0, 0, 0, 0.50 ) } 
-.pum-theme-199871 .pum-container, .pum-theme-cutting-edge .pum-container { padding: 18px; border-radius: 0px; border: 1px none #000000; box-shadow: 0px 10px 25px 0px rgba( 2, 2, 2, 0.50 ); background-color: rgba( 30, 115, 190, 1.00 ) } 
-.pum-theme-199871 .pum-title, .pum-theme-cutting-edge .pum-title { color: #ffffff; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: Sans-Serif; font-size: 26px; line-height: 28px } 
-.pum-theme-199871 .pum-content, .pum-theme-cutting-edge .pum-content { color: #ffffff; font-family: inherit } 
-.pum-theme-199871 .pum-content + .pum-close, .pum-theme-cutting-edge .pum-content + .pum-close { height: 24px; width: 24px; left: auto; right: 0px; bottom: auto; top: 0px; padding: 0px; color: #1e73be; font-family: inherit; font-size: 32px; line-height: 24px; border: 1px none #ffffff; border-radius: 0px; box-shadow: -1px 1px 1px 0px rgba( 2, 2, 2, 0.10 ); text-shadow: -1px 1px 1px rgba( 0, 0, 0, 0.10 ); background-color: rgba( 238, 238, 34, 1.00 ) } 
-
-/* Popup Theme 199870: Hello Box */
-.pum-theme-199870, .pum-theme-hello-box { background-color: rgba( 0, 0, 0, 0.75 ) } 
-.pum-theme-199870 .pum-container, .pum-theme-hello-box .pum-container { padding: 30px; border-radius: 80px; border: 14px solid #81d742; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.00 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
-.pum-theme-199870 .pum-title, .pum-theme-hello-box .pum-title { color: #2d2d2d; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: Montserrat; font-size: 32px; line-height: 36px } 
-.pum-theme-199870 .pum-content, .pum-theme-hello-box .pum-content { color: #2d2d2d; font-family: inherit } 
-.pum-theme-199870 .pum-content + .pum-close, .pum-theme-hello-box .pum-content + .pum-close { height: auto; width: auto; left: auto; right: -30px; bottom: auto; top: -30px; padding: 0px; color: #2d2d2d; font-family: inherit; font-size: 32px; line-height: 28px; border: 1px none #ffffff; border-radius: 28px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
-
-/* Popup Theme 199869: Enterprise Blue */
-.pum-theme-199869, .pum-theme-enterprise-blue { background-color: rgba( 0, 0, 0, 0.70 ) } 
-.pum-theme-199869 .pum-container, .pum-theme-enterprise-blue .pum-container { padding: 28px; border-radius: 5px; border: 1px none #000000; box-shadow: 0px 10px 25px 4px rgba( 2, 2, 2, 0.50 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
-.pum-theme-199869 .pum-title, .pum-theme-enterprise-blue .pum-title { color: #315b7c; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 34px; line-height: 36px } 
-.pum-theme-199869 .pum-content, .pum-theme-enterprise-blue .pum-content { color: #2d2d2d; font-family: inherit } 
-.pum-theme-199869 .pum-content + .pum-close, .pum-theme-enterprise-blue .pum-content + .pum-close { height: 28px; width: 28px; left: auto; right: 8px; bottom: auto; top: 8px; padding: 4px; color: #ffffff; font-family: inherit; font-size: 20px; line-height: 20px; border: 1px none #ffffff; border-radius: 42px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 49, 91, 124, 1.00 ) } 
-
-/* Popup Theme 199868: Light Box */
-.pum-theme-199868, .pum-theme-lightbox { background-color: rgba( 0, 0, 0, 0.60 ) } 
-.pum-theme-199868 .pum-container, .pum-theme-lightbox .pum-container { padding: 18px; border-radius: 3px; border: 8px solid #000000; box-shadow: 0px 0px 30px 0px rgba( 2, 2, 2, 1.00 ); background-color: rgba( 255, 255, 255, 1.00 ) } 
-.pum-theme-199868 .pum-title, .pum-theme-lightbox .pum-title { color: #000000; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
-.pum-theme-199868 .pum-content, .pum-theme-lightbox .pum-content { color: #000000; font-family: inherit } 
-.pum-theme-199868 .pum-content + .pum-close, .pum-theme-lightbox .pum-content + .pum-close { height: 30px; width: 30px; left: auto; right: -24px; bottom: auto; top: -24px; padding: 0px; color: #ffffff; font-family: inherit; font-size: 24px; line-height: 26px; border: 2px solid #ffffff; border-radius: 30px; box-shadow: 0px 0px 15px 1px rgba( 2, 2, 2, 0.75 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 0, 0, 0, 1.00 ) } 
-
-/* Popup Theme 199867: Default Theme */
-.pum-theme-199867, .pum-theme-default-theme { background-color: rgba( 12, 12, 12, 0.50 ) } 
-.pum-theme-199867 .pum-container, .pum-theme-default-theme .pum-container { padding: 20px; border-radius: 50px; border: 1px none #000000; box-shadow: 1px 1px 3px 0px rgba( 2, 2, 2, 0.23 ); background-color: rgba( 249, 249, 249, 1.00 ) } 
-.pum-theme-199867 .pum-title, .pum-theme-default-theme .pum-title { color: #4f3388; text-align: left; text-shadow: 0px 0px 0px rgba( 2, 2, 2, 0.23 ); font-family: inherit; font-size: 32px; line-height: 36px } 
-.pum-theme-199867 .pum-content, .pum-theme-default-theme .pum-content { color: #636363; font-family: inherit } 
-.pum-theme-199867 .pum-content + .pum-close, .pum-theme-default-theme .pum-content + .pum-close { height: auto; width: 30px; left: auto; right: 0px; bottom: auto; top: 0px; padding: 8px; color: #ffffff; font-family: inherit; font-size: 16px; line-height: 14px; border: 1px none #ffffff; border-radius: 25px; box-shadow: 0px 0px 0px 0px rgba( 2, 2, 2, 0.23 ); text-shadow: 0px 0px 0px rgba( 0, 0, 0, 0.23 ); background-color: rgba( 79, 51, 136, 1.00 ) } 
-
-
-	
-		</style>
-<!-- START - Facebook Open Graph, Google+ and Twitter Card Tags 2.1.5 -->
+<link rel="icon" href="https://psnc.org.uk/wp-content/uploads/2022/07/cropped-psnc-logo-1-32x32.png" sizes="32x32" />
+<link rel="icon" href="https://psnc.org.uk/wp-content/uploads/2022/07/cropped-psnc-logo-1-192x192.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://psnc.org.uk/wp-content/uploads/2022/07/cropped-psnc-logo-1-180x180.png" />
+<meta name="msapplication-TileImage" content="https://psnc.org.uk/wp-content/uploads/2022/07/cropped-psnc-logo-1-270x270.png" />
+		<style type="text/css" id="wp-custom-css">
+			.page-content p a, .page-content li a {
+    font-weight: bold
+}		</style>
+		
+<!-- START - Open Graph and Twitter Card Tags 3.2.0 -->
  <!-- Facebook Open Graph -->
-  <meta property="og:site_name" content="PSNC Main site"/>
-  <meta property="og:title" content="Price Concessions and NCSO"/>
-  <meta property="og:url" content="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/"/>
+  <meta property="og:site_name" content="PSNC Website"/>
+  <meta property="og:title" content="Price Concessions"/>
+  <meta property="og:url" content="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/"/>
   <meta property="og:type" content="article"/>
-  <meta property="og:description" content="  
+  <meta property="og:description" content="QUICK LINKS
 
 
 
-
-QUICK LINKS
-
+Price concession webinar now available on demand
 
 
-BGMA best practice guidelines on notification of medicines shortages
+How the price concession system operates
 
 
-Price Concession and NCSO Archive
+Price Concession Archive
 
 
-REF: Drug Tariff Part II, Clause 8B and 9C
+Price concession archive spreadsheet
 
 
 
-November 2017
-Latest information: November Price Concessions Update
-
-
-
-Drug
-Pack size
-Price Concess"/>
+What is a price concession?
+When community pharmacies cannot source a drug at or below the reimbursement p"/>
+  <meta property="og:image:secure_url" content="https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg"/>
  <!-- Google+ / Schema.org -->
-  <meta itemprop="name" content="Price Concessions and NCSO"/>
-  <meta itemprop="description" content="  
+  <meta itemprop="name" content="Price Concessions"/>
+  <meta itemprop="headline" content="Price Concessions"/>
+  <meta itemprop="description" content="QUICK LINKS
 
 
 
-
-QUICK LINKS
-
+Price concession webinar now available on demand
 
 
-BGMA best practice guidelines on notification of medicines shortages
+How the price concession system operates
 
 
-Price Concession and NCSO Archive
+Price Concession Archive
 
 
-REF: Drug Tariff Part II, Clause 8B and 9C
+Price concession archive spreadsheet
 
 
 
-November 2017
-Latest information: November Price Concessions Update
-
-
-
-Drug
-Pack size
-Price Concess"/>
-  <meta itemprop="image" content="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg"/>
+What is a price concession?
+When community pharmacies cannot source a drug at or below the reimbursement p"/>
+  <meta itemprop="image" content="https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg"/>
  <!-- Twitter Cards -->
  <!-- SEO -->
  <!-- Misc. tags -->
-<!-- END - Facebook Open Graph, Google+ and Twitter Card Tags 2.1.5 -->
+ <!-- is_singular -->
+<!-- END - Open Graph and Twitter Card Tags 3.2.0 -->
 	
 
-		<script>
-		(function(){
-			// configure legacy, retina, touch requirements @ conditionizr.com
-			conditionizr();
-		})();
-		</script>
-		
 
+<!-- Google Analytics UA -->	
+<script type="text/javascript">
 
+	var _gaq = _gaq || [];
+	_gaq.push(
+		['_setAccount', 'UA-4143012-1'],
+		['_trackPageview']
+	);
 
-		<!-- analytics -->		
-		
-		<script type="text/javascript">
+	(function() {
+	var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+	ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+	})();
 
-		  var _gaq = _gaq || [];
-		  _gaq.push(
-			  ['_setAccount', 'UA-4143012-1'],
-			  ['_trackPageview']
-			);
-		
-		  (function() {
-		    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-		  })();
-		
-		</script>
-	</head>
-	<body class="page-template-default page page-id-100786 page-child parent-pageid-2106 generic-shortages" id="site-id-1">
-		
-		<!--[if lte IE 7]>
-            <div class="chromeframe" style="background:black;">You are using an outdated browser so elements on this page may not display as intended. <a href="http://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</div>
-        <![endif]-->
-		
-		
-	
-			<!-- header -->
-			<header class="header clear" role="banner" style="z-index:1000;">
-				
-				<!-- wrapper -->
-				<div class="wrapper clear" style="z-index:1000;">
-				
-					<!-- logo -->
-					<div class="logo three columns">
-						<a href="http://psnc.org.uk">
-							<!-- svg logo - toddmotto.com/mastering-svg-use-for-a-retina-web-fallbacks-with-png-script -->
-							<img src="http://psnc.org.uk/wp-content/themes/psnc/img/logo.png" alt="Logo" class="logo-img">
-						</a>
-					</div>
-					<!-- /logo -->
-					
-					<div class="site-title three columns">
-						<span>Pharmaceutical<br>Services<br>Negotiating<br>Committee</span>
-					</div>
-					<!-- /site-title -->
-					
-					<div class="pharmacy-logo four columns">
-						<img src="http://psnc.org.uk/wp-content/themes/psnc/img/pharmacy-logo.png" alt="Pharmacy - At the heart of our community">
-					</div>
-					<!-- /pharmacy-logo -->
-					
-					<div class="utility six columns">
-						<div class="share-login">
-														<!-- <a href="http://psnc.org.uk/login">Login</a> -->
-													</div>
-						<!-- /share-login -->
-						
-						<div class="quick-links-search">
+</script>
 
-							<div class="quick-links">
-								<a href="#" class="dropdown icon-down-dir">Quick links</a>
-								<ul id="menu-hot-topics" class="menu clear"><li id="menu-item-298" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-298"><a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">Online Drug Tariff</a></li>
-<li id="menu-item-200469" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-200469"><a href="http://psnc.org.uk/latest-news/email-sign-up/">Sign up for our email newsletters</a></li>
-<li id="menu-item-100908" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item menu-item-100908"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions and NCSO</a></li>
-<li id="menu-item-13982" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13982"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Report generic medicine supply issue</a></li>
-<li id="menu-item-6952" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6952"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">Where to obtain external resources</a></li>
-<li id="menu-item-126664" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-126664"><a href="http://psnc.org.uk/wp-content/uploads/2013/07/NHS-England-Pharmacy-Contract-Manager-Network.pdf">NHS England local team email addresses</a></li>
-<li id="menu-item-63267" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-63267"><a href="https://www.digital.nhs.uk/Registration-Authorities-and-Smartcards/Service-provider-contact-details">Smartcard Registration Authority contacts</a></li>
-<li id="menu-item-134851" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-134851"><a href="http://psnc.org.uk/psncs-work/our-events/register-your-interest-in-our-webinar/">PSNC webinars</a></li>
-<li id="menu-item-209250" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209250"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/psnctalk-videos/">#PSNCtalk videos</a></li>
-</ul>							</div>
-							<!-- /quick-links -->
-							<!-- search -->
-<form class="search" method="get" action="http://psnc.org.uk" role="search">
-	<input class="search-input" type="text" name="s"  value="Search" onfocus="if (this.value == 'Search') {this.value = '';}" onblur="if (this.value == '') {this.value = 'Search';}">
-	<input type="hidden" value="all" name="post_type" id="searchOptionsAll">
-	<button class="search-submit icon-search" type="submit" role="button"></button>
-</form>
-<!-- /search -->						</div>	
-						<!-- /quick-links-search -->
-					</div>
-					<!-- /utility -->
-					
+<!-- Hotjar Tracking Code for https://beta.psnc.org.uk/ -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:2911945,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+</head>
+<body class="page-template-default page page-id-100786 page-child parent-pageid-600 purple-theme price-concessions" id="site-id-1">
+		
+<header class="site-header">
+
+	<span class="header-overlay search-overlay"></span>
+
+		<div class="search-suggestions">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-6 offset-md-3 search-terms">
+					<p>Search Suggestions</p>
+					<div id="datafetch" class="returned-posts">
+						<a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">Pharmacy Quality Scheme</a><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)</a><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/nms/">New Medicine Service (NMS)</a><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hypertension-case-finding-service/">Hypertension case-finding service</a><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions</a><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/clinical-audit/">Clinical audit</a>					</div>
+					<div class="popular-posts">
+						<a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">Pharmacy Quality Scheme</a><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)</a><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/nms/">New Medicine Service (NMS)</a><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hypertension-case-finding-service/">Hypertension case-finding service</a><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions</a><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/clinical-audit/">Clinical audit</a>					</div>
 				</div>
-				<!-- /wrapper -->
-					
-					<!-- main-nav -->
-					<!--[if lt IE 8]>
-					<style>
-					nav.main-nav ul li a { margin-top: expression(this.offsetHeight < this.parentNode.offsetHeight ? parseInt((this.parentNode.offsetHeight - this.offsetHeight) / 2) + "px" : "0");
-					}
-					</style>
-					<![endif]-->
-					
-					<div class="noscript-hide">
-						<ul class="menu-features">
-							
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="http://psnc.org.uk/contract-it/psnc-briefings-pharmacy-contract-and-it/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/MG_4216-6-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="http://psnc.org.uk/contract-it/psnc-briefings-pharmacy-contract-and-it/" title="PSNC Contract and IT Briefings">PSNC Contract and IT Briefings</a>
-																					</h2>
-										<p>Briefings published by PSNC covering topics such as opening hours, regulations, and NHS IT matters.</p>										<p class="menu-order">3										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="http://psnc.org.uk/latest-news/email-sign-up/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/heart-of-community_purple-200x200.png" class="attachment-square size-square wp-post-image" alt="" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="http://psnc.org.uk/latest-news/email-sign-up/" title="Sign up for PSNC&#8217;s emails">Sign up for PSNC&#8217;s emails</a>
-																					</h2>
-										<p>Join our mailing list for a weekly round-up of news and resources, plus price concession/NCSO alerts.</p>										<p class="menu-order">1										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/MG_4685-25-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/" title="Dispensing and Supply updates">Dispensing and Supply updates</a>
-																					</h2>
-										<p>Our monthly updates on dispensing news and guidance, plus a variety of factsheets.</p>										<p class="menu-order">4										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="/services-commissioning/community-pharmacy-forward-view/"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square.png" class="attachment-square size-square wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square.png 166w, http://psnc.org.uk/wp-content/uploads/2013/07/CPFV-square-120x117.png 120w" sizes="(max-width: 166px) 100vw, 166px" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="/services-commissioning/community-pharmacy-forward-view/" title="Community Pharmacy Forward View">Community Pharmacy Forward View</a>
-																					</h2>
-										<p>Community pharmacy shares its vision on how the sector could be developed to better support patients and the NHS.</p>										<p class="menu-order">5										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="/the-healthcare-landscape"><img src="http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized.jpg" class="attachment-square size-square wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized.jpg 166w, http://psnc.org.uk/wp-content/uploads/2013/08/doctor-with-tablets-resized-120x117.jpg 120w" sizes="(max-width: 166px) 100vw, 166px" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="/the-healthcare-landscape" title="Healthcare Landscape">Healthcare Landscape</a>
-																					</h2>
-										<p>Find out what&#8217;s happening in the wider NHS.</p>										<p class="menu-order">6										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="/lpcs/lposs"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/LPOSS-cover-200x200.png" class="attachment-square size-square wp-post-image" alt="" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="/lpcs/lposs" title="LPOSS">LPOSS</a>
-																					</h2>
-										<p>The Local Pharmacy Organisation Support Services prospectus brings together all our resources and support options for LPCs.</p>										<p class="menu-order">7										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-															<!-- article -->
-								<li class="featured-menu-item">
-									<div class="featured-menu-item-image">
-																					<a href="/funding-and-statistics"><img src="http://psnc.org.uk/wp-content/uploads/2013/07/Stats-200x200.jpg" class="attachment-square size-square wp-post-image" alt="" /></a>
-																				</div>
-									<!-- /image -->
-									
-									<div class="featured-menu-item-text">
-										<h2>
-																						<a href="/funding-and-statistics" title="Funding and Statistics">Funding and Statistics</a>
-																					</h2>
-										<p>Find out the latest on pharmacy funding and NHS statistics.</p>										<p class="menu-order">2										
-										
-									</div>
-									<!-- /text -->
-									
-								</li>
-								<!-- /li -->
-								
-								
-								
-														
-														
-														
-						</ul>
-					</div>
-					<!-- /noscript-hide -->
-					
-					<nav class="main-nav hideformobile" role="navigation">
-												<div class="wrapper clear">
-							<ul id="menu-main-navigation" class="menu root-menu"><li id="menu-item-248" class="menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-248"><a href="http://psnc.org.uk/psncs-work/">PSNC&#8217;s Work</a>
-<ul class="child-menu">
-	<li id="menu-item-1669" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1669"><a href="http://psnc.org.uk/psncs-work/about-psnc/">About PSNC</a>
-	<ul class="child-menu">
-		<li id="menu-item-1903" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1903"><a href="http://psnc.org.uk/psncs-work/about-psnc/psnc-members/">PSNC members</a></li>
-		<li id="menu-item-1904" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1904"><a href="http://psnc.org.uk/psncs-work/about-psnc/psnc-staff/">PSNC staff</a></li>
-		<li id="menu-item-1902" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1902"><a href="http://psnc.org.uk/psncs-work/psnc-vision-and-work-plan/">PSNC Vision &#038; work plan</a></li>
-		<li id="menu-item-20556" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-20556"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/">Communications &#038; lobbying</a></li>
-	</ul>
-</li>
-	<li id="menu-item-1898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1898"><a href="http://psnc.org.uk/psncs-work/the-latest-from-psnc/">The latest from PSNC</a>
-	<ul class="child-menu">
-		<li id="menu-item-218437" class="menu-item menu-item-type-post_type menu-item-object-our-latest-news menu-item-218437"><a href="http://psnc.org.uk/our-news/processes-for-2018-psnc-elections-announced/">2018 PSNC elections</a></li>
-		<li id="menu-item-1901" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1901"><a href="http://psnc.org.uk/psncs-work/the-latest-from-psnc/psnc-meetings/">PSNC meetings</a></li>
-		<li id="menu-item-28264" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-28264"><a href="http://psnc.org.uk/psncs-work/psnc-briefings-psncs-work/">PSNC Briefings</a></li>
-		<li id="menu-item-90270" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-90270"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/community-pharmacy-in-201617-and-beyond/">Community pharmacy in 2016/17 &#038; beyond</a></li>
-	</ul>
-</li>
-	<li id="menu-item-209371" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-209371"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/">PSNC publications</a>
-	<ul class="child-menu">
-		<li id="menu-item-209370" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209370"><a href="http://psnc.org.uk/psncs-work/cpn/">Community Pharmacy News (CPN)</a></li>
-		<li id="menu-item-79637" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79637"><a href="http://psnc.org.uk/psncs-work/our-events/register-your-interest-in-our-webinar/">Webinars</a></li>
-		<li id="menu-item-124841" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-124841"><a href="http://psnc.org.uk/podcast">Podcasts</a></li>
-		<li id="menu-item-209251" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-209251"><a href="http://psnc.org.uk/psncs-work/psnc-publications-and-resources/psnctalk-videos/">#PSNCtalk videos</a></li>
-	</ul>
-</li>
-	<li id="menu-item-1900" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1900"><a href="http://psnc.org.uk/psncs-work/website/">Website</a>
-	<ul class="child-menu">
-		<li id="menu-item-5144" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5144"><a href="/our-latest-news-category/psnc-news/">PSNC News</a></li>
-		<li id="menu-item-5145" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5145"><a href="http://psnc.org.uk/latest-news/email-sign-up/">Email newsletter sign up</a></li>
-		<li id="menu-item-79638" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79638"><a href="http://psnc.org.uk/psncs-work/feedback-to-psnc/">Feedback to PSNC</a></li>
-		<li id="menu-item-4660" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4660"><a href="http://psnc.org.uk/psncs-work/website/rss-feeds/">RSS feeds</a></li>
-		<li id="menu-item-255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-255"><a href="http://psnc.org.uk/psncs-work/website/privacy-cookies/">Privacy &#038; cookies</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-16135" class="menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16135"><a href="http://psnc.org.uk/funding-and-statistics/">Funding and Statistics</a>
-<ul class="child-menu">
-	<li id="menu-item-16192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16192"><a href="http://psnc.org.uk/funding-and-statistics/pharmacy-funding/">Pharmacy funding</a>
-	<ul class="child-menu">
-		<li id="menu-item-135262" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135262"><a href="http://psnc.org.uk/funding-and-statistics/cpcf-funding-changes-201617-and-201718/">Funding changes 2016/17 &#038; 2017/18</a></li>
-		<li id="menu-item-16223" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16223"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/">Funding distribution</a></li>
-		<li id="menu-item-16236" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16236"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/indicative-income-tables/">Income tables</a></li>
-		<li id="menu-item-16225" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16225"><a href="http://psnc.org.uk/funding-and-statistics/pharmacy-funding/margins-survey/">Margins survey</a></li>
-		<li id="menu-item-16226" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16226"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/summary-of-funding-changes/">Summary of changes</a></li>
-	</ul>
-</li>
-	<li id="menu-item-16227" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-16227"><a>Topical funding issues</a>
-	<ul class="child-menu">
-		<li id="menu-item-16228" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16228"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/branded-generics/">Branded generics</a></li>
-		<li id="menu-item-16229" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16229"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/dispensing-at-a-loss/">Dispensing at a loss</a></li>
-		<li id="menu-item-16230" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16230"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/it-and-eps-allowances/">IT/EPS allowances</a></li>
-		<li id="menu-item-16231" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16231"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/pre-registration-training-grant/">Pre-reg training grant</a></li>
-		<li id="menu-item-16232" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16232"><a href="http://psnc.org.uk/funding-and-statistics/funding-distribution/vat/">VAT</a></li>
-	</ul>
-</li>
-	<li id="menu-item-1585" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1585"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/">NHS statistics</a>
-	<ul class="child-menu">
-		<li id="menu-item-5563" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5563"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/eps-statistics/">EPS statistics</a></li>
-		<li id="menu-item-80572" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-80572"><a href="http://psnc.org.uk/services-commissioning/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu statistics</a></li>
-		<li id="menu-item-5565" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5565"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/mur-statistics/">MUR statistics</a></li>
-		<li id="menu-item-5564" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5564"><a href="http://psnc.org.uk/funding-and-statistics/nhs-statistics/nms-statistics/">NMS statistics</a></li>
-		<li id="menu-item-124592" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-124592"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/summary-care-record-scr-home/scr-overview/scr-statistics/">SCR statistics</a></li>
-		<li id="menu-item-210538" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-210538"><a href="http://psnc.org.uk/services-commissioning/essential-services/quality-payments/quality-payments-scheme-statistics/">Quality Payments Statistics</a></li>
-	</ul>
-</li>
-	<li id="menu-item-16233" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-16233"><a>Other resources</a>
-	<ul class="child-menu">
-		<li id="menu-item-5087" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5087"><a href="/our-latest-news-category/funding-and-statistics/">News</a></li>
-		<li id="menu-item-5107" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5107"><a href="http://psnc.org.uk/funding-and-statistics/psnc-briefings-funding-and-statistics/">PSNC Briefings</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-247" class="menu-pharmacy-contract-and-funding menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-247"><a href="http://psnc.org.uk/contract-it/">Contract and IT</a>
-<ul class="child-menu">
-	<li id="menu-item-1599" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1599"><a href="http://psnc.org.uk/contract-it/the-pharmacy-contract/">Contractual Framework</a>
-	<ul class="child-menu">
-		<li id="menu-item-135097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135097"><a href="http://psnc.org.uk/contract-it/cpcf-changes-201617-and-201718/">CPCF changes 2016/17 &#038; 2017/18</a></li>
-		<li id="menu-item-1578" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1578"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/">Market entry</a></li>
-		<li id="menu-item-1594" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1594"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/distance-selling-pharmacies/">Distance selling pharmacies</a></li>
-		<li id="menu-item-10141" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10141"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/relocations-which-do-not-result-in-significant-change/">Relocations</a></li>
-		<li id="menu-item-10142" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10142"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/rural-issues/">Rural issues</a></li>
-		<li id="menu-item-10143" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10143"><a href="http://psnc.org.uk/contract-it/market-entry-regulations/pharmaceutical-needs-assessment/">PNAs</a></li>
-		<li id="menu-item-10135" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10135"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/essential-small-pharmacies/">Essential Small Pharmacies</a></li>
-		<li id="menu-item-1945" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1945"><a href="http://psnc.org.uk/services-commissioning/essential-services/">Essential Services</a></li>
-		<li id="menu-item-1947" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1947"><a href="http://psnc.org.uk/services-commissioning/advanced-services/">Advanced Services</a></li>
-	</ul>
-</li>
-	<li id="menu-item-1583" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1583"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/">Regulatory matters</a>
-	<ul class="child-menu">
-		<li id="menu-item-995" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-995"><a href="http://psnc.org.uk/contract-it/the-pharmacy-contract/contract-monitoring/">Contract monitoring</a></li>
-		<li id="menu-item-3946" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3946"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/dda/">The Equality Act 2010</a></li>
-		<li id="menu-item-10136" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10136"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/fitness-to-practice/">Fitness to Practise</a></li>
-		<li id="menu-item-10139" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10139"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/performance-panels/">Performance panels</a></li>
-		<li id="menu-item-10140" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10140"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/responsible-pharmacist/">Responsible Pharmacist</a></li>
-		<li id="menu-item-10134" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10134"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/direction-of-prescriptions/">Direction of prescriptions</a></li>
-		<li id="menu-item-10133" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10133"><a href="http://psnc.org.uk/contract-it/pharmacy-regulation/dbs-checks/">DBS checks</a></li>
-		<li id="menu-item-135154" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135154"><a href="http://psnc.org.uk/contract-it/pharmacy-mergers-consolidations/">Pharmacy consolidations (mergers)</a></li>
-		<li id="menu-item-135056" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135056"><a href="http://psnc.org.uk/contract-it/pharmacy-access-scheme-phas/">Pharmacy Access Scheme</a></li>
-	</ul>
-</li>
-	<li id="menu-item-1977" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-1977"><a href="http://psnc.org.uk/contract-it/pharmacy-it/">Community pharmacy IT</a>
-	<ul class="child-menu">
-		<li id="menu-item-136230" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-136230"><a href="http://psnc.org.uk/contract-it/pharmacy-it/nhs-mail/">NHSmail</a></li>
-		<li id="menu-item-108748" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108748"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/">EHR home</a></li>
-		<li id="menu-item-2169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2169"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS home</a></li>
-		<li id="menu-item-17186" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17186"><a href="http://psnc.org.uk/dispensing-supply/eps/patient-nomination-of-a-dispensing-site/">EPS nomination</a></li>
-		<li id="menu-item-17188" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17188"><a href="http://psnc.org.uk/dispensing-supply/eps/contingency-arrangements/">EPS Business Continuity</a></li>
-		<li id="menu-item-152131" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152131"><a href="http://psnc.org.uk/contract-it/pharmacy-it/information-governance-and-cybersecurity/">IG &#038; cybersecurity</a></li>
-		<li id="menu-item-10255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10255"><a href="http://psnc.org.uk/contract-it/pharmacy-it/smartcards/">Smartcards</a></li>
-		<li id="menu-item-108749" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108749"><a href="http://psnc.org.uk/contract-it/pharmacy-it/electronic-health-records/summary-care-record-scr-home/">SCR home</a></li>
-		<li id="menu-item-5559" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5559"><a href="http://psnc.org.uk/contract-it/pharmacy-it/pharmacy-system-suppliers/">System suppliers</a></li>
-	</ul>
-</li>
-	<li id="menu-item-8769" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-8769"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/">Clinical Governance</a>
-	<ul class="child-menu">
-		<li id="menu-item-18116" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18116"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/clinical-audit/">Clinical audit</a></li>
-		<li id="menu-item-8770" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8770"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/cppq/">Community Pharmacy Patient Questionnaire (CPPQ)</a></li>
-		<li id="menu-item-18117" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18117"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/complaints/">NHS complaints procedure</a></li>
-		<li id="menu-item-8768" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8768"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/patient-safety-incident-reporting/">Patient safety incident reporting</a></li>
-		<li id="menu-item-8772" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8772"><a href="http://psnc.org.uk/contract-it/essential-service-clinical-governance/practice-leaflet-requirements/">Practice leaflet requirements</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-244" class="menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children menu-item-244"><a href="http://psnc.org.uk/dispensing-supply/">Dispensing and Supply</a>
-<ul class="child-menu">
-	<li id="menu-item-2212" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2212"><a href="http://psnc.org.uk/dispensing-supply/dispensing-process/">The dispensing process</a>
-	<ul class="child-menu">
-		<li id="menu-item-671" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-671"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/">Receiving a prescription</a></li>
-		<li id="menu-item-670" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-670"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/">Is this item allowed?</a></li>
-		<li id="menu-item-668" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-668"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/">Dispensing a prescription</a></li>
-		<li id="menu-item-667" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-667"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/">Controlled Drugs</a></li>
-		<li id="menu-item-672" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-672"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS main page</a></li>
-		<li id="menu-item-17189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17189"><a href="http://psnc.org.uk/dispensing-supply/eps/overview-of-eps-functionality/">Using EPS</a></li>
-	</ul>
-</li>
-	<li id="menu-item-7479" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-7479"><a href="http://psnc.org.uk/dispensing-supply/endorsement-payment/">Endorsement &#038; payment</a>
-	<ul class="child-menu">
-		<li id="menu-item-3569" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3569"><a href="http://psnc.org.uk/dispensing-supply/endorsement/">Item endorsement &#038; pricing</a></li>
-		<li id="menu-item-664" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-664"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-submission/">Prescription submission</a></li>
-		<li id="menu-item-17185" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-17185"><a href="http://psnc.org.uk/dispensing-supply/eps/endorsing-and-submission/">EPS endorsing &#038; submitting</a></li>
-		<li id="menu-item-663" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-663"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/monthly-payments/">Monthly payments</a></li>
-		<li id="menu-item-662" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-662"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-pricing-accuracy/">Prescription pricing accuracy</a></li>
-	</ul>
-</li>
-	<li id="menu-item-2120" class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current-menu-parent current-page-parent current_page_parent current_page_ancestor menu-item-has-children menu-item-2120"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/">Supply chain &#038; shortages</a>
-	<ul class="child-menu">
-		<li id="menu-item-2122" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2122"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/distribution-of-medicines/">Distribution of medicines</a></li>
-		<li id="menu-item-2121" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2121"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer contingency arrangements</a></li>
-		<li id="menu-item-100911" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item menu-item-100911"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions &#038; NCSO</a></li>
-		<li id="menu-item-673" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-673"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/">Branded supply issues</a></li>
-		<li id="menu-item-2123" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2123"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Appliance issues</a></li>
-		<li id="menu-item-13983" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-13983"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/">Supply issue feedback forms</a></li>
-	</ul>
-</li>
-	<li id="menu-item-2231" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2231"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/">Resources</a>
-	<ul class="child-menu">
-		<li id="menu-item-2233" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2233"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/quick-reference-guides/">Quick reference guides</a></li>
-		<li id="menu-item-2232" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2232"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff</a></li>
-		<li id="menu-item-7534" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7534"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">External resources</a></li>
-		<li id="menu-item-108797" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-108797"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/primary-care-support-england-pcse/">Primary Care Support England (PCSE)</a></li>
-		<li id="menu-item-5618" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5618"><a href="/our-latest-news-category/dispensing-and-supply/">News</a></li>
-		<li id="menu-item-5130" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5130"><a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-249" class="menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-249"><a href="http://psnc.org.uk/services-commissioning/">Services and Commissioning</a>
-<ul class="child-menu">
-	<li id="menu-item-979" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-979"><a href="http://psnc.org.uk/services-commissioning/essential-services/">Essential Services</a>
-	<ul class="child-menu">
-		<li id="menu-item-986" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-986"><a href="http://psnc.org.uk/services-commissioning/essential-services/essential-service-dispensing-of-medicines/">Dispensing Medicines</a></li>
-		<li id="menu-item-1829" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1829"><a href="http://psnc.org.uk/services-commissioning/essential-services/dispensing-of-appliances/">Dispensing Appliances</a></li>
-		<li id="menu-item-987" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-987"><a href="http://psnc.org.uk/services-commissioning/essential-services/repeat-dispensing/">Repeat Dispensing/eRD</a></li>
-		<li id="menu-item-1828" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1828"><a href="http://psnc.org.uk/services-commissioning/essential-services/disposal-of-unwanted-medicines/">Unwanted Medicines</a></li>
-		<li id="menu-item-1832" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1832"><a href="http://psnc.org.uk/services-commissioning/essential-services/public-health/">Public Health (Promotion of Healthy Lifestyles)</a></li>
-		<li id="menu-item-1830" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1830"><a href="http://psnc.org.uk/services-commissioning/essential-services/signposting/">Signposting</a></li>
-		<li id="menu-item-1831" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1831"><a href="http://psnc.org.uk/services-commissioning/essential-services/support-for-self-care/">Self Care</a></li>
-	</ul>
-</li>
-	<li id="menu-item-978" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-978"><a href="http://psnc.org.uk/services-commissioning/advanced-services/">Advanced Services</a>
-	<ul class="child-menu">
-		<li id="menu-item-61796" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-61796"><a href="http://psnc.org.uk/services-commissioning/advanced-services/flu-vaccination-service/">Flu Vaccination Service</a></li>
-		<li id="menu-item-984" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-984"><a href="http://psnc.org.uk/services-commissioning/advanced-services/murs/">MUR</a></li>
-		<li id="menu-item-983" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-983"><a href="http://psnc.org.uk/services-commissioning/advanced-services/nms/">NMS</a></li>
-		<li id="menu-item-2486" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2486"><a href="http://psnc.org.uk/services-commissioning/advanced-services/aurs/">AUR</a></li>
-		<li id="menu-item-2485" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2485"><a href="http://psnc.org.uk/services-commissioning/advanced-services/sac/">SAC</a></li>
-		<li id="menu-item-135096" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135096"><a href="http://psnc.org.uk/services-commissioning/urgent-medicine-supply-service/">NHS Urgent Medicine Supply Advanced Service (NUMSAS)</a></li>
-	</ul>
-</li>
-	<li id="menu-item-993" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-993"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/">Local Services</a>
-	<ul class="child-menu">
-		<li id="menu-item-136273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-136273"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/healthy-living-pharmacies/">Healthy Living Pharmacies</a></li>
-		<li id="menu-item-18500" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-18500"><a href="http://psnc.org.uk/services-commissioning/locally-commissioned-services/">Service specifications &#038; resources</a></li>
-		<li id="menu-item-90597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-90597"><a href="http://psnc.org.uk/services-commissioning/essential-facts-stats-and-quotes/">Essential facts, stats &#038; quotes</a></li>
-		<li id="menu-item-2198" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2198"><a href="http://psnc.org.uk/services-commissioning/services-database/">Services Database</a></li>
-		<li id="menu-item-5772" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5772"><a href="http://psnc.org.uk/services-commissioning/pharmoutcomes/">PharmOutcomes</a></li>
-		<li id="menu-item-53437" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53437"><a href="http://psnc.org.uk/services-commissioning/commissioners-portal/">Commissioners Portal</a></li>
-	</ul>
-</li>
-	<li id="menu-item-52550" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-52550"><a>Other resources</a>
-	<ul class="child-menu">
-		<li id="menu-item-135155" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135155"><a href="http://psnc.org.uk/services-commissioning/essential-services/quality-payments/">Quality Payments</a></li>
-		<li id="menu-item-79879" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79879"><a href="http://psnc.org.uk/services-commissioning/antibiotic-resistance-2/">Antibiotic resistance</a></li>
-		<li id="menu-item-2886" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2886"><a href="http://psnc.org.uk/services-commissioning/working-with-gps/">Working with GPs</a></li>
-		<li id="menu-item-5774" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5774"><a href="http://psnc.org.uk/services-commissioning/working-with-hospital-colleagues/">Working with hospital colleagues</a></li>
-		<li id="menu-item-5619" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5619"><a href="/our-latest-news-category/services-commissioning/">News</a></li>
-		<li id="menu-item-5122" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5122"><a href="http://psnc.org.uk/services-commissioning/psnc-briefings-services-and-commissioning/">PSNC Briefings</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-2370" class="menu-the-healthcare-landscape menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2370"><a href="http://psnc.org.uk/the-healthcare-landscape/">The Healthcare Landscape</a>
-<ul class="child-menu">
-	<li id="menu-item-5047" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-5047"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/">Healthcare who&#8217;s who</a>
-	<ul class="child-menu">
-		<li id="menu-item-5046" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5046"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/nhs-england/">NHS England</a></li>
-		<li id="menu-item-5050" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5050"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/clinical-commissioning-groups-ccg/">Clinical Commissioning Groups</a></li>
-		<li id="menu-item-5049" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5049"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/local-authorities-local-government/">Local Authorities (local government)</a></li>
-		<li id="menu-item-5045" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5045"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/local-professional-networks/">Local Professional Networks</a></li>
-		<li id="menu-item-5048" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5048"><a href="http://psnc.org.uk/the-healthcare-landscape/healthcare-whos-who/public-health-england/">Public Health England</a></li>
-	</ul>
-</li>
-	<li id="menu-item-62175" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62175"><a>Health &#038; care policy</a>
-	<ul class="child-menu">
-		<li id="menu-item-16051" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16051"><a href="http://psnc.org.uk/the-healthcare-landscape/the-nhs-five-year-forward-view-5yfv/">The NHS Five-Year Forward View (5YFV)</a></li>
-		<li id="menu-item-62196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62196"><a href="http://psnc.org.uk/the-healthcare-landscape/urgent-and-emergency-care/">Urgent &#038; emergency care</a></li>
-		<li id="menu-item-62192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62192"><a href="http://psnc.org.uk/the-healthcare-landscape/better-care-fund/">Better Care Fund</a></li>
-		<li id="menu-item-100351" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-100351"><a href="http://psnc.org.uk/the-healthcare-landscape/sustainability-and-transformation-plans/">Sustainability &#038; Transformation Partnerships</a></li>
-		<li id="menu-item-152133" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152133"><a href="http://psnc.org.uk/contract-it/pharmacy-it/policy-the-nhs-and-it/">NHS &#038; IT</a></li>
-	</ul>
-</li>
-	<li id="menu-item-62177" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62177"><a>Current initiatives</a>
-	<ul class="child-menu">
-		<li id="menu-item-62185" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62185"><a href="http://psnc.org.uk/the-healthcare-landscape/prime-ministers-challenge-fund/">Prime Minister’s GP Access Fund</a></li>
-		<li id="menu-item-62189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-62189"><a href="http://psnc.org.uk/the-healthcare-landscape/new-models-of-care-vanguard-sites/">Vanguard sites</a></li>
-		<li id="menu-item-16052" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16052"><a href="http://psnc.org.uk/the-healthcare-landscape/co-commissioning-of-primary-care-services/">Co-commissioning of primary care services</a></li>
-		<li id="menu-item-63206" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-63206"><a href="http://psnc.org.uk/the-healthcare-landscape/nhs-diabetes-prevention-programme/">NHS Diabetes Prevention Programme</a></li>
-	</ul>
-</li>
-	<li id="menu-item-62201" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-62201"><a>Other resources</a>
-	<ul class="child-menu">
-		<li id="menu-item-135153" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-135153"><a href="http://psnc.org.uk/the-healthcare-landscape/the-pharmacy-integration-fund-phif/">Pharmacy Integration Fund</a></li>
-		<li id="menu-item-5620" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-5620"><a href="/our-latest-news-category/the-healthcare-landscape/">News</a></li>
-		<li id="menu-item-5065" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5065"><a href="http://psnc.org.uk/the-healthcare-landscape/psnc-briefings-the-healthcare-landscape/">PSNC Briefings</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li id="menu-item-2471" class="menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2471"><a href="http://psnc.org.uk/lpcs/">LPCs</a>
-<ul class="child-menu">
-	<li id="menu-item-2476" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2476"><a href="http://psnc.org.uk/lpcs/about-lpcs/">About LPCs</a>
-	<ul class="child-menu">
-		<li id="menu-item-2483" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2483"><a href="/lpconline">LPC sites</a></li>
-		<li id="menu-item-152179" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-152179"><a href="http://psnc.org.uk/lpcs/lpcs-in-the-spotlight/">LPCs in the Spotlight</a></li>
-	</ul>
-</li>
-	<li id="menu-item-53508" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-53508"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/">Communications &#038; lobbying</a>
-	<ul class="child-menu">
-		<li id="menu-item-53507" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53507"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/communications-and-pr/working-with-commissioners/">Working with commissioners</a></li>
-		<li id="menu-item-53509" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-53509"><a href="http://psnc.org.uk/psncs-work/communications-and-lobbying/communications-and-pr/working-with-commissioners/thinkpharmacy/">Think Pharmacy</a></li>
-		<li id="menu-item-183161" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-183161"><a href="http://psnc.org.uk/lpcs/healthcare-together/">Healthcare Together</a></li>
-	</ul>
-</li>
-	<li id="menu-item-4664" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-4664"><a href="http://psnc.org.uk/lpcs/lpc-members-area/">LPC Members&#8217; Area</a>
-	<ul class="child-menu">
-		<li id="menu-item-7116" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7116"><a href="http://psnc.org.uk/lpcs/about-lpcs/lpc-events/">LPC events</a></li>
-		<li id="menu-item-7115" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7115"><a href="http://psnc.org.uk/lpcs/lpc-members-area/lpc-member-changes/">LPC member changes</a></li>
-		<li id="menu-item-79936" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-79936"><a href="http://psnc.org.uk/lpcs/lpc-members-area/psnc-leadership-academy/">PSNC Leadership Academy</a></li>
-	</ul>
-</li>
-	<li id="menu-item-5621" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-5621"><a href="/our-latest-news-category/latest-lpc-news/">LPC News</a>
-	<ul class="child-menu">
-		<li id="menu-item-11775" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-11775"><a href="http://psnc.org.uk/lpcs/lposs/">Local Pharmacy Organisation Support Services (LPOSS)</a></li>
-		<li id="menu-item-199483" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-199483"><a href="http://psnc.org.uk/podcast">Podcasts</a></li>
-		<li id="menu-item-9150" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9150"><a href="http://psnc.org.uk/lpcs/psnc-briefings/">PSNC Briefings</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-</ul>						</div>
-						<!-- /wrapper -->
-					</nav>
-					<!-- /main-nav -->
-					
-					
-					<!-- mobile-nav -->
-											<script type="text/javascript">
-							jQuery(document).ready(function(){
-								jQuery('.main-nav.mobileelement').hide();
-								jQuery(".show-hide.main-menu a").click(function(){
-									jQuery('.main-nav.mobileelement').slideToggle("fast");
-									jQuery(this).toggleClass("open");
-									return false;
-								});
-							});
-						</script>
-						<div class="show-hide main-menu mobileelement sixteen columns clear"><a href="#">Main menu</a></div>				
-										
-					<nav class="main-nav mobileelement" role="navigation">
-												<div class="wrapper clear">
-							<ul id="menu-main-navigation-1" class="menu root-menu"><li class="menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-248"><a href="http://psnc.org.uk/psncs-work/">PSNC&#8217;s Work</a></li>
-<li class="menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-16135"><a href="http://psnc.org.uk/funding-and-statistics/">Funding and Statistics</a></li>
-<li class="menu-pharmacy-contract-and-funding menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-247"><a href="http://psnc.org.uk/contract-it/">Contract and IT</a></li>
-<li class="menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children menu-item-244"><a href="http://psnc.org.uk/dispensing-supply/">Dispensing and Supply</a></li>
-<li class="menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-249"><a href="http://psnc.org.uk/services-commissioning/">Services and Commissioning</a></li>
-<li class="menu-the-healthcare-landscape menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2370"><a href="http://psnc.org.uk/the-healthcare-landscape/">The Healthcare Landscape</a></li>
-<li class="menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2471"><a href="http://psnc.org.uk/lpcs/">LPCs</a></li>
-</ul>						</div>
-						<!-- /wrapper -->
-						
-					</nav>
-					<!-- /mobile-nav -->
-			
-			</header>
-			<!-- /header -->			
-			
-			
-			
-			
-	<div role="main" class="wrapper clear">		<div class="sidebar-nav four columns">
-						<nav>
-				<ul>
-					<li class="hideformobile"><a href="http://psnc.org.uk" class="back-home">Home</a></li>
-					<!-- mobile navigation toggle -->
-					<li class="mobileelement toggle">
-						<script type="text/javascript">
-							jQuery(document).ready(function($){
-								if ($(window).width() < 500) {
-									$(".sidebar-nav ul li.page_item").hide();
-									$(".sidebar-nav ul li a.parent-page").hide();
-									$(".show-hide.sidebar a").click(function(){
-										$('.sidebar-nav ul li.page_item').slideToggle("fast");
-										$(this).toggleClass("open");
-										return false;
-									});
-								}
-							});
-						</script>
-						<div class="show-hide sidebar mobileelement"><a href="#">Show/Hide all pages in Dispensing and Supply section</a></div>
-					</li>
-					<li class="pagenav"><a href="http://psnc.org.uk/dispensing-supply" class="parent-page">Dispensing and Supply</a><ul><li class="page_item page-item-218273"><a href="http://psnc.org.uk/dispensing-supply/digitisation-of-the-prescription-submission-fp34c-form-referred-back-items/">Digitisation of the Prescription Submission (FP34C) Form &#038; Referred Back Items</a></li>
-<li class="page_item page-item-589 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/">Dispensing a prescription</a>
-<ul class='children'>
-	<li class="page_item page-item-2292"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/appliances/">Appliances</a></li>
-	<li class="page_item page-item-333"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/medicinal-products/">Medicinal products</a></li>
-	<li class="page_item page-item-2298"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/quantity/">Quantity</a></li>
-	<li class="page_item page-item-547 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/special-containers/">Special containers (including dispensing of oral liquid antibiotics requiring reconstitution)</a>
-	<ul class='children'>
-		<li class="page_item page-item-2304"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/special-containers/special-container-database/">Special Container Database</a></li>
-	</ul>
-</li>
-	<li class="page_item page-item-2301"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/split-pack-dispensing/">Split pack dispensing</a></li>
-	<li class="page_item page-item-1442"><a href="http://psnc.org.uk/dispensing-supply/dispensing-a-prescription/unlicensed-specials-and-imports/">Unlicensed specials and imports</a></li>
-</ul>
-</li>
-<li class="page_item page-item-593 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/">Dispensing Controlled Drugs</a>
-<ul class='children'>
-	<li class="page_item page-item-1744"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/controlled-drug-prescription-forms-validity/">Controlled Drug prescription forms and validity</a></li>
-	<li class="page_item page-item-1718"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/controlled-drug-resources-faqs/">Controlled Drug resources and FAQs</a></li>
-	<li class="page_item page-item-327"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/instalment-dispensing/">Instalment dispensing</a></li>
-	<li class="page_item page-item-1732"><a href="http://psnc.org.uk/dispensing-supply/dispensing-controlled-drugs/methadone-dispensing/">Methadone dispensing (FP10 and FP10MDA)</a></li>
-</ul>
-</li>
-<li class="page_item page-item-2139 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/">Drug Tariff resources</a>
-<ul class='children'>
-	<li class="page_item page-item-823"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/quick-reference-guides/">Quick reference guides</a></li>
-	<li class="page_item page-item-827"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff</a></li>
-	<li class="page_item page-item-5830"><a href="http://psnc.org.uk/dispensing-supply/drug-tariff-resources/external-resources/">Where to obtain external resources</a></li>
-</ul>
-</li>
-<li class="page_item page-item-7358"><a href="http://psnc.org.uk/dispensing-supply/endorsement-payment/">Endorsement and payment</a></li>
-<li class="page_item page-item-386"><a href="http://psnc.org.uk/dispensing-supply/eps/">EPS home</a></li>
-<li class="page_item page-item-285 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/">Is this item allowed?</a>
-<ul class='children'>
-	<li class="page_item page-item-2290"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/common-disallowed-appliances-list/">Common Disallowed Appliances List</a></li>
-	<li class="page_item page-item-20682"><a href="http://psnc.org.uk/dispensing-supply/is-this-item-allowed/fp10database/">Dispensing on an FP10 database</a></li>
-</ul>
-</li>
-<li class="page_item page-item-600 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/endorsement/">Item endorsement and pricing</a>
-<ul class='children'>
-	<li class="page_item page-item-363"><a href="http://psnc.org.uk/dispensing-supply/endorsement/endorsement-guidance/">Endorsement guidance</a></li>
-	<li class="page_item page-item-797 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/">Fees and allowances</a>
-	<ul class='children'>
-		<li class="page_item page-item-72"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/bb/">Broken bulk</a></li>
-		<li class="page_item page-item-402"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/consumables-containers/">Consumables and container allowance</a></li>
-		<li class="page_item page-item-56"><a href="http://psnc.org.uk/dispensing-supply/endorsement/fees-allowances/oop/">Out of pocket expenses</a></li>
-	</ul>
-</li>
-	<li class="page_item page-item-405"><a href="http://psnc.org.uk/dispensing-supply/endorsement/discount-deduction/">How discount deduction works</a></li>
-	<li class="page_item page-item-2309"><a href="http://psnc.org.uk/dispensing-supply/endorsement/how-the-price-change-mechanism-works/">How the price change mechanism works</a></li>
-</ul>
-</li>
-<li class="page_item page-item-2215 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/">Prescription payment and pricing accuracy</a>
-<ul class='children'>
-	<li class="page_item page-item-90120"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/common-issues-that-can-lead-to-pricing-errors/">Common issues that can lead to pricing errors</a></li>
-	<li class="page_item page-item-605"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/monthly-payments/">Monthly payments</a></li>
-	<li class="page_item page-item-14954"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-payment-and-pricing-accuracy-factsheets/">Prescription payment and pricing accuracy factsheets</a></li>
-	<li class="page_item page-item-607"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-pricing-accuracy/">Prescription pricing accuracy</a></li>
-	<li class="page_item page-item-602"><a href="http://psnc.org.uk/dispensing-supply/payment-accuracy/prescription-submission/">Prescription submission</a></li>
-</ul>
-</li>
-<li class="page_item page-item-3660"><a href="http://psnc.org.uk/dispensing-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing and Supply</a></li>
-<li class="page_item page-item-375 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/">Receiving a prescription</a>
-<ul class='children'>
-	<li class="page_item page-item-2280 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/is-this-prescription-form-valid/">Is this prescription form valid?</a>
-	<ul class='children'>
-		<li class="page_item page-item-7592"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/is-this-prescription-form-valid/period-of-validity/">How long is a prescription valid for?</a></li>
-	</ul>
-</li>
-	<li class="page_item page-item-2283"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/how-to-identify-prescriber-codes/">Prescriber codes</a></li>
-	<li class="page_item page-item-368 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/">What does the patient pay?</a>
-	<ul class='children'>
-		<li class="page_item page-item-384"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/exemptions/">Exemptions from the prescription charge</a></li>
-		<li class="page_item page-item-12946"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/prescription-charge-card/">Prescription Charge Card and Multi Charge Card</a></li>
-		<li class="page_item page-item-381"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/patient-charges/refunds/">Prescription charge refund procedure</a></li>
-	</ul>
-</li>
-	<li class="page_item page-item-2285"><a href="http://psnc.org.uk/dispensing-supply/receiving-a-prescription/who-can-prescribe-what/">Who can prescribe what?</a></li>
-</ul>
-</li>
-<li class="page_item page-item-2106 page_item_has_children current_page_ancestor current_page_parent"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/">Supply chain and shortages</a>
-<ul class='children'>
-	<li class="page_item page-item-227 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/">Branded medicine shortages</a>
-	<ul class='children'>
-		<li class="page_item page-item-1467"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/branded-shortages/branded-shortages-list/">Branded supply problems</a></li>
-	</ul>
-</li>
-	<li class="page_item page-item-598"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/distribution-of-medicines/">Distribution of medicines</a></li>
-	<li class="page_item page-item-1473"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer contingency arrangements</a></li>
-	<li class="page_item page-item-100786 current_page_item"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/">Price Concessions and NCSO</a></li>
-	<li class="page_item page-item-6739 page_item_has_children"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/">Supply issue feedback forms</a>
-	<ul class='children'>
-		<li class="page_item page-item-1910"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-a-branded-medicine/">Problems obtaining a branded medicine?</a></li>
-		<li class="page_item page-item-3115"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Problems obtaining a generic medicine?</a></li>
-		<li class="page_item page-item-229"><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Problems obtaining an appliance?</a></li>
-	</ul>
-</li>
-</ul>
-</li>
-<li class="page_item page-item-2032"><a href="http://psnc.org.uk/dispensing-supply/dispensing-process/">The dispensing process</a></li>
-</ul></li>					
-					
-				</ul>
-			</nav>
+			</div>
 		</div>
-		<!-- /sidebar-nav -->
-		
-		
-		<div class="page-content twelve columns">
-		
-			<div class="breadcrumb fifteen columns"><a href='http://psnc.org.uk'>Home</a> > <a href=http://psnc.org.uk/dispensing-supply/supply-chain/>Dispensing and Supply</a> > Price Concessions and NCSO </div><div class="one column"><div class='printomatic pom-default ' id='id5989'  data-print_target='.page-content'></div> </div><br />
-		
-			<h1 class="mobileelement" style="margin:0.5em 0 0 0; clear: left; float: left; width: 100%;">Price Concessions and NCSO</h1>
+	</div>
+	
+		<div class="header-wrapper">
+		<div class="container-wide header-container">
+			<div class="row align-items-center">
+				
+				<!-- Site logo -->
+				<div class="col-l-3 col-6">
+					<div class="site-logo-title">
 
-			<!-- post thumbnail -->
-							<img src="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image-250x96.jpg 250w, http://psnc.org.uk/wp-content/uploads/2016/02/Small-pharmacy-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />						<!-- /post thumbnail -->
+						<a href="https://psnc.org.uk" class="site-logo "><img src="https://psnc.org.uk/wp-content/uploads/2021/09/psnc-logo.svg" alt="PSNC"></a>
+						<a href="https://psnc.org.uk" class="site-title"><h2>Pharmaceutical Services<br />
+Negotiating Committee</h2></a>						
+					</div>
+				</div>
+				
+				<!-- Search form -->
+				<div class="col-l-6 search-wrap d-l-block d-none">
+											<div class="search-form-wrap">
+							<form class="search-form" method="get" action="https://psnc.org.uk" role="search" autocomplete="off">
+	<input class="search-input" type="text" name="s" id="keyword" value="" placeholder="Hello, what are you looking for today?"></input>
+	<input type="hidden" value="all" name="post_type" id="searchOptionsAll">
+	<button class="btn-gradient btn-search btn-form" type="submit" role="button"><svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.55295 17.105C10.5265 17.105 12.3408 16.4261 13.7884 15.3004L18.4883 20L20 18.4883L15.3002 13.7888C16.427 12.3402 17.1059 10.526 17.1059 8.55249C17.1059 3.83686 13.2688 0 8.55295 0C3.83707 0 0 3.83686 0 8.55249C0 13.2681 3.83707 17.105 8.55295 17.105ZM8.55295 2.13812C12.0907 2.13812 14.9677 5.01497 14.9677 8.55249C14.9677 12.09 12.0907 14.9669 8.55295 14.9669C5.01523 14.9669 2.13824 12.09 2.13824 8.55249C2.13824 5.01497 5.01523 2.13812 8.55295 2.13812Z" /></svg></button>
+</form>						</div>
+									</div>
+				
+				<!-- Header right -->
+				<div class="col-l-3 col-6 header-right-wrap">
+					<div class="header-right">
+
+						<div class="top-links">
+							<a href="https://lpc-online.org.uk/" class="link-text">LPC Websites</a><span>|</span><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/" class="link-text">Contact Us</a>						</div>
+						
+													<div class="header-link pharmacy-link">
+								<a href="https://psnc.org.uk/pharmacy-the-heart-of-our-community/">
+									<div class="link-title">
+										<div class="icon"><svg width="8" height="12" viewBox="0 0 8 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4.0007 0.5C3.04466 0.501213 2.12812 0.881537 1.45209 1.55756C0.776068 2.23359 0.395744 3.15012 0.394531 4.10617H2.22786C2.22786 3.12808 3.02353 2.33333 4.0007 2.33333C4.97787 2.33333 5.77353 3.12808 5.77353 4.10617C5.77353 4.65433 5.33262 5.05217 4.65887 5.59667C4.43876 5.76909 4.22736 5.95234 4.02545 6.14575C3.11062 7.05967 3.08403 8.03042 3.08403 8.13858V8.75H4.91737L4.91645 8.16975C4.91736 8.15508 4.9467 7.81592 5.3207 7.44283C5.4582 7.30533 5.63145 7.16783 5.81112 7.023C6.5252 6.44458 7.60595 5.571 7.60595 4.10617C7.60522 3.15013 7.22518 2.23345 6.54925 1.55735C5.87331 0.881246 4.95673 0.500971 4.0007 0.5ZM3.08403 9.66667H4.91737V11.5H3.08403V9.66667Z" fill="#55318C"/></svg></div>
+										<p>Not a pharmacy</p>
+									</div>
+									<div class="link-text">Use these resources <svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div>
+								</a>
+							</div>
+						
+					</div>
+					<div class="btn-gradient btn-form search-close"><svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10.8661 0.608398L6.44635 5.02715L2.0276 0.608398L0.554688 2.08132L4.97344 6.50007L0.554688 10.9188L2.0276 12.3917L6.44635 7.97298L10.8661 12.3917L12.3391 10.9188L7.92031 6.50007L12.3391 2.08132L10.8661 0.608398Z"/></svg></div>
+
+					<div id="mobile-menu-button" class="mobile-right">
+						<div class="search-button-mobile btn-gradient btn-form">
+							<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.55295 17.105C10.5265 17.105 12.3408 16.4261 13.7884 15.3004L18.4883 20L20 18.4883L15.3002 13.7888C16.427 12.3402 17.1059 10.526 17.1059 8.55249C17.1059 3.83686 13.2688 0 8.55295 0C3.83707 0 0 3.83686 0 8.55249C0 13.2681 3.83707 17.105 8.55295 17.105ZM8.55295 2.13812C12.0907 2.13812 14.9677 5.01497 14.9677 8.55249C14.9677 12.09 12.0907 14.9669 8.55295 14.9669C5.01523 14.9669 2.13824 12.09 2.13824 8.55249C2.13824 5.01497 5.01523 2.13812 8.55295 2.13812Z" /></svg>						</div>
+
+						<div class="mobile-menu-button">
+							<span class="top"></span>
+							<span class="middle"></span>
+							<span class="bottom"></span>
+						</div>
+					</div>
+
+				</div>
+			</div>
+		</div>
+	</div>
+	<!-- Navigation -->
+	<div class="outer-main-nav">
+		<div class="header-main-nav">
+			<span class="header-overlay nav-overlay"></span>
+			<div class="container-wide">
+				<div class="row">
+					<div class="col-12">
+						<nav class="main-navigation reduced-size-menu">
+						
+							<a href="https://psnc.org.uk" class="site-logo"><img src="https://psnc.org.uk/wp-content/uploads/2021/09/psnc-logo.svg" alt="PSNC"></a>				
+							<div class="menu-main-navigation-container"><ul id="primary-menu" class="menu"><li id="menu-item-427484" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor menu-item-has-children top-item purple-bg-item menu-item-427484"><a href="#">Quick Links</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-462781" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children sub-item menu-item-462781"><a href="#">KEY PAGES</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462786" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462786"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/community-pharmacist-consultation-service/">CPCS</a></li>
+		<li id="menu-item-462756" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462756"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/covid19/">COVID-19 Hub</a></li>
+		<li id="menu-item-427876" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427876"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)</a></li>
+		<li id="menu-item-462785" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462785"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/medicine-shortages/">Medicine Shortages</a></li>
+		<li id="menu-item-462783" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item menu-item-462783"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" aria-current="page">Price Concessions</a></li>
+		<li id="menu-item-462784" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462784"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Item Over Drug Tariff Price</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462790" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item menu-item-462790"><a href="#">PSNC RESOURCES</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427485" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427485"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us</a></li>
+		<li id="menu-item-462774" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462774"><a href="/our-latest-news-category/headline/">Headline News</a></li>
+		<li id="menu-item-462773" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462773"><a href="/our-news/">News Index</a></li>
+		<li id="menu-item-462782" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462782"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-webinars/">Our Webinars</a></li>
+		<li id="menu-item-462775" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462775"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database</a></li>
+		<li id="menu-item-462779" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462779"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Sign Up For Our Email Newsletters</a></li>
+		<li id="menu-item-462776" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462776"><a href="/psncs-work/our-events/">Upcoming Events</a></li>
+		<li id="menu-item-462777" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462777"><a href="https://twitter.com/PSNCNews">@PSNCNews on Twitter</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462780" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item menu-item-462780"><a href="#">OTHER USEFUL RESOURCES</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427486" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-427486"><a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">Drug Tariff</a></li>
+		<li id="menu-item-462788" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462788"><a href="https://www.england.nhs.uk/primary-care/pharmacy/pharmacy-contract-teams/">Local NHS England Team Contacts</a></li>
+		<li id="menu-item-462789" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462789"><a href="https://digital.nhs.uk/services/registration-authorities-and-smartcards/primary-care-service-provider-contact-details">Smartcard RA Contacts</a></li>
+		<li id="menu-item-462778" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462778"><a href="https://lpc-online.org.uk/">Visit Your LPC&#8217;s Website</a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-248" class="menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item purple-item menu-item-248"><a href="https://psnc.org.uk/psnc-and-negotiations/">PSNC &#038; Negotiations</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-1669" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-1669"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/">About PSNC</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-1903" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-1903"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-members/">Committee Members</a></li>
+		<li id="menu-item-1901" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-1901"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-meetings/">Meeting Agendas &#038; Minutes</a></li>
+		<li id="menu-item-1904" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-1904"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-staff/">Our Team</a></li>
+		<li id="menu-item-427874" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427874"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us</a></li>
+		<li id="menu-item-457990" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-457990"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-structure-governance/">Structure &#038; Governance</a></li>
+		<li id="menu-item-457989" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-457989"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-annual-report-accounts/">Annual Report &#038; Accounts</a></li>
+		<li id="menu-item-1902" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-1902"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-vision-and-work-plan/">Vision &#038; Strategy</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462841" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-462841"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/">Negotiations</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427501" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427501"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/cpcf-settlement-2019-20-to-2023-24/">Five-Year CPCF (Overview)</a></li>
+		<li id="menu-item-427500" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427500"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/negotiation-updates/">Latest Negotiation Updates</a></li>
+		<li id="menu-item-462731" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462731"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/the-nhs-long-term-plan/">NHS Long Term Plan</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427873" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427873"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/">Representation</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427504" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427504"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/">Communications &#038; Public Affairs</a></li>
+		<li id="menu-item-427503" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427503"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/responses-to-consultations/">Responses To Consultations</a></li>
+		<li id="menu-item-507258" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507258"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/transforming-pharmacy-representation-tapr-programme/">Transforming Pharmacy Representation (TAPR)</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427872" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427872"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/">Updates &#038; Events</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458139" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458139"><a href="/our-news/">Latest News</a></li>
+		<li id="menu-item-458113" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458113"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Newsletter Sign-Up</a></li>
+		<li id="menu-item-427877" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427877"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/blog/">PSNC Blog</a></li>
+		<li id="menu-item-427879" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427879"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database</a></li>
+		<li id="menu-item-427878" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427878"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-events/">PSNC Events</a></li>
+		<li id="menu-item-427506" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427506"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-webinars/">PSNC Webinars</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458115" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular menu-item-458115"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458114" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458114"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us</a></li>
+		<li id="menu-item-427508" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-427508"><a href="/our-latest-news-category/psnc-and-negotiations/">News: PSNC &#038; Negotiations</a></li>
+		<li id="menu-item-458130" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458130"><a href="https://psnc.org.uk/psnc-and-negotiations/psnc-briefings-psnc-and-negotiations/">PSNC Briefings: PSNC &#038; Negotiations</a></li>
+		<li id="menu-item-427674" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427674"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Sign Up For PSNC&#8217;s Newsletters</a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-16135" class="menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children has-most-popular top-item pink-item menu-item-16135"><a href="https://psnc.org.uk/funding-and-reimbursement/">Funding &#038; Reimbursement</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-427886" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427886"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/">Funding</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427520" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427520"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/discount-deduction/">Discount Deduction</a></li>
+		<li id="menu-item-427887" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427887"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding Distribution</a></li>
+		<li id="menu-item-427516" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427516"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/indicative-income-tables/">Indicative Income Tables</a></li>
+		<li id="menu-item-462802" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462802"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/margins-survey/">Margins Survey</a></li>
+		<li id="menu-item-427518" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427518"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/pre-registration-training-grant/">Pre-registration Training Grant</a></li>
+		<li id="menu-item-427515" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427515"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/psnc-ongoing-funding-work/">PSNC Ongoing Funding Work</a></li>
+		<li id="menu-item-427521" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427521"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/retained-margin-category-m/">Retained Margin (Category M)</a></li>
+		<li id="menu-item-462733" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462733"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/summary-of-funding-changes/">Summary of Funding Changes</a></li>
+		<li id="menu-item-427519" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427519"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/vat/">VAT</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427888" class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current-menu-parent current-page-parent current_page_parent current_page_ancestor menu-item-has-children sub-item menu-item-427888"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427525" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427525"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/branded-generics/">Branded Generics</a></li>
+		<li id="menu-item-427524" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427524"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/dispensing-at-a-loss/">Dispensing At A Loss</a></li>
+		<li id="menu-item-427890" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427890"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/endorsement-guidance/">Endorsement Guidance</a></li>
+		<li id="menu-item-462804" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462804"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/">Payment &#038; Pricing Accuracy</a></li>
+		<li id="menu-item-427523" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427523"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/how-the-price-change-mechanism-works/">Price Change Mechanism</a></li>
+		<li id="menu-item-427889" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item menu-item-427889"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" aria-current="page">Price Concessions</a></li>
+		<li id="menu-item-462772" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462772"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price</a></li>
+		<li id="menu-item-427527" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427527"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/temporary-safeguarding-payments/">Temporary Safeguarding Payments</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458057" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458057"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/">Monthly Payments</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458059" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458059"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/payment-timetable-and-deadline-tracker/">Payment Timetable</a></li>
+		<li id="menu-item-458060" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458060"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/interactive-fp34/">Schedule Of Payments</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458052" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458052"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/">NHS Statistics</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462796" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462796"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical Services Statistics</a></li>
+		<li id="menu-item-462799" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462799"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/community-pharmacy-statistics/">Community Statistics</a></li>
+		<li id="menu-item-462805" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462805"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/eps-statistics/">EPS &#038; IT Statistics</a></li>
+		<li id="menu-item-462732" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462732"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu Vaccination Statistics</a></li>
+		<li id="menu-item-462798" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462798"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/nms-statistics/">NMS Statistics</a></li>
+		<li id="menu-item-427517" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427517"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/remuneration-statistics/">Remuneration Statistics</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458133" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children most-popular menu-item-458133"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458146" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458146"><a href="https://psnc.org.uk/funding-and-reimbursement/a-z-of-funding-topics/">A-Z of Funding Topics</a></li>
+		<li id="menu-item-458145" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458145"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding Distribution</a></li>
+		<li id="menu-item-462734" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462734"><a href="/our-latest-news-category/funding-and-reimbursement/">News: Funding &#038; Reimbursement</a></li>
+		<li id="menu-item-458144" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item menu-item-458144"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" aria-current="page">Price Concessions</a></li>
+		<li id="menu-item-458132" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458132"><a href="https://psnc.org.uk/funding-and-reimbursement/psnc-briefings-funding-and-reimbursement/">PSNC Briefings: Funding &#038; Reimbursement</a></li>
+		<li id="menu-item-458140" class="menu-item menu-item-type-custom menu-item-object-custom most-popular-image menu-item-458140"><a href="/funding-and-reimbursement/"><img src="https://psnc.org.uk/wp-content/uploads/2015/07/Graph-analysis.jpg" alt=""></a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-457977" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item yellow-item menu-item-457977"><a href="https://psnc.org.uk/quality-and-regulations/">Quality &#038; Regulations</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-427913" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427913"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/">Contractual Framework</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462810" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462810"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/pharmacy-mergers-consolidations/">Consolidations (Mergers)</a></li>
+		<li id="menu-item-427917" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427917"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/contract-monitoring/">Contract Monitoring</a></li>
+		<li id="menu-item-427916" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427916"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/">Market Entry</a></li>
+		<li id="menu-item-427915" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427915"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/opening-a-pharmacy/">Opening A Pharmacy</a></li>
+		<li id="menu-item-462745" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462745"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/pharmaceutical-needs-assessment/">Pharmaceutical Needs Assessment (PNA)</a></li>
+		<li id="menu-item-462757" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462757"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/pharmacy-access-scheme-phas/">Pharmacy Access Scheme</a></li>
+		<li id="menu-item-427918" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427918"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/opening-hours/">Opening hours (including unplanned temporary closures)</a></li>
+		<li id="menu-item-462808" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462808"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/relocations-which-do-not-result-in-significant-change/">Relocations</a></li>
+		<li id="menu-item-462843" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462843"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/changes-to-the-terms-of-service-in-2020/">2020 Terms of Service changes</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427912" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427912"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/">Clinical Governance etc.</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462748" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462748"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/emergency-planning/">Business Continuity Planning</a></li>
+		<li id="menu-item-507675" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507675"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/managing-a-temporary-pharmacy-closure/">Managing a temporary pharmacy closure</a></li>
+		<li id="menu-item-427581" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427581"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/clinical-audit/">Clinical Audit</a></li>
+		<li id="menu-item-427582" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427582"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/complaints/">NHS Complaints Procedure</a></li>
+		<li id="menu-item-427583" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427583"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/cppq/">Patient Satisfaction Survey</a></li>
+		<li id="menu-item-462747" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462747"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/practice-leaflet-requirements/">Practice Leaflet Requirements</a></li>
+		<li id="menu-item-427584" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427584"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/patient-safety-incident-reporting/">Safety Incident Reporting</a></li>
+		<li id="menu-item-514728" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-514728"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/security-and-personal-safety/">Security and personal safety</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427849" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427849"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">Pharmacy Quality Scheme</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462813" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462813"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/pharmacy-quality-scheme-faqs/">PQS FAQs</a></li>
+		<li id="menu-item-462814" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462814"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/pharmacy-quality-scheme-outcomes/">PQS Outcomes</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427914" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427914"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/">Regulations</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-507335" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507335"><a href="https://psnc.org.uk/quality-and-regulations/annual-workforce-survey/">Annual workforce survey</a></li>
+		<li id="menu-item-427919" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427919"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/controlled-drug-regulations/">Controlled Drug Regulations</a></li>
+		<li id="menu-item-462746" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462746"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/dbs-checks/">DBS Checks</a></li>
+		<li id="menu-item-427921" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427921"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/direction-of-prescriptions/">Direction of Prescriptions</a></li>
+		<li id="menu-item-427922" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427922"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/distance-selling-pharmacies/">Distance Selling Pharmacies</a></li>
+		<li id="menu-item-427587" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427587"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/equality-act/">Equality Act</a></li>
+		<li id="menu-item-462809" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462809"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/fitness-to-practice/">Fitness To Practise</a></li>
+		<li id="menu-item-427585" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427585"><a href="https://psnc.org.uk/digital-and-technology/data-security/the-general-data-protection-regulation-gdpr/">GDPR</a></li>
+		<li id="menu-item-462749" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462749"><a href="https://psnc.org.uk/briefings/psnc-briefing-017-21-hub-and-spoke-dispensing/">Hub &#038; Spoke Dispensing</a></li>
+		<li id="menu-item-427920" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427920"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/responsible-pharmacist/">Responsible Pharmacist</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427681" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular menu-item-427681"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427678" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427678"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">PQS</a></li>
+		<li id="menu-item-528904" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-528904"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)</a></li>
+		<li id="menu-item-507336" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507336"><a href="https://psnc.org.uk/quality-and-regulations/annual-workforce-survey/">Annual workforce survey</a></li>
+		<li id="menu-item-427689" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427689"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/changes-to-the-terms-of-service-in-2020/">Changes To Terms of Service Late 2020</a></li>
+		<li id="menu-item-462842" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462842"><a href="/our-latest-news-category/quality-and-regulations/">News: Quality &#038; Regulations</a></li>
+		<li id="menu-item-458118" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458118"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/pharmacy-access-scheme-phas/">PhAS 2022</a></li>
+		<li id="menu-item-462806" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462806"><a href="https://psnc.org.uk/quality-and-regulations/psnc-briefings-quality-and-regulations/">PSNC Briefings: Quality &#038; Regulations</a></li>
+		<li id="menu-item-458021" class="menu-item menu-item-type-custom menu-item-object-custom most-popular-image menu-item-458021"><a href="/quality-and-regulations/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front.webp" alt=""></a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-244" class="menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-menu-ancestor current_page_ancestor menu-item-has-children has-most-popular top-item green-item menu-item-244"><a href="https://psnc.org.uk/dispensing-and-supply/">Dispensing &#038; Supply</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-427891" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427891"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/">Dispensing</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427536" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427536"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/appliances/">Appliances</a></li>
+		<li id="menu-item-427542" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427542"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/">Controlled Drugs</a></li>
+		<li id="menu-item-462738" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462738"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/">Dispensing A Prescription</a></li>
+		<li id="menu-item-458062" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458062"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/drug-tariff-resources/">Drug Tariff Resources</a></li>
+		<li id="menu-item-462737" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462737"><a href="https://psnc.org.uk/digital-and-technology/eps/">EPS</a></li>
+		<li id="menu-item-427541" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427541"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/medicinal-products/">Medicinal Products</a></li>
+		<li id="menu-item-427539" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427539"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/special-containers/">Special Containers</a></li>
+		<li id="menu-item-427537" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427537"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/split-pack-dispensing/">Split Pack Dispensing</a></li>
+		<li id="menu-item-427538" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427538"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/unlicensed-specials-and-imports/">Unlicensed Specials &#038; Imports</a></li>
+		<li id="menu-item-462736" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462736"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458055" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458055"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/">Prescription Processing</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427894" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427894"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/how-are-prescriptions-processed/">How Prescriptions are Processed</a></li>
+		<li id="menu-item-427893" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427893"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/is-this-item-allowed/">Is This Item Allowed?</a></li>
+		<li id="menu-item-427892" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427892"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/patient-charges/">Patient Charges &#038; Exemptions</a></li>
+		<li id="menu-item-458056" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458056"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/">Payment &#038; Pricing Accuracy</a></li>
+		<li id="menu-item-462735" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462735"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/is-this-prescription-form-valid/">Prescription Form Validity</a></li>
+		<li id="menu-item-458061" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458061"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/prescription-submission/">Prescription Submission</a></li>
+		<li id="menu-item-458053" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458053"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/">Receiving A Prescription</a></li>
+		<li id="menu-item-462739" class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-page-parent sub-item menu-item-462739"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427895" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427895"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/">Supply Chain</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427546" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427546"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer Contingency Arrangements</a></li>
+		<li id="menu-item-427896" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427896"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/medicine-shortages/">Medicine Shortages</a></li>
+		<li id="menu-item-427548" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427548"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price</a></li>
+		<li id="menu-item-427545" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427545"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols</a></li>
+		<li id="menu-item-427549" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427549"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/shortage-reporting-form/">Shortage Reporting Form</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458131" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458131"><a href="https://psnc.org.uk/dispensing-and-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing &#038; Supply</a></li>
+	<li id="menu-item-427667" class="menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children most-popular menu-item-427667"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427670" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427670"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/controlled-drug-prescription-forms-and-validity/">Controlled Drug Prescription Forms</a></li>
+		<li id="menu-item-427672" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427672"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/methadone-dispensing/">Methadone Dispensing</a></li>
+		<li id="menu-item-458138" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458138"><a href="/our-latest-news-category/dispensing-and-supply/">News: Dispensing &#038; Supply</a></li>
+		<li id="menu-item-427668" class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item menu-item-427668"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" aria-current="page">Price Concessions</a></li>
+		<li id="menu-item-462844" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462844"><a href="https://psnc.org.uk/dispensing-and-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing &#038; Supply</a></li>
+		<li id="menu-item-427671" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427671"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price</a></li>
+		<li id="menu-item-427669" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427669"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/special-containers/special-container-database/">Special Container Database</a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-249" class="menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item mint-item menu-item-249"><a href="https://psnc.org.uk/national-pharmacy-services/">National Pharmacy Services</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-427534" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427534"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/">Essential Services</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427900" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427900"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/dispensing-of-medicines/">Dispensing Medicines</a></li>
+		<li id="menu-item-427898" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427898"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/repeat-dispensing/">Repeat Dispensing/eRD</a></li>
+		<li id="menu-item-427899" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427899"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/dispensing-of-appliances/">Dispensing Appliances</a></li>
+		<li id="menu-item-427901" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427901"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/discharge-medicines-service/">Discharge Medicines Service</a></li>
+		<li id="menu-item-427897" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427897"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/public-health/">Public Health</a></li>
+		<li id="menu-item-427902" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427902"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/healthy-living-pharmacies/">Healthy Living Pharmacy</a></li>
+		<li id="menu-item-427553" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427553"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/support-for-self-care/">Self Care</a></li>
+		<li id="menu-item-427551" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427551"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/signposting/">Signposting</a></li>
+		<li id="menu-item-427554" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427554"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/disposal-of-unwanted-medicines/">Disposal or unwanted meds</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427535" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427535"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/">Advanced Services</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-507763" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507763"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/pharmacy-contraception-service/">Pharmacy Contraception Service</a></li>
+		<li id="menu-item-427903" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427903"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/aurs/">Appliance Use Reviews</a></li>
+		<li id="menu-item-427910" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427910"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/community-pharmacist-consultation-service/">CPCS</a></li>
+		<li id="menu-item-427906" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427906"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/">Flu Vaccination Service</a></li>
+		<li id="menu-item-427555" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427555"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hep-c/">Hepatitis C Testing Service</a></li>
+		<li id="menu-item-427909" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427909"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hypertension-case-finding-service/">Hypertension Case-Finding</a></li>
+		<li id="menu-item-427905" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427905"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/nms/">NMS</a></li>
+		<li id="menu-item-427908" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427908"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/smoking-cessation-service/">Smoking Cessation Service</a></li>
+		<li id="menu-item-427559" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427559"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/sac/">Stoma Appliance Customisation</a></li>
+	</ul>
+</li>
+	<li id="menu-item-506208" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-506208"><a href="https://psnc.org.uk/national-pharmacy-services/national-enhanced-services/">National Enhanced Services</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-506230" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-506230"><a href="https://psnc.org.uk/national-pharmacy-services/national-enhanced-services/covid-19-vaccination-service/">COVID-19 Vaccination Service</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458153" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458153"><a href="https://psnc.org.uk/national-pharmacy-services/psnc-briefings-national-pharmacy-services/">PSNC Briefings: National Pharmacy Services</a></li>
+	<li id="menu-item-458116" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular menu-item-458116"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462800" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462800"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical Services Statistics</a></li>
+		<li id="menu-item-462740" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462740"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu Vaccination Statistics</a></li>
+		<li id="menu-item-462743" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462743"><a href="/our-latest-news-category/national-pharmacy-services/">News: National Pharmacy Services</a></li>
+		<li id="menu-item-427690" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427690"><a href="https://psnc.org.uk/national-pharmacy-services/psnc-briefings-national-pharmacy-services/">PSNC Briefings: National Pharmacy Services</a></li>
+		<li id="menu-item-462742" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462742"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/working-with-gps/">Working With GPs</a></li>
+		<li id="menu-item-458141" class="menu-item menu-item-type-custom menu-item-object-custom most-popular-image menu-item-458141"><a href="/national-pharmacy-services/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Asthma-consultation.webp" alt=""></a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-457979" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item blue-item menu-item-457979"><a href="https://psnc.org.uk/digital-and-technology/">Digital &#038; Technology</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-427966" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427966"><a href="https://psnc.org.uk/digital-and-technology/systems-apps/">Systems &#038; Suppliers</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427953" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427953"><a href="https://psnc.org.uk/digital-and-technology/communications-across-healthcare-it/">Comms &#038; Connectivity</a></li>
+		<li id="menu-item-462770" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462770"><a href="https://psnc.org.uk/digital-and-technology/databases-of-pharmacies-and-services/directory-of-services-dos/">Directory of Services (DoS)</a></li>
+		<li id="menu-item-427956" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427956"><a href="https://psnc.org.uk/digital-and-technology/databases-of-pharmacies-and-services/">NHS Databases &#038; Profiles</a></li>
+		<li id="menu-item-427983" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427983"><a href="https://psnc.org.uk/digital-and-technology/nhsbsa-manage-your-service-mys-application/">Manage Your Service (MYS)</a></li>
+		<li id="menu-item-462769" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462769"><a href="https://psnc.org.uk/digital-and-technology/nhs-mail/">NHSmail</a></li>
+		<li id="menu-item-427666" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427666"><a href="https://psnc.org.uk/digital-and-technology/system-suppliers/">Suppliers Hub incl contacts</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427927" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427927"><a href="https://psnc.org.uk/digital-and-technology/eps/">Digital Dispensing</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458155" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458155"><a href="https://psnc.org.uk/digital-and-technology/eps/">EPS Home</a>
+		<ul class='sub-menu'>
+			<li id="menu-item-427931" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427931"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-dispensing/">EPS Dispensing</a></li>
+			<li id="menu-item-462751" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462751"><a href="https://psnc.org.uk/digital-and-technology/eps/endorsing-and-submission/">EPS Submission</a></li>
+			<li id="menu-item-427939" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427939"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-tokens/">EPS Tokens</a></li>
+			<li id="menu-item-462768" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462768"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-prescription-tracker/">EPS Prescription Tracker</a></li>
+			<li id="menu-item-507010" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507010"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/repeat-dispensing/">eRD</a></li>
+		</ul>
+</li>
+		<li id="menu-item-462767" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462767"><a href="https://psnc.org.uk/digital-and-technology/standards-and-interoperability-it/nhs-dictionary-of-medicines-and-devices/">Medicines Database (dm+d)</a></li>
+		<li id="menu-item-462766" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462766"><a href="https://psnc.org.uk/digital-and-technology/systems-apps/real-time-exemption-checking-rtec/">RTEC Exemption Checking</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462771" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-462771"><a href="https://psnc.org.uk/digital-and-technology/records-data-security-ig/">Records, Data Security &#038; IG</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427955" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427955"><a href="https://psnc.org.uk/digital-and-technology/data-security/">Data security (DS) hub</a></li>
+		<li id="menu-item-458156" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458156"><a href="https://psnc.org.uk/digital-and-technology/data-security/data-security-and-protection-toolkit/">DS Protection Toolkit</a></li>
+		<li id="menu-item-427928" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-427928"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/">Digital &#038; Shared Care Records</a>
+		<ul class='sub-menu'>
+			<li id="menu-item-462764" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462764"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/retention-of-pharmacy-records/">Pharmacy Records Retention</a></li>
+			<li id="menu-item-462765" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462765"><a href="https://psnc.org.uk/digital-and-technology/smartcards/">Smartcards</a></li>
+			<li id="menu-item-462811" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462811"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/shared-care-records-shcr/">Shared Care Records (ShCR)</a></li>
+			<li id="menu-item-427665" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427665"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/summary-care-record-scr/">Summary Care Record (SCR)</a></li>
+		</ul>
+</li>
+		<li id="menu-item-462750" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462750"><a href="https://psnc.org.uk/digital-and-technology/data-security/the-general-data-protection-regulation-gdpr/">GDPR</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458160" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458160"><a href="https://psnc.org.uk/digital-and-technology/technology-policy-development/">Tech, Policy &#038; Development</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427950" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427950"><a href="https://psnc.org.uk/digital-and-technology/contingency-it/">Contingency Planning</a></li>
+		<li id="menu-item-507008" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507008"><a href="https://psnc.org.uk/digital-and-technology/community-pharmacy-it-group-cpitg/">CP IT Group</a></li>
+		<li id="menu-item-427957" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427957"><a href="https://psnc.org.uk/digital-and-technology/get-involved-it/">Get Involved With IT</a></li>
+		<li id="menu-item-427933" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427933"><a href="https://psnc.org.uk/digital-and-technology/organisations-policies-it/">IT Policy &#038; Development</a></li>
+		<li id="menu-item-427962" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427962"><a href="https://psnc.org.uk/digital-and-technology/patient-facing-tools-apps-and-services/">Patient Digital Services</a></li>
+		<li id="menu-item-427949" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427949"><a href="https://psnc.org.uk/digital-and-technology/contingency-it/reporting-it/">Reporting Issues &#038; Feedback</a></li>
+		<li id="menu-item-507009" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-507009"><a href="https://psnc.org.uk/digital-and-technology/digital-training/">Training &#038; capabilities</a></li>
+	</ul>
+</li>
+	<li id="menu-item-427684" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular menu-item-427684"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-427954" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427954"><a href="https://psnc.org.uk/digital-and-technology/community-pharmacy-it-a-z-index/">A-Z Index of Pharmacy IT</a></li>
+		<li id="menu-item-427686" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427686"><a href="https://psnc.org.uk/digital-and-technology/smartcards/smartcard-registration-authorities/">Contact Smartcard Registration Authority (RA)</a></li>
+		<li id="menu-item-463162" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-463162"><a href="/our-latest-news-category/digital-and-technology/">News: Digital &#038; Technology</a></li>
+		<li id="menu-item-496766" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-496766"><a href="https://psnc.org.uk/digital-and-technology/psnc-briefings-digital-technology/">PSNC Briefings: Digital &#038; Technology</a></li>
+		<li id="menu-item-427687" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427687"><a href="https://psnc.org.uk/digital-and-technology/system-suppliers/system-supplier-lists/">Supplier List &#038; Contacts</a></li>
+		<li id="menu-item-458152" class="menu-item menu-item-type-custom menu-item-object-custom most-popular-image menu-item-458152"><a href="/digital-and-technology/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Dispensing-electronic-prescription-with-computer.webp" alt=""></a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+<li id="menu-item-2471" class="menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item orange-item menu-item-2471"><a href="https://psnc.org.uk/lpcs-and-local/">LPCs &#038; Local</a>
+<div class='sub-menu-wrap'><ul class='sub-menu sub-menu-container'>
+	<li id="menu-item-458027" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458027"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/">About LPCs</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-462759" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462759"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/lpcs-in-the-spotlight/">LPCs In The Spotlight</a></li>
+		<li id="menu-item-458135" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458135"><a href="https://lpc-online.org.uk/">LPC Websites</a></li>
+		<li id="menu-item-427570" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-427570"><a href="/our-latest-news-category/lpcs-and-local/">News: LPCs &#038; Local</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462763" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item menu-item-462763"><a href="/lpcs-and-local/lpc-members-area/">For LPCs</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458031" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458031"><a href="/lpcs-and-local/lpc-members-area/">LPC Members Area</a></li>
+		<li id="menu-item-462812" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462812"><a href="/lpcs-and-local/lpc-members-area/lpc-member-changes/">LPC Member Changes Form</a></li>
+		<li id="menu-item-462762" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462762"><a href="/podcast/">MyCoach Podcast</a></li>
+		<li id="menu-item-462846" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462846"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458026" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item menu-item-458026"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/">Local Engagement</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-463129" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-463129"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/key-terms-in-community-pharmacy/">Glossary of Acronyms</a></li>
+		<li id="menu-item-462761" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462761"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/thinkpharmacy/">Think Pharmacy</a></li>
+		<li id="menu-item-462760" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462760"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/working-with-commissioners/">Working With Commissioners</a></li>
+		<li id="menu-item-427577" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427577"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/working-with-gps/">Working With GPs</a></li>
+	</ul>
+</li>
+	<li id="menu-item-462754" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item menu-item-462754"><a href="/lpcs-and-local/locally-commissioned-services/">Local Commissioning</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458029" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458029"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/essential-facts-stats-and-quotes/">Facts, Stats &#038; Quotes</a></li>
+		<li id="menu-item-462753" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462753"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/integrated-care-systems/">Integrated Care Systems</a></li>
+		<li id="menu-item-458030" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458030"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/">Locally Commissioned Services</a></li>
+		<li id="menu-item-427679" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-427679"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/local-services-database/">Local Services Database</a></li>
+		<li id="menu-item-462752" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462752"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/primary-care-networks-pcns/">Primary Care Networks</a></li>
+	</ul>
+</li>
+	<li id="menu-item-458122" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular menu-item-458122"><a href="#">Most Popular</a>
+	<ul class='sub-menu'>
+		<li id="menu-item-458137" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458137"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/">About LPCs</a></li>
+		<li id="menu-item-458121" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-458121"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/local-services-database/">Local Services Database</a></li>
+		<li id="menu-item-458134" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458134"><a href="https://psnc.org.uk/lpcs-and-local/lpc-members-area/">LPC Members Area</a></li>
+		<li id="menu-item-458136" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-458136"><a href="https://lpc-online.org.uk/">LPC Websites Portal</a></li>
+		<li id="menu-item-462845" class="menu-item menu-item-type-custom menu-item-object-custom sub-item menu-item-462845"><a href="/our-latest-news-category/lpcs-and-local/">News: LPCs &#038; Local</a></li>
+		<li id="menu-item-496765" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-496765"><a href="https://psnc.org.uk/lpcs-and-local/psnc-briefings-lpcs-local/">PSNC Briefings: LPCs &#038; Local</a></li>
+		<li id="menu-item-462755" class="menu-item menu-item-type-post_type menu-item-object-page sub-item menu-item-462755"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/primary-care-networks-pcns/">Primary Care Networks (PCNs)</a></li>
+	</ul>
+</li>
+</ul></div>
+</li>
+</ul></div>
+						</nav>
+					</div>
+				</div>
+			</div>
+		</div>
+		
+	</div>		
+
+	<!-- Mobile navigation -->
+	<div class="mobile-nav-wrap">
+
+		<div class="mobile-search mobile-search-wrap">
+			<form class="search-form" method="get" action="https://psnc.org.uk" role="search" autocomplete="off">
+	<input class="search-input" type="text" name="s" id="keyword" value="" placeholder="Hello, what are you looking for today?"></input>
+	<input type="hidden" value="all" name="post_type" id="searchOptionsAll">
+	<button class="btn-gradient btn-search btn-form" type="submit" role="button"><svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.55295 17.105C10.5265 17.105 12.3408 16.4261 13.7884 15.3004L18.4883 20L20 18.4883L15.3002 13.7888C16.427 12.3402 17.1059 10.526 17.1059 8.55249C17.1059 3.83686 13.2688 0 8.55295 0C3.83707 0 0 3.83686 0 8.55249C0 13.2681 3.83707 17.105 8.55295 17.105ZM8.55295 2.13812C12.0907 2.13812 14.9677 5.01497 14.9677 8.55249C14.9677 12.09 12.0907 14.9669 8.55295 14.9669C5.01523 14.9669 2.13824 12.09 2.13824 8.55249C2.13824 5.01497 5.01523 2.13812 8.55295 2.13812Z" /></svg></button>
+</form>		</div>
+
+		<div class="mobile-navigation"><ul id="mobile-menu" class="menu"><li class=' menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor menu-item-has-children top-item purple-bg-item'><div class="sub-menu-item sub-menu-parent"><span>Quick Links<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Quick Links</a></div></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>KEY PAGES<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to KEY PAGES</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">KEY PAGES</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/community-pharmacist-consultation-service/">CPCS<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/covid19/">COVID-19 Hub<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/medicine-shortages/">Medicine Shortages<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Item Over Drug Tariff Price<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>PSNC RESOURCES<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to PSNC RESOURCES</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">PSNC RESOURCES</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/headline/">Headline News<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-news/">News Index<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-webinars/">Our Webinars<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Sign Up For Our Email Newsletters<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/psncs-work/our-events/">Upcoming Events<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://twitter.com/PSNCNews">@PSNCNews on Twitter<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>OTHER USEFUL RESOURCES<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to OTHER USEFUL RESOURCES</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">OTHER USEFUL RESOURCES</a></div></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">Drug Tariff<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://www.england.nhs.uk/primary-care/pharmacy/pharmacy-contract-teams/">Local NHS England Team Contacts<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://digital.nhs.uk/services/registration-authorities-and-smartcards/primary-care-service-provider-contact-details">Smartcard RA Contacts<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://lpc-online.org.uk/">Visit Your LPC's Website<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class='menu-psncs-work menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item purple-item'><div class="sub-menu-item sub-menu-parent"><span>PSNC &#038; Negotiations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/psnc-and-negotiations/">PSNC &#038; Negotiations</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>About PSNC<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to About PSNC</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/">About PSNC</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-members/">Committee Members<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-meetings/">Meeting Agendas & Minutes<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-staff/">Our Team<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-structure-governance/">Structure & Governance<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-annual-report-accounts/">Annual Report & Accounts<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/psnc-vision-and-work-plan/">Vision & Strategy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Negotiations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Negotiations</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/">Negotiations</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/cpcf-settlement-2019-20-to-2023-24/">Five-Year CPCF (Overview)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/negotiation-updates/">Latest Negotiation Updates<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/negotiations/the-nhs-long-term-plan/">NHS Long Term Plan<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Representation<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Representation</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/">Representation</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/">Communications & Public Affairs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/responses-to-consultations/">Responses To Consultations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/transforming-pharmacy-representation-tapr-programme/">Transforming Pharmacy Representation (TAPR)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Updates &#038; Events<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Updates &#038; Events</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/">Updates &#038; Events</a></div></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-news/">Latest News<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Newsletter Sign-Up<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/blog/">PSNC Blog<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-events/">PSNC Events<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/our-webinars/">PSNC Webinars<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Contact Us<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/psnc-and-negotiations/">News: PSNC & Negotiations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/psnc-briefings-psnc-and-negotiations/">PSNC Briefings: PSNC &#038; Negotiations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">Sign Up For PSNC's Newsletters<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class='menu-funding-and-statistics menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current_page_ancestor menu-item-has-children has-most-popular top-item pink-item'><div class="sub-menu-item sub-menu-parent"><span>Funding &#038; Reimbursement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/funding-and-reimbursement/">Funding &#038; Reimbursement</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Funding<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Funding</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/">Funding</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/discount-deduction/">Discount Deduction<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding Distribution<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/indicative-income-tables/">Indicative Income Tables<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/margins-survey/">Margins Survey<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/pre-registration-training-grant/">Pre-registration Training Grant<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/psnc-ongoing-funding-work/">PSNC Ongoing Funding Work<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/retained-margin-category-m/">Retained Margin (Category M)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/summary-of-funding-changes/">Summary of Funding Changes<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/vat/">VAT<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-menu-ancestor current-menu-parent current-page-parent current_page_parent current_page_ancestor menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Reimbursement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Reimbursement</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/branded-generics/">Branded Generics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/dispensing-at-a-loss/">Dispensing At A Loss<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/endorsement-guidance/">Endorsement Guidance<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/">Payment & Pricing Accuracy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/how-the-price-change-mechanism-works/">Price Change Mechanism<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/temporary-safeguarding-payments/">Temporary Safeguarding Payments<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Monthly Payments<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Monthly Payments</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/">Monthly Payments</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/payment-timetable-and-deadline-tracker/">Payment Timetable<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/interactive-fp34/">Schedule Of Payments<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>NHS Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to NHS Statistics</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/">NHS Statistics</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical Services Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/community-pharmacy-statistics/">Community Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/eps-statistics/">EPS & IT Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu Vaccination Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/nms-statistics/">NMS Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/remuneration-statistics/">Remuneration Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/a-z-of-funding-topics/">A-Z of Funding Topics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding Distribution<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/funding-and-reimbursement/">News: Funding & Reimbursement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/psnc-briefings-funding-and-reimbursement/">PSNC Briefings: Funding &#038; Reimbursement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom most-popular-image'><div class="sub-menu-item sub-menu-link"><a href="/funding-and-reimbursement/"><img src="https://psnc.org.uk/wp-content/uploads/2015/07/Graph-analysis.jpg" alt=""><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item yellow-item'><div class="sub-menu-item sub-menu-parent"><span>Quality &#038; Regulations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/quality-and-regulations/">Quality &#038; Regulations</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Contractual Framework<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Contractual Framework</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/">Contractual Framework</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/pharmacy-mergers-consolidations/">Consolidations (Mergers)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/contract-monitoring/">Contract Monitoring<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/">Market Entry<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/opening-a-pharmacy/">Opening A Pharmacy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/pharmaceutical-needs-assessment/">Pharmaceutical Needs Assessment (PNA)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/pharmacy-access-scheme-phas/">Pharmacy Access Scheme<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/opening-hours/">Opening hours (including unplanned temporary closures)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/relocations-which-do-not-result-in-significant-change/">Relocations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/changes-to-the-terms-of-service-in-2020/">2020 Terms of Service changes<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Clinical Governance etc.<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Clinical Governance etc.</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/">Clinical Governance etc.</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/emergency-planning/">Business Continuity Planning<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/managing-a-temporary-pharmacy-closure/">Managing a temporary pharmacy closure<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/clinical-audit/">Clinical Audit<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/complaints/">NHS Complaints Procedure<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/cppq/">Patient Satisfaction Survey<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/practice-leaflet-requirements/">Practice Leaflet Requirements<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/patient-safety-incident-reporting/">Safety Incident Reporting<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/clinical-governance/security-and-personal-safety/">Security and personal safety<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Pharmacy Quality Scheme<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Pharmacy Quality Scheme</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">Pharmacy Quality Scheme</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/pharmacy-quality-scheme-faqs/">PQS FAQs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/pharmacy-quality-scheme-outcomes/">PQS Outcomes<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Regulations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Regulations</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/">Regulations</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/annual-workforce-survey/">Annual workforce survey<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/controlled-drug-regulations/">Controlled Drug Regulations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/dbs-checks/">DBS Checks<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/direction-of-prescriptions/">Direction of Prescriptions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/market-entry-regulations/distance-selling-pharmacies/">Distance Selling Pharmacies<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/equality-act/">Equality Act<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/fitness-to-practice/">Fitness To Practise<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/data-security/the-general-data-protection-regulation-gdpr/">GDPR<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/briefings/psnc-briefing-017-21-hub-and-spoke-dispensing/">Hub & Spoke Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/responsible-pharmacist/">Responsible Pharmacist<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-quality-scheme/">PQS<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols (SSPs)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/annual-workforce-survey/">Annual workforce survey<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/changes-to-the-terms-of-service-in-2020/">Changes To Terms of Service Late 2020<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/quality-and-regulations/">News: Quality & Regulations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/the-pharmacy-contract/pharmacy-access-scheme-phas/">PhAS 2022<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/psnc-briefings-quality-and-regulations/">PSNC Briefings: Quality &#038; Regulations<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom most-popular-image'><div class="sub-menu-item sub-menu-link"><a href="/quality-and-regulations/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front.webp" alt=""><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class='menu-dispensing-and-supply menu-item menu-item-type-post_type menu-item-object-page current-menu-ancestor current_page_ancestor menu-item-has-children has-most-popular top-item green-item'><div class="sub-menu-item sub-menu-parent"><span>Dispensing &#038; Supply<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/dispensing-and-supply/">Dispensing &#038; Supply</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Dispensing</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/">Dispensing</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/appliances/">Appliances<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/">Controlled Drugs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/">Dispensing A Prescription<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/drug-tariff-resources/">Drug Tariff Resources<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/eps/">EPS<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/medicinal-products/">Medicinal Products<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/special-containers/">Special Containers<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/split-pack-dispensing/">Split Pack Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/unlicensed-specials-and-imports/">Unlicensed Specials & Imports<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/drug-tariff-resources/virtual-drug-tariff/">Virtual Drug Tariff<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Prescription Processing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Prescription Processing</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/">Prescription Processing</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/how-are-prescriptions-processed/">How Prescriptions are Processed<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/is-this-item-allowed/">Is This Item Allowed?<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/patient-charges/">Patient Charges & Exemptions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/payment-accuracy/">Payment & Pricing Accuracy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/is-this-prescription-form-valid/">Prescription Form Validity<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/prescription-submission/">Prescription Submission<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/prescription-processing/receiving-a-prescription/">Receiving A Prescription<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor current-page-parent sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Supply Chain<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Supply Chain</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/">Supply Chain</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/manufacturer-contingency-arrangements/">Manufacturer Contingency Arrangements<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/medicine-shortages/">Medicine Shortages<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/ssps/">Serious Shortage Protocols<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/shortage-reporting-form/">Shortage Reporting Form<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing &#038; Supply<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom current-menu-ancestor current-menu-parent menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/controlled-drug-prescription-forms-and-validity/">Controlled Drug Prescription Forms<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-controlled-drugs/methadone-dispensing/">Methadone Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/dispensing-and-supply/">News: Dispensing & Supply<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-100786 current_page_item sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/psnc-briefings-dispensing-and-supply/">PSNC Briefings: Dispensing &#038; Supply<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/">Report Product Over Drug Tariff Price<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/dispensing-and-supply/dispensing-process/dispensing-a-prescription/special-containers/special-container-database/">Special Container Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class='menu-services-and-commissioning menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item mint-item'><div class="sub-menu-item sub-menu-parent"><span>National Pharmacy Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/national-pharmacy-services/">National Pharmacy Services</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Essential Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Essential Services</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/">Essential Services</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/dispensing-of-medicines/">Dispensing Medicines<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/repeat-dispensing/">Repeat Dispensing/eRD<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/dispensing-of-appliances/">Dispensing Appliances<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/discharge-medicines-service/">Discharge Medicines Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/public-health/">Public Health<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/healthy-living-pharmacies/">Healthy Living Pharmacy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/support-for-self-care/">Self Care<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/signposting/">Signposting<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/disposal-of-unwanted-medicines/">Disposal or unwanted meds<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Advanced Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Advanced Services</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/">Advanced Services</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/pharmacy-contraception-service/">Pharmacy Contraception Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/aurs/">Appliance Use Reviews<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/community-pharmacist-consultation-service/">CPCS<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/">Flu Vaccination Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hep-c/">Hepatitis C Testing Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/hypertension-case-finding-service/">Hypertension Case-Finding<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/nms/">NMS<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/smoking-cessation-service/">Smoking Cessation Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/sac/">Stoma Appliance Customisation<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>National Enhanced Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to National Enhanced Services</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/national-pharmacy-services/national-enhanced-services/">National Enhanced Services</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/national-enhanced-services/covid-19-vaccination-service/">COVID-19 Vaccination Service<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/psnc-briefings-national-pharmacy-services/">PSNC Briefings: National Pharmacy Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical Services Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/advanced-services/flu-vaccination-service/flu-vaccination-statistics/">Flu Vaccination Statistics<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/national-pharmacy-services/">News: National Pharmacy Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/psnc-briefings-national-pharmacy-services/">PSNC Briefings: National Pharmacy Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/working-with-gps/">Working With GPs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom most-popular-image'><div class="sub-menu-item sub-menu-link"><a href="/national-pharmacy-services/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Asthma-consultation.webp" alt=""><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item blue-item'><div class="sub-menu-item sub-menu-parent"><span>Digital &#038; Technology<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/">Digital &#038; Technology</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Systems & Suppliers<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Systems & Suppliers</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/systems-apps/">Systems & Suppliers</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/communications-across-healthcare-it/">Comms & Connectivity<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/databases-of-pharmacies-and-services/directory-of-services-dos/">Directory of Services (DoS)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/databases-of-pharmacies-and-services/">NHS Databases & Profiles<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/nhsbsa-manage-your-service-mys-application/">Manage Your Service (MYS)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/nhs-mail/">NHSmail<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/system-suppliers/">Suppliers Hub incl contacts<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Digital Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Digital Dispensing</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/eps/">Digital Dispensing</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>EPS Home<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+		<ul class="sub-menu menu-depth-3"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to EPS Home</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/eps/">EPS Home</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-dispensing/">EPS Dispensing<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/eps/endorsing-and-submission/">EPS Submission<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-tokens/">EPS Tokens<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/eps/eps-prescription-tracker/">EPS Prescription Tracker<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/national-pharmacy-services/essential-services/repeat-dispensing/">eRD<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+		</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/standards-and-interoperability-it/nhs-dictionary-of-medicines-and-devices/">Medicines Database (dm+d)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/systems-apps/real-time-exemption-checking-rtec/">RTEC Exemption Checking<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Records, Data Security & IG<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Records, Data Security & IG</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/records-data-security-ig/">Records, Data Security & IG</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/data-security/">Data security (DS) hub<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/data-security/data-security-and-protection-toolkit/">DS Protection Toolkit<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Digital & Shared Care Records<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+		<ul class="sub-menu menu-depth-3"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Digital & Shared Care Records</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/">Digital & Shared Care Records</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/quality-and-regulations/pharmacy-regulation/retention-of-pharmacy-records/">Pharmacy Records Retention<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/smartcards/">Smartcards<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/shared-care-records-shcr/">Shared Care Records (ShCR)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/electronic-health-records/summary-care-record-scr/">Summary Care Record (SCR)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+		</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/data-security/the-general-data-protection-regulation-gdpr/">GDPR<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Tech, Policy & Development<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Tech, Policy & Development</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/digital-and-technology/technology-policy-development/">Tech, Policy & Development</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/contingency-it/">Contingency Planning<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/community-pharmacy-it-group-cpitg/">CP IT Group<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/get-involved-it/">Get Involved With IT<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/organisations-policies-it/">IT Policy & Development<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/patient-facing-tools-apps-and-services/">Patient Digital Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/contingency-it/reporting-it/">Reporting Issues & Feedback<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/digital-training/">Training & capabilities<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/community-pharmacy-it-a-z-index/">A-Z Index of Pharmacy IT<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/smartcards/smartcard-registration-authorities/">Contact Smartcard Registration Authority (RA)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/digital-and-technology/">News: Digital & Technology<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/psnc-briefings-digital-technology/">PSNC Briefings: Digital &#038; Technology<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/digital-and-technology/system-suppliers/system-supplier-lists/">Supplier List & Contacts<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom most-popular-image'><div class="sub-menu-item sub-menu-link"><a href="/digital-and-technology/"><img src="https://psnc.org.uk/wp-content/uploads/2021/11/Dispensing-electronic-prescription-with-computer.webp" alt=""><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li class='menu-lpcs menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children has-most-popular top-item orange-item'><div class="sub-menu-item sub-menu-parent"><span>LPCs &#038; Local<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+<ul class="sub-menu menu-depth-1"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Main Menu</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/lpcs-and-local/">LPCs &#038; Local</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>About LPCs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to About LPCs</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/">About LPCs</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/lpcs-in-the-spotlight/">LPCs In The Spotlight<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://lpc-online.org.uk/">LPC Websites<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/lpcs-and-local/">News: LPCs & Local<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>For LPCs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to For LPCs</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="/lpcs-and-local/lpc-members-area/">For LPCs</a></div></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/lpcs-and-local/lpc-members-area/">LPC Members Area<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/lpcs-and-local/lpc-members-area/lpc-member-changes/">LPC Member Changes Form<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/podcast/">MyCoach Podcast<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/psnc-briefings/">PSNC Briefings Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Local Engagement<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Local Engagement</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/">Local Engagement</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/key-terms-in-community-pharmacy/">Glossary of Acronyms<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/thinkpharmacy/">Think Pharmacy<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/psnc-and-negotiations/representation/communications-and-public-affairs/working-with-commissioners/">Working With Commissioners<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/local-engagement/working-with-gps/">Working With GPs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children sub-item'><div class="sub-menu-item sub-menu-parent"><span>Local Commissioning<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Local Commissioning</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="/lpcs-and-local/locally-commissioned-services/">Local Commissioning</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/essential-facts-stats-and-quotes/">Facts, Stats & Quotes<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/integrated-care-systems/">Integrated Care Systems<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/">Locally Commissioned Services<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/local-services-database/">Local Services Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/primary-care-networks-pcns/">Primary Care Networks<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children most-popular'><div class="sub-menu-item sub-menu-parent"><span>Most Popular<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div>
+	<ul class="sub-menu menu-depth-2"><li><div class="sub-menu-item back-sub-menu"><span><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg>Back to Most Popular</span></li><li><div class="sub-menu-item sub-menu-top-link"><a href="#">Most Popular</a></div></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/about-lpcs/">About LPCs<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/local-services-database/">Local Services Database<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/lpc-members-area/">LPC Members Area<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://lpc-online.org.uk/">LPC Websites Portal<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-custom menu-item-object-custom sub-item'><div class="sub-menu-item sub-menu-link"><a href="/our-latest-news-category/lpcs-and-local/">News: LPCs & Local<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/psnc-briefings-lpcs-local/">PSNC Briefings: LPCs &#038; Local<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+<li class=' menu-item menu-item-type-post_type menu-item-object-page sub-item'><div class="sub-menu-item sub-menu-link"><a href="https://psnc.org.uk/lpcs-and-local/locally-commissioned-services/primary-care-networks-pcns/">Primary Care Networks (PCNs)<svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></a></li>
+	</ul>
+</li>
+</ul>
+</li>
+</ul></div>
+	</div>
+
+</header>
+
+<div class="site-content">
+<div class="container-wide">
+	<div class="row">
+
+		<!-- Sidebar mobile  -->
+		<div class="col-12 d-lg-none">
+			<div class="sidebar-mobile-toggle"><span>Click here to view other pages in Funding &#038; Reimbursement section</span> <svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div>
+		</div>
+
+		<!-- Breadcrumbs -->
+		<div class="col-12 page-top">
+			<div class="breadcrumbs">
+				<a href='https://psnc.org.uk'>Home</a> <span>/</span> <a href=https://psnc.org.uk/funding-and-reimbursement/reimbursement/>Funding &#038; Reimbursement</a> <span>/</span> Price Concessions			</div>
+
+			<div class="print-btn d-none d-lg-block"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" xmlns:v="https://vecta.io/nano"><path d="M19 7h-1V2H6v5H5c-1.654 0-3 1.346-3 3v7c0 1.103.897 2 2 2h2v3h12v-3h2c1.103 0 2-.897 2-2v-7c0-1.654-1.346-3-3-3zM8 4h8v3H8V4zm8 16H8v-4h8v4zm4-3h-2v-3H6v3H4v-7a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v7z" fill="#55318C"/><path d="M14 10h4v2h-4v-2z" fill="#55318C"/></svg><div class='printomatictext ' id='id5320' alt='Print Page' title='Print Page' data-print_target='.page-content'>Print Page</div></div>
+		</div>	
+
+		<!-- Sidebar -->
+		<div class="col-lg-3">
 			
+<div class="sidebar-nav">
+	<nav class="sidebar-desktop">
+		<ul>
+			<li class="pagenav"><a href="https://psnc.org.uk/funding-and-reimbursement" class="parent-page">Funding &#038; Reimbursement</a><ul><li class="page_item page-item-15830"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/a-z-of-funding-topics/">A-Z of funding topics</a></div></li><li class="page_item page-item-605 page_item_has_children"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/">Monthly payments</a></div>
+<ul class='children'>
+<li class="page_item page-item-426384"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/expensive-items/">Expensive Items</a></div></li><li class="page_item page-item-410774"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/payment-timetable-and-deadline-tracker/">Payment timetable and deadline tracker</a></div></li><li class="page_item page-item-411158"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/reconciling-payments/">Reconciling payments</a></div></li><li class="page_item page-item-364317"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/interactive-fp34/">Understanding your FP34 Schedule of Payments</a></div></li><li class="page_item page-item-12682"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/using-your-schedule-of-payment-to-monitor-performance/">Using your Schedule of Payment to monitor performance</a></div></li></ul>
+</li><li class="page_item page-item-1173 page_item_has_children"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/">NHS statistics</a></div>
+<ul class='children'>
+<li class="page_item page-item-428070"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical services statistics</a></div></li><li class="page_item page-item-4590"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/community-pharmacy-statistics/">Community statistics</a></div></li><li class="page_item page-item-4586"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/eps-statistics/">EPS and IT statistics</a></div></li><li class="page_item page-item-3078"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/nms-statistics/">NMS statistics</a></div></li><li class="page_item page-item-4609"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/remuneration-statistics/">Remuneration statistics</a></div></li></ul>
+</li><li class="page_item page-item-15762 page_item_has_children"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/">Pharmacy funding</a></div>
+<ul class='children'>
+<li class="page_item page-item-15766"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/cost-of-service-inquiry/">Cost of Service Inquiry</a></div></li><li class="page_item page-item-15792 page_item_has_children"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding distribution</a></div>
+	<ul class='children'>
+<li class="page_item page-item-15823"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/branded-generics/">Branded generics</a></div></li><li class="page_item page-item-15817"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/dispensing-at-a-loss/">Dispensing at a loss</a></div></li><li class="page_item page-item-15794"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/essential-service-payments/">Essential Service payments</a></div></li><li class="page_item page-item-15811"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/indicative-income-tables/">Indicative income tables</a></div></li><li class="page_item page-item-15815"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/pre-registration-training-grant/">Pre-registration training grant</a></div></li><li class="page_item page-item-15805"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/retained-margin-category-m/">Retained margin (Category M)</a></div></li><li class="page_item page-item-15813"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/summary-of-funding-changes/">Summary of funding changes</a></div></li><li class="page_item page-item-18075"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/temporary-safeguarding-payments/">Temporary safeguarding payments</a></div></li><li class="page_item page-item-15819"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/vat/">VAT</a></div></li>	</ul>
+</li><li class="page_item page-item-364250"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-during-the-pandemic/">Funding during the pandemic</a></div></li><li class="page_item page-item-15774"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/historical-funding-arrangements/">Historical funding arrangements</a></div></li><li class="page_item page-item-405"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/discount-deduction/">How discount deduction works</a></div></li><li class="page_item page-item-15771"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/margins-survey/">Margins survey</a></div></li><li class="page_item page-item-15790"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/psnc-ongoing-funding-work/">PSNC Ongoing Funding Work</a></div></li></ul>
+</li><li class="page_item page-item-5092"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/psnc-briefings-funding-and-reimbursement/">PSNC Briefings: Funding & Reimbursement</a></div></li><li class="page_item page-item-600 page_item_has_children page-item-open"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement</a></div>
+<ul class='children'>
+<li class="page_item page-item-363"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/endorsement-guidance/">Endorsement guidance</a></div></li><li class="page_item page-item-797 page_item_has_children"><div class="page-link"><span class="indicator indicator-open-submenu"><svg width="10" height="7" viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.57747 0.744141L4.99997 4.32164L1.42247 0.744141L0.244141 1.92247L4.99997 6.67831L9.75581 1.92247L8.57747 0.744141Z" /></svg></span><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/">Fees and allowances</a></div>
+	<ul class='children'>
+<li class="page_item page-item-72"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/bb/">Broken bulk</a></div></li><li class="page_item page-item-402"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/consumables-containers/">Consumables and container allowance</a></div></li><li class="page_item page-item-56"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/oop/">Out of pocket expenses</a></div></li>	</ul>
+</li><li class="page_item page-item-2309"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/how-the-price-change-mechanism-works/">How the price change mechanism works</a></div></li><li class="page_item page-item-100786 current_page_item"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions</a></div></li></ul>
+</li></ul></li>			
+		</ul>
+	</nav>
+
+	<nav class="sidebar-mobile">
+		<ul>
 			
+			<li class="pagenav"><div class="close-mobile-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to page</span></div><a href="https://psnc.org.uk/funding-and-reimbursement" class="parent-page">Funding &#038; Reimbursement</a><ul><li class="page_item page-item-15830"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/a-z-of-funding-topics/">A-Z of funding topics</a></div></li><li class="page_item page-item-605 page_item_has_children"><div class="page-link open-sub-sidebar"><span>Monthly payments</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Main Menu</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/">Monthly payments</a></div></li><li class="page_item page-item-426384"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/expensive-items/">Expensive Items</a></div></li><li class="page_item page-item-410774"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/payment-timetable-and-deadline-tracker/">Payment timetable and deadline tracker</a></div></li><li class="page_item page-item-411158"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/reconciling-payments/">Reconciling payments</a></div></li><li class="page_item page-item-364317"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/interactive-fp34/">Understanding your FP34 Schedule of Payments</a></div></li><li class="page_item page-item-12682"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/monthly-payments/using-your-schedule-of-payment-to-monitor-performance/">Using your Schedule of Payment to monitor performance</a></div></li></ul>
+</li><li class="page_item page-item-1173 page_item_has_children"><div class="page-link open-sub-sidebar"><span>NHS statistics</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Main Menu</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/">NHS statistics</a></div></li><li class="page_item page-item-428070"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/clinical-services-statistics/">Clinical services statistics</a></div></li><li class="page_item page-item-4590"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/community-pharmacy-statistics/">Community statistics</a></div></li><li class="page_item page-item-4586"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/eps-statistics/">EPS and IT statistics</a></div></li><li class="page_item page-item-3078"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/nms-statistics/">NMS statistics</a></div></li><li class="page_item page-item-4609"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/nhs-statistics/remuneration-statistics/">Remuneration statistics</a></div></li></ul>
+</li><li class="page_item page-item-15762 page_item_has_children"><div class="page-link open-sub-sidebar"><span>Pharmacy funding</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Main Menu</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/">Pharmacy funding</a></div></li><li class="page_item page-item-15766"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/cost-of-service-inquiry/">Cost of Service Inquiry</a></div></li><li class="page_item page-item-15792 page_item_has_children"><div class="page-link open-sub-sidebar"><span>Funding distribution</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Pharmacy funding</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/">Funding distribution</a></div></li><li class="page_item page-item-15823"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/branded-generics/">Branded generics</a></div></li><li class="page_item page-item-15817"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/dispensing-at-a-loss/">Dispensing at a loss</a></div></li><li class="page_item page-item-15794"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/essential-service-payments/">Essential Service payments</a></div></li><li class="page_item page-item-15811"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/indicative-income-tables/">Indicative income tables</a></div></li><li class="page_item page-item-15815"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/pre-registration-training-grant/">Pre-registration training grant</a></div></li><li class="page_item page-item-15805"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/retained-margin-category-m/">Retained margin (Category M)</a></div></li><li class="page_item page-item-15813"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/summary-of-funding-changes/">Summary of funding changes</a></div></li><li class="page_item page-item-18075"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/temporary-safeguarding-payments/">Temporary safeguarding payments</a></div></li><li class="page_item page-item-15819"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-distribution/vat/">VAT</a></div></li>	</ul>
+</li><li class="page_item page-item-364250"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/funding-during-the-pandemic/">Funding during the pandemic</a></div></li><li class="page_item page-item-15774"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/historical-funding-arrangements/">Historical funding arrangements</a></div></li><li class="page_item page-item-405"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/discount-deduction/">How discount deduction works</a></div></li><li class="page_item page-item-15771"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/margins-survey/">Margins survey</a></div></li><li class="page_item page-item-15790"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/psnc-ongoing-funding-work/">PSNC Ongoing Funding Work</a></div></li></ul>
+</li><li class="page_item page-item-5092"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/psnc-briefings-funding-and-reimbursement/">PSNC Briefings: Funding & Reimbursement</a></div></li><li class="page_item page-item-600 page_item_has_children"><div class="page-link open-sub-sidebar"><span>Reimbursement</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Main Menu</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/">Reimbursement</a></div></li><li class="page_item page-item-363"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/endorsement-guidance/">Endorsement guidance</a></div></li><li class="page_item page-item-797 page_item_has_children"><div class="page-link open-sub-sidebar"><span>Fees and allowances</span><span class="indicator"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></span></div><ul class="children"><li class="back-sub-sidebar"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg><span>Back to Reimbursement</span></li><li><div class="page-link sub-sidebar-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/">Fees and allowances</a></div></li><li class="page_item page-item-72"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/bb/">Broken bulk</a></div></li><li class="page_item page-item-402"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/consumables-containers/">Consumables and container allowance</a></div></li><li class="page_item page-item-56"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/fees-allowances/oop/">Out of pocket expenses</a></div></li>	</ul>
+</li><li class="page_item page-item-2309"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/how-the-price-change-mechanism-works/">How the price change mechanism works</a></div></li><li class="page_item page-item-100786 current_page_item"><div class="page-link"><a href="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/">Price Concessions</a></div></li></ul>
+</li></ul></li>		</ul>
+	</nav>
+</div>		</div>
+
+		<!-- Page builder -->
+		<div class="page-content page-default col-lg-9">
+
+			<h1 class="page-heading">Price Concessions</h1>
+
+							<div class="page-date">
+					<p>
+						<span>Published on: 28th February 2020</span> 
+						<span class="separator">|</span> 
+						<span>Updated on: 15th March 2023</span>
+					</p>
+				</div>
+			
+			<div class="page-blocks">
+							</div>
+		
 			<div class="banner-ad page">
 						</div>
 			<!-- /banner-ad -->
-			
-						<h1 class="hideformobile">Price Concessions and NCSO</h1>
+		
 
-	
-						
-						
-			
-						<!-- article -->
-						<article id="post-100786" class="post-100786 page type-page status-publish has-post-thumbnail hentry">
-						
-							<!-- AddThis Sharing Buttons above --><p><a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/"><img class="alignnone wp-image-100869" src="http://psnc.org.uk/wp-content/uploads/2016/05/button-final.png" alt="button final" width="280" height="42" srcset="http://psnc.org.uk/wp-content/uploads/2016/05/button-final.png 420w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final-250x38.png 250w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final-120x18.png 120w" sizes="(max-width: 280px) 100vw, 280px" /></a>  <a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/"><img class="alignnone wp-image-100868" src="http://psnc.org.uk/wp-content/uploads/2016/05/button-final1.png" alt="button final1" width="280" height="42" srcset="http://psnc.org.uk/wp-content/uploads/2016/05/button-final1.png 420w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final1-250x38.png 250w, http://psnc.org.uk/wp-content/uploads/2016/05/button-final1-120x18.png 120w" sizes="(max-width: 280px) 100vw, 280px" /></a></p>
-<table class="alignright" style="height: 211px;" border="0" width="308">
+					
+								
+				
+							<!-- article -->
+							<div class="legacy-wysiwyg">
+								<article id="post-100786" class="post-100786 page type-page status-publish has-post-thumbnail hentry tag-drug-tariff tag-price-concessions tag-shortage">
+								
+									<table class=" alignright" style="height: 210px; width: 28.597%;" border="0">
 <tbody>
 <tr style="height: 65px;">
-<td class="lastcol" style="height: 65px; width: 298px; background-color: #659200;">
-<h3 style="text-align: center;"><span style="color: #ffffff;">QUICK LINKS</span></h3>
+<td class="lastcol" style="height: 65px;">
+<h3 style="text-align: center;">QUICK LINKS</h3>
 </td>
 </tr>
-<tr style="height: 48px;">
-<td style="width: 298px; height: 48px;"><a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/237071/dh_063440_1_.pdf">BGMA best practice guidelines on notification of medicines shortages</a></td>
+<tr style="height: 24px;">
+<td class="lastcol" style="height: 24px;"><a href="https://psnc.org.uk/our-news/price-concessions-webinar-now-available-on-demand/">Price concession webinar now available on demand</a></td>
+</tr>
+<tr style="height: 32px;">
+<td style="height: 32px;"><a class="briefings-link" title=" PSNC Briefing 023/22: How the price concession system operates " href="https://psnc.org.uk/briefings/psnc-briefing-023-22-how-the-price-concession-system-operates/" target="_blank" rel="noopener">How the price concession system operates</a></td>
+</tr>
+<tr style="height: 17px;">
+<td style="height: 17px;"><a title="NCSO/ Price Concession Archive" href="https://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">Price Concession Archive</a></td>
 </tr>
 <tr style="height: 24px;">
-<td class="lastcol" style="height: 24px; width: 298px;"><a title="NCSO/ Price Concession Archive" href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">Price Concession and NCSO Archive</a></td>
-</tr>
-<tr style="height: 24px;">
-<td class="lastcol lastrow" style="height: 24px; width: 298px;"><a title="Online Drug Tariff" href="http://www.ppa.org.uk/ppa/edt_intro.htm" target="_blank" rel="noopener noreferrer">REF: Drug Tariff Part II, Clause 8B and 9C</a></td>
+<td class="lastcol" style="height: 24px;"><a href="https://psnc.org.uk/wp-content/uploads/2022/10/Price-concession-archive-922.xlsx">Price concession archive spreadsheet</a></td>
 </tr>
 </tbody>
 </table>
-<h1>November 2017</h1>
-<p><span style="color: #ff0000;"><strong>Latest information:</strong></span> <a href="http://psnc.org.uk/our-news/november-price-concession-update/">November Price Concessions Update</a></p>
-<table style="width: 476px;">
+<h2 style="text-align: justify;">What is a price concession?</h2>
+<p style="text-align: justify;">When community pharmacies cannot source a drug at or below the reimbursement price as set out in the Drug Tariff, the Department of Health and Social Care (DHSC) can introduce a price concession at the request of PSNC. A price concession can be requested for any drugs listed in Part VIIIA, Part VIIIB and Part VIIID of the Drug Tariff. For any drugs granted price concessions, contractors are automatically reimbursed at the new prices for that month.</p>
+<p><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/"><img class="alignnone" src="https://psnc.org.uk/wp-content/uploads/2019/10/Price-concession-button.jpg" width="298" height="162" /></a></p>
+<p style="text-align: justify;"><div class="trigger the-trigger"><strong>The following price concessions have been granted for March 2023</strong><div class="icon"></div></div><div class="toggle_container"></p>
+<p style="text-align: justify;">The Department of Health and Social Care (DHSC) has  granted the following list of price concessions for <strong>March 2023.</strong></p>
+<p style="text-align: justify;">The individual updates can be found here:</p>
+<p style="text-align: justify;"><a href="https://psnc.org.uk/our-news/march-2023-price-concessions-1st-update/">15th March 2023</a></p>
+<table width="452">
 <tbody>
 <tr>
-<td style="width: 304px;"><strong>Drug</strong></td>
-<td style="width: 61px;"><strong>Pack size</strong></td>
-<td style="width: 97px;"><strong>Price Concession</strong></td>
+<td width="233">Drug</td>
+<td width="85">Pack size</td>
+<td width="134">Price concession</td>
 </tr>
 <tr>
-<td style="width: 304px;">Amiloride 5mg tablets</td>
-<td style="width: 61px;">28</td>
-<td style="width: 97px;">£9.25</td>
+<td>Amiloride 5mg tablets</td>
+<td>28</td>
+<td>£9.25</td>
 </tr>
 </tbody>
 </table>
-
-<table style="width: 476px;">
+<table width="452">
 <tbody>
 <tr>
-<td style="width: 304px;"><strong>Drug</strong></td>
-<td style="width: 61px;"><strong>Pack size</strong></td>
-<td style="width: 97px;"><strong>Price Concession</strong></td>
+<td width="233">Drug</td>
+<td width="85">Pack size</td>
+<td width="134">Price concession</td>
 </tr>
 <tr>
-<td style="width: 304px;">Amlodipine 5mg tablets (new)</td>
-<td style="width: 61px;">28</td>
-<td style="width: 97px;">£3.75</td>
+<td>Amlodipine 5mg tablets (new)</td>
+<td>28</td>
+<td>£3.75</td>
 </tr>
 </tbody>
 </table>
-<p><strong>The price concession only applies to the month that it is granted.</strong></p>
-<p><strong style="line-height: 1.5;">PSNC cannot provide details of generic products that are suspected of being affected by generic supply problems unless and until the Department of Health grants a concession.</strong><strong>Please note negotiations are still ongoing regarding a number of products.</strong></p>
-<p>Updates on price concessions will be shown on this page or you can <a href="http://psnc.org.uk/latest-news/email-sign-up/" target="_blank" rel="noopener noreferrer">sign up</a> to receive price concession alerts and updates by email.</p>
-<hr />
-<p>All drugs listed in Part VIII of the Drug Tariff are eligible for price concessions and ‘No Cheaper Stock Obtainable’ (NCSO) status.</p>
-<p>Occasionally there are shortages of these products, for example, if there are manufacturing problems or a change in demand, resulting in pharmacy contractors having to dispense an equivalent product that is only available above the set Drug Tariff price.</p>
-<p>When this happens, PSNC is able to apply to the Department of Health for either a price concession or NCSO status for that particular month.</p>
-<h2>What is a price concession?</h2>
-<p>The Department of Health could consider setting a price concession for products listed in Part VIIIA and Part VIIIB where they are available above the set Drug Tariff reimbursement price. Pharmacy contractors will be automatically reimbursed based on the set price rather than the Drug Tariff listed price. There is no need for any endorsement.</p>
-<p>Applications are made in month and once the price concession has been announced, it only lasts for the month in which it is granted. Where problems persist into the following month a new application is made. It is possible that a new concession will be granted by the Department of Health for subsequent months; however, these are subject to application and are not guaranteed.</p>
-<p>The Department of Health set price concessions using information derived from manufacturers and wholesalers.  Where contractors are unable to purchase products at the set prices, they may wish to challenge suppliers for an explanation of why their prices are so high.  Where contractors are unable to secure products at or near the concessionary price, PSNC would like to receive copies of invoices for monitoring of prices.  Please email these to <a href="mailto:info@psnc.org.uk" target="_blank" rel="noopener noreferrer">info@psnc.org.uk</a> or fax to 0207 278 1127  for the attention of the Dispensing and Supply Team.</p>
-<h2>Reporting generic supply issues</h2>
-<div>
-<p>If you have problems obtaining a Part VIII product at the set Drug Tariff price, please report the issue using our <a title="Problems obtaining a generic medicine" href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">online feedback form</a>. PSNC will investigate the extent of the problem and where necessary discuss the issue with the Department of Health.</p>
-<p>Please note, PSNC is unable to provide details of generic products that are suspected of being affected by generic supply problems unless and until the Department of Health grants a concession.</p>
-<p>Contractors will be alerted to any updates through our website and via our e-news email.  You can subscribe to our mailing list by <a title="Newsletter Sign Up" href="http://psnc.org.uk/latest-news/email-sign-up/">clicking here</a>.</p>
-<p>Sometimes a price concession or NCSO is granted late in the month, this is due to changing stock levels within the month.  Contractors are advised to procure as economically as is possible for their individual businesses.</p>
-<hr />
-<h2>FAQs</h2>
-<p><strong>Q. How long do price concessions or NCSOs last?</strong></p>
-<div>
-<p>A. If price concessions or NCSOs are granted, it is valid until the end of the month in which it was granted. PSNC needs to apply/re-apply for concessions on a monthly basis. If there is an on-going supply problem, it is possible that a new concession will be granted by the Department of Health the following month; however, this is not guaranteed.</p>
-<p><strong>Q. Why do contractors need to report generic shortages each month? If a price concession or NCSO is granted in one month and is still a problem in the next month why doesn&#8217;t the price roll over?</strong></p>
-<div>
-<p>A. Price concessions  and NCSOs only apply for the month in which they are granted. Because the market fluctuates on a regular basis in terms of stock levels and prices it would not be appropriate to roll the price over from one month to the next.</p>
-<p>PSNC regularly monitors the market through contractor reports and communications with wholesalers. Where appropriate, we apply to the Department of Health for price concessions on products which aren&#8217;t available at Drug Tariff price.  As stock levels and prices can vary across the country, we rely on contractor reports to help feed into our market surveillance and our discussions with the Department of Health. It is also important to note that the Department may not act on something unless contractors have reported it.</p>
+<p style="text-align: justify;">No additional endorsements are required for price concessions. <strong>A price concession only applies for the month in which it is granted.</strong></p>
+<p style="text-align: justify;">If you have problems obtaining a Part VIII product at the stated Drug Tariff price, please report the issue using the <u><a href="https://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">online feedback form</a></u> on the PSNC website. Please include full details of the supplier and price paid for any products sourced above the Drug Tariff price. PSNC will investigate the extent of the problem and, if appropriate, discuss the issue with DHSC.</p>
+<p style="text-align: justify;"><em>Contractors will be alerted to further updates to the price concession list through our website and via our e-news email.  If you wish to <a href="https://psnc.org.uk/signup/">subscribe to our email list</a>, you can receive an email as soon as any announcements are made. </em></p>
+<p style="text-align: justify;"></div></p>
+<p style="text-align: justify;"><strong><div class="trigger the-trigger">How does PSNC apply for price concessions?<div class="icon"></div></div><div class="toggle_container"> </strong></p>
+<p style="text-align: justify;">Each month, PSNC receives a considerable number of contractor reports (submitted via an online reporting form, by email or telephone) and system-generated reports showing actual purchases of generics made by community pharmacies above the Drug Tariff listed price. PSNC also monitors monthly price lists and price change notifications shared by various suppliers. The reports received help PSNC investigate and determine whether it is appropriate to submit a request for a price concession. At the start of each month, an initial application is submitted to DHSC for any generic drugs reported to PSNC that are unavailable at or below the Drug Tariff price for that month. Further price concession requests for other generic drugs unavailable at Tariff-listed prices are submitted throughout the month.</p>
+<p style="text-align: justify;">Contractors should continue to use PSNC’s online reporting form to share details of drugs unavailable at Drug Tariff listed prices. As stock levels and prices can vary across the country, we rely on these contractor reports which help feed into our market surveillance and inform our discussions with DHSC. The reports help us to demonstrate the scale of the problems to DHSC and support escalations on particular lines, as needed. In certain circumstances, DHSC may request wholesaler invoices showing actual purchase prices as evidence to help PSNC make further representations to the Department for an improved price concession. Contractors can email in copies of wholesaler invoices to <a href="mailto:concessions@psnc.org.uk">concessions@psnc.org.uk</a>.</p>
+<p style="text-align: justify;"></div><div class="trigger the-trigger">Setting a price concession<div class="icon"></div></div><div class="toggle_container"></p>
+<p style="text-align: justify;">Upon receiving PSNC’s initial request, DHSC conducts its own research into the market, by gathering volume and price information of drugs from manufacturers, wholesalers and importers, through its data-gathering powers afforded by the Information and Disclosure Regulations 2018 (Information Regulations) Following their initial investigation, DHSC may then decide to grant an initial price concession or grant no price concession at all. DHSC include a margin uplift for drugs granted a price concession.</p>
+<p style="text-align: justify;"></div><div class="trigger the-trigger">Arriving at a decision<div class="icon"></div></div><div class="toggle_container"></p>
+<p style="text-align: justify;">PSNC compares DHSC’s initial proposed price, where offered, against the reported contractor purchase prices, latest wholesaler prices and any further market data gathered after the initial application. PSNC uses this data to determine a minimum acceptable price below which a price concession cannot be agreed to. Where PSNC does not accept a price proposal, we will approach DHSC and seek to negotiate a more acceptable price for contractors. Care is taken to ensure that the prices requested by PSNC are fair and reasonable based on the available purchase data and wholesaler selling-out prices across the country. If inflated prices are requested by the PSNC, there is a risk of over-delivery of margin which would be subsequently clawed back by DHSC through Category M adjustments. For this reason, we urge contractors to only report actual purchase prices rather than the highest available prices from various wholesalers. DHSC will consider PSNC’s revised price proposals, and any new requests submitted throughout the month. DHSC will review its initial price offering against PSNC’s requested prices and the data they have access to. DHSC may then decide to: agree a price concession that matches PSNC’s initial request, or offer a lower price concession to PSNC’s initial request; or grant no price concession at all. Any drugs which PSNC is unable to agree prices for are subject to further discussion with DHSC. If PSNC and DHSC are still unable to come to an agreement on the final price, DHSC, following Ministerial approval, will impose a price they feel is reflective of the market data they have access to. DHSC often cites that the reason behind its decision is due to their research indicating that a considerable amount of stock has been available at or below the proposed price concession at some point during the month in question.</p>
+<p style="text-align: justify;">PSNC is mindful of the need to finalise price concessions as early as possible in the month so that contractors have certainty over what they will be reimbursed. However, there is a fine balance between agreeing to a price too early in the month versus holding out to secure a better price later in the month particularly in a market where prices are increasing.</p>
+<p style="text-align: justify;">Price concessions are published on PSNC’s website as soon as they are finalised with DHSC. Contractors can sign up to receive <a href="https://psnc.org.uk/psnc-and-negotiations/updates-events/email-sign-up/">email alerts</a> as soon as any price concession announcements are made.</p>
+<p style="text-align: justify;"></div><div class="trigger the-trigger">Improving the system<div class="icon"></div></div><div class="toggle_container"></p>
+<p style="text-align: justify;">PSNC understands the difficult challenges faced by contractors when the final prices granted or imposed by DHSC fall below the purchase prices they have paid. This can have a disproportionate effect particularly on those pharmacies dispensing large volumes of any affected lines.</p>
+<p style="text-align: justify;">PSNC is <a href="https://psnc.org.uk/our-news/psnc-to-seek-overhaul-of-pricing-concessions-system/">escalating its concerns</a> about the process for setting price concessions to senior Government officials responsible for medicines supply.</p>
+<p style="text-align: justify;"></div><div class="trigger the-trigger">This flow chart shows the expected process throughout the month: <div class="icon"></div></div><div class="toggle_container"></p>
+<div style="text-align: justify;">
+<p><a href="https://psnc.org.uk/wp-content/uploads/2022/11/Price-concession-process.jpg"><img loading="lazy" class="" src="https://psnc.org.uk/wp-content/uploads/2022/11/Price-concession-process.jpg" width="489" height="530" /></a></p>
+<p></div><div class="trigger the-trigger">Margins Survey<div class="icon"></div></div><div class="toggle_container"></p>
+<p>As part of the <a href="https://psnc.org.uk/funding-and-reimbursement/pharmacy-funding/margins-survey/">margins survey</a> each year, an exercise is conducted to calculate the financial impact of concession lines on contractors throughout the year. Data is gathered for all items which have been on concession and the financial impact of these lines is calculated and accounted for in the final margins survey result. The calculation also considers any discount deduction (‘clawback’) applied to reimbursement of concession lines and any wholesaler surcharges paid by contractors. If an independent contractor selected in the survey sample purchased a drug at price higher than the final price concession, this will be picked up by the margins survey. This is then factored into the overall retained margin survey result and is off set against any excess margin made on other sampled drugs. On the contrary, if the price concession is higher than the contractor’s actual purchase price, any margin earned will count towards the community pharmacy’s overall retained margin allowance of £800m per year.</p>
 </div>
-<p><strong>Q. Why aren’t price concessions or NCSOs granted on the first day of each month?</strong></p>
+<p style="text-align: justify;"></div><div class="trigger the-trigger">FAQs<div class="icon"></div></div><div class="toggle_container"></p>
+<p style="text-align: justify;"><strong>Q. Why does it take so long for prices to be released?</strong></p>
+<p style="text-align: justify;">A. The reason for the delays in announcement of concessions is because we see prices for many lines changing throughout the month and the initial prices granted by DHSC are not reflective of the reports we have received from contractors. We understand that contractors want certainty of expected reimbursement prices and that prices granted late in the month are not ideal, especially when there is a wide variation between Tariff and purchase prices. However, we do need to strike a fine balance between agreeing to a price too early in the month versus holding out to secure a better price later in the month particularly in a market where</p>
+<div style="text-align: justify;">
+<p><strong>Q. How long do price concessions last?</strong></p>
 <div>
-<p>A. If there is a supply issue, PSNC needs to make a fresh concession application at the start of each month. The Department of Health then take time to undertake checks and make a decision. In some cases, there is a need for negotiation between PSNC and the Department of Health on an individual product’s circumstances; this can take time.</p>
-<p>PSNC would like to see changes to the arrangements that would allow contractors to have certainty over what they will be reimbursed, much earlier in the month, a point which we have raised with the Department of Health.</p>
-<p><strong>Q. If a medicine is granted a price concession or NCSO , are all strengths of the product covered by the price concession or NCSO ?</strong></p>
+<p>A. If price concessions are granted, it is valid until the end of the month in which it was granted. PSNC needs to apply/re-apply for concessions on a monthly basis. If there is an on-going supply problem, it is possible that a new concession will be granted by DHSC the following month; however, this is not guaranteed.</p>
+<p style="text-align: justify;"><strong>Q. Why do some drugs take longer than others to be added to the list?</strong></p>
+<p style="text-align: justify;">A. Some products can be agreed early where prices are deemed acceptable to PSNC based on the reports received. Other drugs may be requested later in the month or require further negotiation and interrogation based on contractor reports and wholesaler prices before an agreement can be reached. If agreement cannot be reached the decision is made by ministers to either impose a concession price or grant no concession at all</p>
+<p><strong>Q. Why do contractors need to report generic pricing issues each month? If a price concession is granted in one month and is still a problem in the next month why doesn’t the price roll over?</strong></p>
 <div>
-<p>A. No, concessions are granted to specific strengths of a product so contractors must check the latest list so they know which strengths have been granted a concession.</p>
-<p><strong>Q. What happens if a price concession is announced after the date that I have sent my EPS claim message to the Pricing Authority for an EPSR2 prescription?</strong></p>
+<p>A. Price concessions only apply for the month in which they are granted. Because the market fluctuates on a regular basis in terms of stock levels and prices it would not be appropriate to roll the price over from one month to the next.</p>
+<p>PSNC regularly monitors the market through contractor reports and communications with wholesalers. Where appropriate, we apply to DHSC for price concessions on products which aren’t available at Drug Tariff price.  As stock levels and prices can vary across the country, we rely on contractor reports to help feed into our market surveillance and our discussions with DHSC. It is also important to note that the Department may not act on something unless contractors have reported it.</p>
+<p>PSNC has repeatedly raised the point around price roll over however DHSCs view is that it is not appropriate to roll concession prices over because of market fluctuations.</p>
+<p><strong>Q. Why aren’t price concessions granted on the first day of each month?</strong></p>
+</div>
+<div>
+<p>A. If there is a pricing issue, PSNC needs to make a fresh concession application at the start of each month. DHSC then take time to undertake checks and make a decision. In some cases, there is a need for negotiation between PSNC and DHSC on an individual product’s circumstances; this can take time.</p>
+<p>PSNC would like to see changes to the arrangements that would allow contractors to have certainty over what they will be reimbursed, much earlier in the month, a point which we continue to raise with the DHSC.</p>
+<div>
+<p><strong>Q. What happens if a price concession is announced after the date that I have sent my EPS claim message to the NHS Business Services Authority (NHSBSA) for an EPSR2 prescription?</strong></p>
 <div>
 <p>A. Price concessions, once granted, apply for the whole ‘dispensing month’. For example a price concession announced on August 30th applies to the entirety of your August ‘prescription bundle’.</p>
-<p>Your August prescription bundle is made up of all your paper prescriptions which are sent to the Pricing Authority by the 5th September and all the EPS prescriptions which fall into the August dispensing month (see below). Prescriptions for any one dispensing month are not priced until the Pricing Authority receives both the electronic and paper prescriptions as the FP34C submission document is needed from the paper bundle to calculate the advance payment for the contractor.</p>
-<p>How a dispensing month is determined for electronic prescriptions is outlined below:</p>
-<p><img src="http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table.png" sizes="(max-width: 590px) 100vw, 590px" srcset="http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table.png 896w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-250x129.png 250w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-700x363.png 700w, http://psnc.org.uk/wp-content/uploads/2014/08/eps-timing-mini-table-120x62.png 120w" alt="eps timing mini table" width="590" height="306" /></p>
-<p><strong>Q. I have received a prescription for &#8217;28 x 5mg tablets&#8217;; however, there is currently a supply issue with that strength and we can only purchase it above Drug Tariff price. The 2.5mg strength is available and works out at the same Drug Tariff price so can I dispense &#8217;56 x 2.5mg tablets&#8217; instead?</strong></p>
+<p>Your August prescription bundle is made up of all your paper prescriptions which are sent to the NHSBSA by the 5th September and all the EPS prescriptions which fall into the August dispensing month (see below). Prescriptions for any one dispensing month are not priced until the NHSBSA receives both the electronic and paper prescriptions as the MYS submission figures are needed to calculate the advance payment for the contractor.</p>
+<p><strong>Q. Why can’t PSNC tell where they can see stock at the agreed price?</strong></p>
+<p style="text-align: justify;">A. PSNC is unable to advise contractors where to procure products from due to competition law. The French equivalent of PSNC, Ordre National des Pharmaciens, was fined €5 million by the European Commission for exactly this behavior.</p>
+<p style="text-align: justify;"><strong>Q. Can price concession drugs be exempted from discount deduction?</strong></p>
+<p style="text-align: justify;">A. Unfortunately, the answer is no, We have raised this with the Department on a number of occasions but they will not consider DND status for any drugs granted a price concession. From October 2022, the discount deduction applied to the monthly total of reimbursement prices will be transitioning to new arrangements. Products granted concessionary prices will have the brands discount deduction rate of 5% applied to it for the month in which the concession applies.</p>
+<p><strong>Q. I have received a prescription for ’28 x 5mg tablets’; however, there is currently a supply issue with that strength and we can only purchase it above Drug Tariff price. The 2.5mg strength is available and works out at the same Drug Tariff price so can I dispense ’56 x 2.5mg tablets’ instead?</strong></p>
 <div>
-<p>A. No. Reimbursement will be based on the prescribed strength and quantity (Please note that the ‘PC’ endorsement is not a sufficient endorsement in this situation).  If contractors believe it is in the patients best interest to ‘double up’ to support patient care, contractors are advised to return the prescription to the prescriber so they can make a clinical decision and if necessary amend the prescription to ensure correct reimbursement.</p>
+<p>A. No. Reimbursement will be based on the prescribed strength and quantity (Please note that the ‘PC’ endorsement is not a sufficient endorsement in this situation).  If contractors believe it is in the patients best interest to ‘double up’ to support patient care, contractors are advised to return the prescription to the prescriber so they can make a clinical decision and if necessary amend the prescription to ensure correct reimbursement.</p>
 <div>
-<p><strong>Q. I have been told by my wholesaler that a Part VIIIA licensed generic product is unavailable. There is not an alternative proprietary product available but a specials manufacturer can prepare this product for me. Can a price concession or NCSO  be requested?</strong></p>
+<p><strong>Q. I have been told by my wholesaler that a Part VIIIA licensed generic product is unavailable. There is not an alternative proprietary product available but a specials manufacturer can prepare this product for me. Can a price concession  be requested?</strong></p>
 <div>
-<p>A. No. The Department of Health’s view is that the prescription should be referred back to the prescriber so that they have the opportunity to prescribe an alternative licensed product and/or are aware of the changes in liability caused by an unlicensed product being given to the patient. If the prescriber believes that the product should be specially manufactured, the prescription should be amended to specify “unlicensed special” within the product description. If the prescriber has stated the name of the specials manufacturer, the Pricing Authority will pay based on the endorsed invoice price for the specially manufactured product rather than the Drug Tariff Price. Remember that if the prescriber makes a hand written amendment or includes additional product information that does not appear in the product description (i.e. to provide a certain brand), the prescription must be included in the red separator.</p>
-<p>It is helpful to inform the PSNC Dispensing and Supply Team about the shortage. If there is a long term supply problem, PSNC can make an application to the Department of Health to remove the product from the Drug Tariff.</p>
-<p><a title="Unlicensed specials and imports" href="http://www.psnc.org.uk/dispensing-supply/dispensing-a-prescription/unlicensed-specials-and-imports/">More information on the dispensing of unlicensed medicines is available in this section of our site.</a></p>
+<p>A. No. DHSC’s view is that the prescription should be referred back to the prescriber so that they have the opportunity to prescribe an alternative licensed product and/or are aware of the changes in liability caused by an unlicensed product being given to the patient. If the prescriber believes that the product should be specially manufactured, the prescription should be amended to specify “unlicensed special” within the product description. If the prescriber has stated the name of the specials manufacturer, the NHSBSA will pay based on the endorsed invoice price for the specially manufactured product rather than the Drug Tariff Price. Remember that if the prescriber makes a hand written amendment or includes additional product information that does not appear in the product description (i.e. to provide a certain brand), the prescription must be included in the red separator.</p>
+<p>It is helpful to inform the PSNC Dispensing and Supply Team about the shortage. If there is a long term supply problem, PSNC can make an application to DHSC to remove the product from the Drug Tariff.</p>
+<p><a title="Unlicensed specials and imports" href="https://psnc.org.uk/dispensing-supply/dispensing-a-prescription/unlicensed-specials-and-imports/">More information on the dispensing of unlicensed medicines is available in this section of our site.</a></p>
 </div>
 </div>
 </div>
@@ -1056,215 +1394,301 @@ Price Concess"/>
 </div>
 </div>
 </div>
-<p>&nbsp;</p>
+<div style="text-align: justify;">
+<p style="text-align: justify;"><strong>Q. I have received a prescription for a Part VIIIB unlicensed medicine but cannot obtain it at the Part VIIIB price, what should I do?</strong></p>
 <div>
-<p><strong>Q. I have received a prescription for a Part VIIIB unlicensed medicine but cannot obtain it at the Part VIIIB price, what should I do?</strong></p>
+<p style="text-align: justify;">A. Pharmacy contractors should ensure they have considered a range of suppliers and where they are still having difficulties, pharmacy contractors should contact PSNC who will then be able to investigate the situation and apply to the DHSC for a price concession if appropriate.</p>
+<p style="text-align: justify;"><strong>Q. What is NCSO status?</strong></p>
 <div>
-<p>A. Unless there are exceptional circumstances pharmacy contractors should be able to purchase the products in Part VIIIB at or below the Drug Tariff price. Pharmacy contractors will need to ensure they have considered a range of suppliers and where they are still having difficulties, pharmacy contractors should contact PSNC who will then be able to investigate the situation and apply to the DH for a price concession or NCSO if appropriate.</p>
-<h2 class="trigger">What is NCSO status?</h2><div class="toggle_container"></p>
-<p>No Cheaper Stock Obtainable (NCSO) status, is granted for products listed in Part VIIIA &amp; Part VIIIB of the Drug Tariff where pharmacy contractors have been unable to purchase product at the set Drug Tariff reimbursement price.</p>
-<p>Where a NCSO is granted, the reimbursement price is based upon the appropriate prescription endorsement rather than the fixed Drug Tariff price. However, it is essential that contractors <a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/#endorsing">endorse the prescription fully</a>.</p>
-<p>Applications are made in month and once the NCSO status has been announced, it only lasts for the month in which it is granted. Where problems persist into the following month, a new application may be made. It is possible that a new concession will be granted by the Department of Health for subsequent months; however, these are subject to application and are not guaranteed.</p>
-<h2>NCSO endorsing guide</h2>
-<div>
-<p>Given the number of products in short supply at present, contractors may want to consider undertaking an additional check during their end of month prescription submission process, to ensure that all prescriptions have been endorsed correctly, where necessary. Key things to consider:</p>
-<ul>
-<li>The NCSO is granted at different times during the month; have staff been giving consideration to whether the concession needs to be claimed for all products on the NCSO list?</li>
-<li>Where staff have endorsed to claim the NCSO, does the endorsement include all of the necessary information? In checks PSNC has undertaken on endorsing practice, the most common omission is the initial for the dispenser (any authorised staff member can add the initial, it doesn’t need to be the pharmacist. The initials can be computer generated).</li>
-<li>If the Pricing Authority do not have a price on their system for the endorsed brand or supplier, the endorsement must also include the price paid (before discount and ex VAT). An indication of which suppliers are listed on the NHS RxS system for a particular product is available through the <a href="http://dmd.medicines.org.uk/" target="_blank" rel="noopener noreferrer">Dictionary of Medicines and Devices</a> browser.</li>
-<li>The Pricing Authority will only reimburse based on an NCSO endorsement where a prescription has been submitted in the month that the NCSO has been granted. Care should be taken to ensure that prescriptions dispensed in a particular month are submitted with that month’s prescription bundle.</li>
-</ul>
-<p>For further information,  see our guidance on NCSOs:  <a href="http://www.psnc.org.uk/wp-content/uploads/2013/05/NCSO_Endorsement_Guidance_and_FAQs_May_13.pdf">NCSO Endorsement Guidance and FAQs (May 13)</a>.</p>
-<h2>NCSO Endorsement FAQs</h2>
-<p><strong>Q. Do I need to include the name of the supplier or is just the price acceptable for NCSO endorsements?</strong></p>
-<p>A. It is essential to endorse the following:</p>
-<ul>
-<li>NCSO</li>
-<li>Pharmacist initials</li>
-<li>Date</li>
-<li>Supplier, manufacturer or brand name;</li>
-<li>Pack size</li>
-<li>Price if appropriate</li>
-</ul>
-<p>If this information is missing, even if a price has been endorsed, the NCSO claim will not be accepted by the Pricing Authority.</p>
-<p><strong>Q. Does it need to be the pharmacist that initials the NCSO endorsement?</strong></p>
-<p>A. No, it can be any staff member who has been authorised by the pharmacy owner. It doesn’t need to be the pharmacist.</p>
-<p><strong>Q. Is it acceptable to provide a fully computer-generated NCSO endorsement or do any parts of this endorsement need to be handwritten?</strong></p>
-<p>A. It is acceptable for the NCSO endorsement (including the date and initials of the staff member making the endorsement) to be computer-generated.</p>
-<p><strong>Q. Can I endorse ‘NCSO’ for any item I am unable to purchase at the Drug Tariff Part VIII price?</strong></p>
-<p>A. No. No Cheaper Stock Obtainable (NCSO) products are items for which in the opinion of the Secretary of State for Health and the Welsh Ministers there is no product available to contractors at the price in Part VIII of the Drug Tariff. In this scenario the Pricing Authority will only reimburse based on a full NCSO endorsement against those items which have been granted this status.</p>
-<p><strong>Q. Can I endorse that I have given a branded product against a prescription for the Part VIIIA generic item and be reimbursed for doing so?</strong></p>
-<div>
-<p>Contractors will only be reimbursed for a branded equivalent if the NCSO has been granted for that product in that dispensing month, and the prescription has been endorsed fully to claim the concession (see endorsing guidance above).</p>
-</div>
-<p></div>
-<p>&nbsp;</p>
+<p style="text-align: justify;">The information provided in this section does not relate to the use of the NCSO endorsement for SSPs. For information on endorsing SSPs please see our <a href="https://psnc.org.uk/wp-content/uploads/2019/08/PSNC-Briefing-023.19-Serious-Shortage-Protocols-FINAL-PUBLISHED-v2.0.pdf">Briefing 023/19: Serious Shortage Protocols (SSPs)</a> also see our <a href="https://psnc.org.uk/dispensing-supply/supply-chain/ssps-faqs/?preview_id=315582&amp;preview_nonce=a38dfb021a&amp;_thumbnail_id=91326&amp;preview=true">SSPs – FAQs</a></p>
+<p style="text-align: justify;"><strong>The last No Cheaper Stock Obtainable (NCSO) was granted in April 2013.</strong>  An NCSO status was used where products listed in Part VIIIA &amp; Part VIIIB of the Drug Tariff were not available at the set Drug Tariff reimbursement price.</p>
+<p style="text-align: justify;">Previously where an NCSO was granted, the reimbursement price was based upon the appropriate prescription endorsement rather than the fixed Drug Tariff price. Correct endorsement for an NCSO was essential.</p>
+<p style="text-align: justify;">Applications were made in month and once an NCSO status was announced, it only lasted for the month in which it is granted. Where problems persisted into the following month, a new application had to be made.</p>
+<p style="text-align: justify;"></div></p>
 </div>
 </div>
 </div>
-<!-- AddThis Sharing Buttons below --><div class="addthis_toolbox addthis_default_style" addthis:url='http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/' ><a class="addthis_button_twitter"></a><a class="addthis_button_facebook"></a><a class="addthis_button_linkedin"></a><a class="addthis_button_email"></a><a class="addthis_button_compact"></a><a class="addthis_counter addthis_bubble_style"></a></div>							
-							<br class="clear">
+<hr />
+<h2>Additional Information</h2>
+<p><a href="https://psnc.org.uk/dispensing-and-supply/supply-chain/medicine-shortages/">Medicine Shortages</a></p>
+<p><a href="https://psnc.org.uk/our-news/medicine-supply-contractor-update-from-psnc/">Contractor Update on Medicines Supply  (July 2022)</a></p>
+<p><a href="https://psnc.org.uk/wp-content/uploads/2022/07/PSNC-Medicines-Supply-Information-Leaflet-July-2022.pdf">Medicines Supply Factsheet (July 2022)</a></p>
+<p><a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/237071/dh_063440_1_.pdf">BGMA Best Practice Guidelines on Notification of Medicine Shortages</a></p>
+<div class="addtoany_share_save_container addtoany_content addtoany_content_bottom"><div class="a2a_kit a2a_kit_size_24 addtoany_list" data-a2a-url="https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/" data-a2a-title="Price Concessions"><a class="a2a_button_twitter" href="https://www.addtoany.com/add_to/twitter?linkurl=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F&amp;linkname=Price%20Concessions" title="Twitter" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_linkedin" href="https://www.addtoany.com/add_to/linkedin?linkurl=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F&amp;linkname=Price%20Concessions" title="LinkedIn" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_facebook" href="https://www.addtoany.com/add_to/facebook?linkurl=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F&amp;linkname=Price%20Concessions" title="Facebook" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_email" href="https://www.addtoany.com/add_to/email?linkurl=https%3A%2F%2Fpsnc.org.uk%2Ffunding-and-reimbursement%2Freimbursement%2Fprice-concessions%2F&amp;linkname=Price%20Concessions" title="Email" rel="nofollow noopener" target="_blank"></a><a class="a2a_dd addtoany_share_save addtoany_share" href="https://www.addtoany.com/share"></a></div></div>									
+									<p>For more information on this topic please email <a href="mailto:info@psnc.org.uk">info@psnc.org.uk</a></p>								
+								</article>
+							</div>
+							<!-- /article -->	
 							
-													
-						</article>
-						<!-- /article -->	
-						
-										
-						
-				
-				
-		</div>
-		<!-- /page-content -->
-		
-		<hr>
-	
-		<div class="page-news-releases sixteen columns">
-			
-			<!-- Conditional news items. Structure:
-				1. Checks if is a main site section OR an ancestor of the section parent
-				2. Sets the correct arguments to query the correct taxonomy
-				3. Opens a div to enable specific colouring
-				4. <h2> Title
-				5. Content
-			 -->
-							<div class="ds-news">
-				<h2>Latest Dispensing and Supply news</h2>
-				<p class="view-more"><a href="http://psnc.org.uk/our-latest-news-category/dispensing-and-supply/" >View more Dispensing and Supply news ></a></p>
-						<!-- End conditional news items -->
-					<div style="clear:both; height:10px; width:100%;"></div>
-					<div class="slider4col">
 											
-								
-								<!-- article -->
-								<article id="post-233323"  class="news-box">
-									<!-- post thumbnail -->
-									<div class="news-thumb clear">
-																			<a href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/" title="Drug shortages featured in national press">
-											<img src="http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image-250x95.jpg 250w, http://psnc.org.uk/wp-content/uploads/2014/01/Drug-tray-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />										</a>
-																			</div>
-									<!-- /post thumbnail -->
-									<!-- post title -->
-									<h3>
-										<a href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/" title="Drug shortages featured in national press">Drug shortages featured in national press</a>
-									</h3>
-									<!-- /post title -->
-									<p>The front cover of this morning&#8217;s (Thursday 7th December) The Times featured an article raising concerns about patients not being able...<a class="view-article" href="http://psnc.org.uk/our-news/drug-shortages-featured-in-national-press/"></a></p>																	</article>
-								<!-- /article -->
-								
-																
-														
 							
-												
-								
-								<!-- article -->
-								<article id="post-225998"  class="news-box">
-									<!-- post thumbnail -->
-									<div class="news-thumb clear">
-																			<a href="http://psnc.org.uk/our-news/november-price-concession-update/" title="November Price Concession Update">
-											<img src="http://psnc.org.uk/wp-content/uploads/2015/09/Drug-Tariff-300x115.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" />										</a>
-																			</div>
-									<!-- /post thumbnail -->
-									<!-- post title -->
-									<h3>
-										<a href="http://psnc.org.uk/our-news/november-price-concession-update/" title="November Price Concession Update">November Price Concession Update</a>
-									</h3>
-									<!-- /post title -->
-									<p>Update as of 5th December: We continue to press DH and they have confirmed November price concessions are still under consideration....<a class="view-article" href="http://psnc.org.uk/our-news/november-price-concession-update/"></a></p>																	</article>
-								<!-- /article -->
-								
-																
-														
-							
-												
-								
-								<!-- article -->
-								<article id="post-226039"  class="news-box">
-									<!-- post thumbnail -->
-									<div class="news-thumb clear">
-																			<a href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/" title="NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year">
-											<img src="http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" srcset="http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image.jpg 300w, http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image-250x95.jpg 250w, http://psnc.org.uk/wp-content/uploads/2014/01/Picking-out-medicine-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" />										</a>
-																			</div>
-									<!-- /post thumbnail -->
-									<!-- post title -->
-									<h3>
-										<a href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/" title="NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year">NHS England agrees prescribing restrictions for low value meds and consultation on OTC products in New Year</a>
-									</h3>
-									<!-- /post title -->
-									<p>NHS England has today issued guidance to GPs and CCGs to &#8220;remove ineffective, unsafe and low clinical value treatments, such...<a class="view-article" href="http://psnc.org.uk/our-news/nhs-england-agrees-prescribing-restrictions-for-low-value-meds-and-consultation-on-otc-products-in-new-year/"></a></p>																	</article>
-								<!-- /article -->
-								
-																
-														
-							
-												
-								
-								<!-- article -->
-								<article id="post-225989"  class="news-box">
-									<!-- post thumbnail -->
-									<div class="news-thumb clear">
-																			<a href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/" title="MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)">
-											<img src="http://psnc.org.uk/wp-content/uploads/2013/07/MHRA-for-website-300x115.jpg" class="attachment-news-thumb size-news-thumb wp-post-image" alt="" />										</a>
-																			</div>
-									<!-- /post thumbnail -->
-									<!-- post title -->
-									<h3>
-										<a href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/" title="MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)">MHRA company-led drug alert – Calcichew-D3 500mg/400 IU caplets (Takeda UK Ltd)</a>
-									</h3>
-									<!-- /post title -->
-									<p>CLDA number: CLDA (17) A/05 Date issued: 28th November 2017 The Medicines and Healthcare products Regulatory Agency (MHRA) has issued...<a class="view-article" href="http://psnc.org.uk/our-news/mhra-company-led-drug-alert-calcichew-d3-500mg400-iu-caplets-takeda-uk-ltd/"></a></p>																	</article>
-								<!-- /article -->
-								
-																
-														
-												</div>
-					<!-- /slider4col -->
+					
 			
-				</div>
-				<!-- end specific news item wrap -->
-		
+			<div class="page-blocks">
+							</div>
 		</div>
-		<!-- /home-news-releases -->
-	
-	</div>
-	<!-- /wrapper -->
 
-		<!-- footer -->
-		<footer class="footer" role="contentinfo" >
-			
-			<div class="wrapper clear">
-				
-				<div id="text-2" class="four columns clear widget_text"><h3 class="widgettitle">Contact PSNC</h3>			<div class="textwidget"><p>Tel: 0203 1220 810<br />
-Fax: 0207 278 1127</p>
-<p><a title="Ask PSNC" href="http://askpsnc.org.uk">info@psnc.org.uk</a></p>
-<p>PSNC<br />
+	</div>
+
+
+	
+	<div class="page-latest-news">
+		<div class="row row-reduced-padding">
+		
+			<div class="col-12">
+				<div class="heading main-site">
+					<h2>Latest Funding & Reimbursement news</h2>
+					<a href="/our-latest-news-category/funding-and-reimbursement" class="see-all"><span class="desktop">View more Funding & Reimbursement news</span><span class="mobile">See all</span> <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.293 12.293L6.707 13.707L13.414 6.99997L6.707 0.292969L5.293 1.70697L9.586 5.99997H0V7.99997H9.586L5.293 12.293Z" fill="url(#paint0_linear_1443:1159)"/><defs><linearGradient id="paint0_linear_1443:1159" x1="13.414" y1="6.99997" x2="-1.41608e-07" y2="6.99997" gradientUnits="userSpaceOnUse"><stop stop-color="#93378A"/><stop offset="1" stop-color="#55318C"/></linearGradient></defs></svg></a>
+				</div>
+			</div>
+
+			<div class="news-carousel-wrap"><div class="news-carousel">
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/march-2023-price-concessions-1st-update/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>March 2023 Price Concessions 1st Update</h3>
+        <div class="excerpt">
+            <p>The Department of Health and Social Care (DHSC) has today (15/03/2023) granted the following initial list of price concessions for March 2023. Drug Pack size Price&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        15th March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/year-5-cpcf-services-cannot-go-ahead-without-funding-uplift/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front.webp" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front.webp 682w, https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front-250x167.webp 250w, https://psnc.org.uk/wp-content/uploads/2021/11/Pharmacy-front-120x80.webp 120w" sizes="(max-width: 682px) 100vw, 682px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Year 5 CPCF services cannot go ahead without funding uplift</h3>
+        <div class="excerpt">
+            <p>PSNC has today told Ministers that NHS England and the Department of Health and Social Care (DHSC) must not roll out any new or expanded&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        13th March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/ssp-for-lipitor-10mg-chewable-tablets-extended/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>SSP for Lipitor® 10mg chewable tablets extended</h3>
+        <div class="excerpt">
+            <p>The Department of Health and Social Care (DHSC) has provided an update on the Serious Shortage Protocols (SSPs) for Lipitor® 10mg chewable tablets (SSP032). SSP032&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        13th March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/prescription-charge-rises-to-9-65/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2014/01/Taking-prescription-charge-slide.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2014/01/Taking-prescription-charge-slide.jpg 528w, https://psnc.org.uk/wp-content/uploads/2014/01/Taking-prescription-charge-slide-250x123.jpg 250w, https://psnc.org.uk/wp-content/uploads/2014/01/Taking-prescription-charge-slide-120x59.jpg 120w" sizes="(max-width: 528px) 100vw, 528px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Prescription charge rises to £9.65</h3>
+        <div class="excerpt">
+            <p>The Department of Health and Social Care (DHSC) has announced that from 1st April 2023, the NHS prescription charge will increase to £9.65 per prescription item&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        10th March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/pharmacy-bodies-launch-save-our-pharmacies-campaign-website/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2023/03/SOP-Logo.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2023/03/SOP-Logo.jpg 500w, https://psnc.org.uk/wp-content/uploads/2023/03/SOP-Logo-250x250.jpg 250w, https://psnc.org.uk/wp-content/uploads/2023/03/SOP-Logo-120x120.jpg 120w, https://psnc.org.uk/wp-content/uploads/2023/03/SOP-Logo-200x200.jpg 200w" sizes="(max-width: 500px) 100vw, 500px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Pharmacy bodies launch Save Our Pharmacies campaign website</h3>
+        <div class="excerpt">
+            <p>A Save Our Pharmacies campaign website has been created by leading national pharmacy bodies, to give new focus to calls for fair pharmacy funding in&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        8th March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/retrospective-pricing-adjustments-for-venofer-ferinject-and-aptamil-products/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2016/02/Dispensary-shelves-4-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2016/02/Dispensary-shelves-4-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2016/02/Dispensary-shelves-4-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2016/02/Dispensary-shelves-4-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Retrospective pricing adjustments for Venofer, Ferinject and Aptamil products</h3>
+        <div class="excerpt">
+            <p>Following representations from PSNC, the Department of Health and Social Care (DHSC) has confirmed that the following products have been granted upward retrospective pricing adjustments&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        3rd March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/dexcom-one-transmitters-to-be-added-to-march-2023-drug-tariff/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Reminder: Dexcom One Transmitter added to March 2023 Drug Tariff</h3>
+        <div class="excerpt">
+            <p>Following representations from PSNC and Dexcom International Ltd, the Department of Health of Social Care (DHSC) the Dexcom One Transmitter was added to Part IXA&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        1st March 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/february-2023-price-concessions-final-update/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2016/02/Drug-Tariff-book-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>February 2023 Price Concessions Final Update</h3>
+        <div class="excerpt">
+            <p>The Department of Health and Social Care (DHSC) has today (28/02/2023) granted the following final list of price concessions for February 2023: Drug Pack size&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        28th February 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/february-ssp-updates/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2016/02/Working-in-dispensary-2-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>February SSP updates</h3>
+        <div class="excerpt">
+            <p>Pharmacy contractors should note a number of changes that have been made to different SSPs. SSP Extensions SSP029 for Sandrena® 0.5mg and 1mg gel sachets&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        27th February 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/contractor-notice-expiry-of-ssp048-estradot-50mcg-patches/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2021/02/Mask-in-dispensary-3-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2021/02/Mask-in-dispensary-3-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2021/02/Mask-in-dispensary-3-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2021/02/Mask-in-dispensary-3-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Contractor Notice: Expiry of SSP048 Estradot® 50mcg patches</h3>
+        <div class="excerpt">
+            <p>The Department of Health and Social Care (DHSC) has confirmed that sufficient stock of Estradot® 50mcg patches are now available to meet normal demand. As&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        24th February 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/pharmacy-funding-crisis-psnc-update/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2021/11/Busy-dispensary-with-masks-portrait.webp" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2021/11/Busy-dispensary-with-masks-portrait.webp 682w, https://psnc.org.uk/wp-content/uploads/2021/11/Busy-dispensary-with-masks-portrait-250x375.webp 250w, https://psnc.org.uk/wp-content/uploads/2021/11/Busy-dispensary-with-masks-portrait-120x180.webp 120w" sizes="(max-width: 682px) 100vw, 682px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>Pharmacy Funding Crisis: PSNC Update</h3>
+        <div class="excerpt">
+            <p>PSNC met for a full Committee meeting early in February to consider the urgent funding and capacity crisis, as well as proposals from the Department&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        17th February 2023    </div>
+</div>
+
+</a>			</div>
+		
+			<div class="news-slide news-card-wrap">
+				                   
+<a href="https://psnc.org.uk/our-news/two-new-ssps-issued-for-estradot-50mcg-and-100mcg-patches/" class="news-card">
+<div class="image-wrap">
+    <img src="https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image.jpg" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" loading="lazy" srcset="https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image.jpg 300w, https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image-250x96.jpg 250w, https://psnc.org.uk/wp-content/uploads/2021/06/Dispensing-featured-image-120x46.jpg 120w" sizes="(max-width: 300px) 100vw, 300px" /></div>
+<div class="content-wrap">
+    <div>
+        <h3>SSPs extended for Estradot® 50mcg and 100mcg patches</h3>
+        <div class="excerpt">
+            <p>Update 16/02/23 – The Department of Health and Social Care (DHSC) has provided an update on the Serious Shortage Protocols (SSPs) for Estradot® 50mcg patches&hellip;</p>        </div>
+    </div>
+    <div class="date">
+        <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 9H6V11H4V9ZM4 13H6V15H4V13ZM8 9H10V11H8V9ZM8 13H10V15H8V13ZM12 9H14V11H12V9ZM12 13H14V15H12V13Z" fill="#444444"/><path d="M2 20H16C17.103 20 18 19.103 18 18V6V4C18 2.897 17.103 2 16 2H14V0H12V2H6V0H4V2H2C0.897 2 0 2.897 0 4V6V18C0 19.103 0.897 20 2 20ZM16 6L16.001 18H2V6H16Z" fill="#444444"/></svg>        16th February 2023    </div>
+</div>
+
+</a>			</div>
+		</div> <div class="slider-controls d-md-block d-none"><div class="page-link-prev news-prev slick-arrow"><div class="cta-arrow prev"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.834 17.5223L4.80056 10L11.834 2.47766L9.51736 -1.01263e-07L0.167317 10L9.51736 20L11.834 17.5223Z" fill="white"/></svg></div></div><div class="page-link-next news-next slick-arrow"><div class="cta-arrow next"><svg width="12" height="20" viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.166015 2.47766L7.19944 10L0.166016 17.5223L2.48264 20L11.8327 10L2.48264 -1.01263e-07L0.166015 2.47766Z" fill="white"/></svg></div></div></div></div>	
+	</div>
+	</div>
+
+
+</div><!-- Site content end -->
+
+<footer class="footer">
+	<div class="container-wide">
+		<div class="row">
+
+							<div class="col-lg-4 col-md-6 footer-col">
+					<h3>Contact PSNC</h3>
+					
+					<div class="contact-information"><p>General Enquiries: <a href="mailto:info@psnc.org.uk">info@psnc.org.uk</a></p><p> Press/Media Queries: <a href="mailto:commsteam@psnc.org.uk">commsteam@psnc.org.uk</a></p><p>Telephone: <span>0203 1220 810</span></p></div>
+					<p>PSNC<br />
 14 Hosier Lane<br />
 London<br />
-EC1A 9LQ<br />
-&nbsp;<br />
-<a title="Contact PSNC" href="http://psnc.org.uk/psncs-work/contact-us/">How to find us</a><br />
-&nbsp;<br />
-<span style="color: #ffffff;"><a href="https://twitter.com/PSNCNews" class="twitter-follow-button" data-show-count="false" data-size="large">Follow @PSNCNews</a></span><br />
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></p>
-</div>
-		</div><div id="frm_show_form-2" class="four columns clear widget_frm_show_form"><div class="frm_form_widget"><h3 class="widgettitle">Newsletter Sign Up</h3><div class="frm_forms " id="frm_form_12_container" >
+EC1A 9LQ</p>
+					<p><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/" target="">Further contact details</a></p>					
+					<a href="https://twitter.com/intent/user?screen_name=PSNCNews" target="_blank" class="twitter-btn"><svg width="18" height="14" viewBox="0 0 18 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.3602 3.66412C15.371 3.80995 15.371 3.95495 15.371 4.09995C15.371 8.53745 11.9935 13.6508 5.82102 13.6508C3.91935 13.6508 2.15268 13.1 0.666016 12.1433C0.936016 12.1741 1.19602 12.185 1.47685 12.185C2.98768 12.1886 4.45572 11.6834 5.64435 10.7508C4.94387 10.7381 4.26483 10.507 3.70205 10.0897C3.13927 9.67247 2.72084 9.08987 2.50518 8.42329C2.71268 8.45412 2.92102 8.47495 3.13935 8.47495C3.44018 8.47495 3.74268 8.43329 4.02352 8.36079C3.26332 8.2073 2.57974 7.79524 2.08903 7.19469C1.59832 6.59414 1.33076 5.84216 1.33185 5.06662V5.02495C1.77935 5.27412 2.29852 5.42995 2.84852 5.45079C2.38776 5.14461 2.00995 4.72914 1.7488 4.24145C1.48765 3.75375 1.35128 3.209 1.35185 2.65579C1.35185 2.03245 1.51768 1.46079 1.80852 0.962455C2.65196 1.99997 3.70393 2.84876 4.8963 3.45384C6.08866 4.05892 7.39482 4.4068 8.73018 4.47495C8.67852 4.22495 8.64685 3.96579 8.64685 3.70579C8.64663 3.26492 8.7333 2.82834 8.90191 2.42099C9.07052 2.01364 9.31777 1.64352 9.62951 1.33178C9.94124 1.02004 10.3114 0.772797 10.7187 0.604186C11.1261 0.435576 11.5626 0.348902 12.0035 0.349122C12.9702 0.349122 13.8427 0.754121 14.456 1.40912C15.2075 1.2638 15.9281 0.989473 16.586 0.598288C16.3355 1.37397 15.8108 2.03171 15.1102 2.44829C15.7767 2.37227 16.428 2.197 17.0427 1.92829C16.5836 2.59754 16.0148 3.18441 15.3602 3.66412Z" fill="white"/></svg>Follow @PSNCNews</a>
+				</div>
+
+			
+							<div class="col-lg-4 col-md-6 footer-col">
+					<h3>Newsletter Sign Up</h3>
+					<div class="frm_forms " id="frm_form_12_container" >
 <form enctype="multipart/form-data" method="post" class="frm-show-form  frm_pro_form " id="form_uzb6jm"  >
 <div class="frm_form_fields ">
 <fieldset>
 <legend class="frm_hidden">PSNC Newsletter Mailing List Signup</legend>
 
+<div class="frm_fields_container">
 <input type="hidden" name="frm_action" value="create" />
 <input type="hidden" name="form_id" value="12" />
 <input type="hidden" name="frm_hide_fields_12" id="frm_hide_fields_12" value="" />
 <input type="hidden" name="form_key" value="uzb6jm" />
 <input type="hidden" name="item_meta[0]" value="" />
-<input type="hidden" id="frm_submit_entry_12" name="frm_submit_entry_12" value="8ef29656de" /><input type="hidden" name="_wp_http_referer" value="/dispensing-supply/supply-chain/generic-shortages/" /><input type="text" class="frm_hidden frm_verify" id="frm_verify_12" name="frm_verify" value=""  />
-
-<div id="frm_field_153_container" class="frm_form_field form-field  frm_required_field frm_top_container">
+<input type="hidden" id="frm_submit_entry_12" name="frm_submit_entry_12" value="26ffdff09c" /><input type="hidden" name="_wp_http_referer" value="/funding-and-reimbursement/reimbursement/price-concessions/" /><div id="frm_field_153_container" class="frm_form_field form-field  frm_required_field frm_top_container">
     <label  class="frm_primary_label">First Name
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_qnm432" name="item_meta[153]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_qnm432" name="item_meta[153]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="First Name is invalid" aria-invalid="false"  />
     
     
 </div>
@@ -1272,8 +1696,7 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">Surname
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_jur1w2" name="item_meta[154]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_jur1w2" name="item_meta[154]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Surname is invalid" aria-invalid="false"  />
     
     
 </div>
@@ -1281,20 +1704,23 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">Email
         <span class="frm_required">*</span>
     </label>
-    <input type="email" id="field_rskaik" name="item_meta[151]" value=""  data-reqmsg="This field cannot be blank." data-invmsg="Email is invalid"  />
-
-    <div class="frm_description">Please ensure your email address is correct</div>
+    <input type="email" id="field_rskaik" name="item_meta[151]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Email is invalid" aria-invalid="false"   aria-describedby="frm_desc_field_rskaik"/>
+    <div id="frm_desc_field_rskaik" class="frm_description">Please ensure your email address is correct</div>
     
 </div>
 <div id="frm_field_155_container" class="frm_form_field form-field  frm_required_field frm_top_container">
     <label  class="frm_primary_label">Your organisation
         <span class="frm_required">*</span>
     </label>
-    		<select name="item_meta[155]" id="field_nj9ai2"  data-reqmsg="This field cannot be blank."  >
-			<option value=""  selected="selected"> </option>
-				<option value="Community Pharmacy" >Community Pharmacy</option>
-				<option value="Local Pharmaceutical Committee" >Local Pharmaceutical Committee</option>
-				<option value="Other" >Other</option>
+    		<select name="item_meta[155]" id="field_nj9ai2"  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Your organisation is invalid" aria-invalid="false"  >
+				<option  value="" selected="selected">
+			 		</option>
+				<option  value="Community Pharmacy">
+			Community Pharmacy		</option>
+				<option  value="Local Pharmaceutical Committee">
+			Local Pharmaceutical Committee		</option>
+				<option  value="Other">
+			Other		</option>
 			</select>
 	
     
@@ -1304,8 +1730,7 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">What is the name of your pharmacy?
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_dj4y8h" name="item_meta[157]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_dj4y8h" name="item_meta[157]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="What is the name of your pharmacy? is invalid" aria-invalid="false"  />
     
     
 </div>
@@ -1313,15 +1738,23 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">What is your position in the pharmacy?
         <span class="frm_required">*</span>
     </label>
-    		<select name="item_meta[162]" id="field_5ss0gx"  data-reqmsg="This field cannot be blank."  >
-			<option value=""  selected="selected"> </option>
-				<option value="Pharmacist" >Pharmacist</option>
-				<option value="Pharmacy Owner" >Pharmacy Owner</option>
-				<option value="Pharmacy Manager" >Pharmacy Manager</option>
-				<option value="Area Manager" >Area Manager</option>
-				<option value="Technician" >Technician</option>
-				<option value="Dispensing Assistant" >Dispensing Assistant</option>
-				<option value="Other" >Other</option>
+    		<select name="item_meta[162]" id="field_5ss0gx"  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="What is your position in the pharmacy? is invalid" aria-invalid="false"  >
+				<option  value="" selected="selected">
+			 		</option>
+				<option  value="Pharmacist">
+			Pharmacist		</option>
+				<option  value="Pharmacy Owner">
+			Pharmacy Owner		</option>
+				<option  value="Pharmacy Manager">
+			Pharmacy Manager		</option>
+				<option  value="Area Manager">
+			Area Manager		</option>
+				<option  value="Technician">
+			Technician		</option>
+				<option  value="Dispensing Assistant">
+			Dispensing Assistant		</option>
+				<option  value="Other">
+			Other		</option>
 			</select>
 	
     
@@ -1331,17 +1764,15 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">What is your pharmacy F-code or ODS code?
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_iqdesw" name="item_meta[158]" value=""  data-reqmsg="This field cannot be blank."  />
-
-    <div class="frm_description">The F-Code or ODS code is the the unique code issued to your pharmacy which identifies you to NHS Prescription Services.  You can find this on any pricing authority statement or your prescription submission document (FP34c).</div>
+    <input type="text" id="field_iqdesw" name="item_meta[158]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="What is your pharmacy F-code or ODS code? is invalid" aria-invalid="false"   aria-describedby="frm_desc_field_iqdesw"/>
+    <div id="frm_desc_field_iqdesw" class="frm_description">The F-Code or ODS code is the the unique code issued to your pharmacy which identifies you to NHS Prescription Services.  You can find this on any pricing authority statement or your prescription submission document (FP34c).</div>
     
 </div>
 <div id="frm_field_1715_container" class="frm_form_field form-field  frm_required_field frm_top_container">
     <label for="field_55kyc" class="frm_primary_label">Which LPC do you work for?
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_55kyc" name="item_meta[1715]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_55kyc" name="item_meta[1715]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Which LPC do you work for? is invalid" aria-invalid="false"  />
     
     
 </div>
@@ -1349,8 +1780,7 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">Please tell us the name of your organisation
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_7gipyc" name="item_meta[163]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_7gipyc" name="item_meta[163]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="Please tell us the name of your organisation is invalid" aria-invalid="false"  />
     
     
 </div>
@@ -1358,171 +1788,261 @@ EC1A 9LQ<br />
     <label  class="frm_primary_label">What is your position?
         <span class="frm_required">*</span>
     </label>
-    <input type="text" id="field_uxyr36" name="item_meta[161]" value=""  data-reqmsg="This field cannot be blank."  />
-
+    <input type="text" id="field_uxyr36" name="item_meta[161]" value=""  data-reqmsg="This field cannot be blank." aria-required="true" data-invmsg="What is your position? is invalid" aria-invalid="false"  />
     
     
 </div>
-<input type="hidden" name="item_key" value="" />
-<div class="frm_submit">
+<div id="frm_field_2318_container" class="frm_form_field form-field  frm_none_container">
+    <label for="g-recaptcha-response" id="field_7yst5_label" class="frm_primary_label">
+        <span class="frm_required" aria-hidden="true"></span>
+    </label>
+    <div id="field_7yst5" class="frm-g-recaptcha" data-sitekey="6LeA3SIeAAAAAKq8ObO77SnJPEAPNpE_e1eqdO_k"" data-size="invisible" data-theme="light"></div>
+    
+    
+</div>
+	<input type="hidden" name="item_key" value="" />
+				<div class="frm_verify" aria-hidden="true">
+				<label for="frm_email_12">
+					If you are human, leave this field blank.				</label>
+				<input type="text" class="frm_verify" id="frm_email_12" name="frm_verify" value=""  />
+			</div>
+		<input name="frm_state" type="hidden" value="szQp0z28la5Rr2LTeIfPEQ1IfBayDU5svB9Zp386mPk=" /><div class="frm_submit">
 
 <input type="submit" value="Submit"  class="frm_final_submit" formnovalidate="formnovalidate" />
-<img class="frm_ajax_loading" src="http://psnc.org.uk/wp-content/plugins/formidable/images/ajax_loader.gif" alt="Sending"/>
+<img class="frm_ajax_loading" src="https://psnc.org.uk/wp-content/plugins/formidable/images/ajax_loader.gif" alt="Sending"/>
 
-</div></fieldset>
+</div></div>
+</fieldset>
 </div>
 </form>
 </div>
-</div></div><div id="text-5" class="four columns clear widget_text"><h3 class="widgettitle">Visit your LPC&#8217;s website</h3>			<div class="textwidget"><a href="http://www.lpc-online.org.uk" target="new"><img class="aligncenter" src="http://psnc.org.uk/wp-content/uploads/2013/08/LPC-Widget-Purple.png" width="171" height="234" /></a></div>
-		</div><div id="text-7" class="four columns clear widget_text"><h3 class="widgettitle">Keep in touch</h3>			<div class="textwidget"><p><a href="http://psnc.org.uk/psncs-work/website/feedback-on-our-site/">Website feedback form</a><br />
-<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-with-obtaining-a-generic-medicine/">Report Generic Medicine Supply Issue</a><br />
-<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-a-branded-medicine/">Report Branded Medicine Supply Issue</a><br />
-<a href="http://psnc.org.uk/dispensing-supply/supply-chain/supply-issues-feedback/problems-obtaining-an-appliance/">Report Appliance Supply Issue</a></p>
-<p><a href="/psncs-work/website/rss-feeds"><img src="/wp-content/uploads/2013/06/RSS-icon-small.png" /></a> <a href="/psncs-work/website/rss-feeds"> RSS Feeds</a></p>
-<hr />
-<h4><a href="http://archive.psnc.org.uk/">Archive PSNC Site</a></h4>
-</div>
-		</div>				
-				<hr class="hrwhite">
-				
-				<div class="footer-credits">
-					<p>Copyright &copy; 2017 PSNC &bull; Site designed and built by <a href="http://www.jellyhaus.com" target="_blank">Jellyhaus</a></p>
+
 				</div>
-
 			
+							<div class="col-lg-4 col-md-6 footer-col">
+					<h3>Useful Links</h3>
+
+					<div class="links-list"><a href="https://psnc.org.uk/psnc-and-negotiations/about-psnc/contact-us/">Feedback to PSNC</a><a href="https://psnc.org.uk/website/">About This Website</a><a href="https://psnc.org.uk/website/psnc-privacy-notice/">PSNC Privacy Notice</a><a href="https://psnc.org.uk/website/privacy-cookies/">Privacy & Cookies</a><a href="https://psnc.org.uk/website/terms-conditions/">Website Terms & Conditions</a><a href="http://archive.psnc.org.uk/">Archive of previous PSNC website</a></div>
+					
+					<div class="btn-wrap"><a href="https://psnc.org.uk/website/rss-feeds/" class="btn-outline"><svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="#fff" d="m23.999 24c0-13.234-10.766-24-23.998-24v3.1998c11.468 0 20.799 9.3306 20.799 20.8h3.1998z"/><path fill="#fff" d="m12.8 24h3.1998c0-8.8234-7.1771-16-15.999-16v3.1998c7.0571 0 12.799 5.742 12.799 12.801z"/><path fill="#fff" d="m3.2008 23.998c1.7672 0 3.1998-1.4326 3.1998-3.1998s-1.4326-3.1998-3.1998-3.1998c-1.7672 0-3.1998 1.4326-3.1998 3.1998s1.4326 3.1998 3.1998 3.1998z"/></svg>RSS Feeds</a></div>
+				</div>
+			
+			<!-- Copyright -->
+			<div class="col-12">
+				<div class="copyright">
+					<p><p style="text-align: center;">Copyright © 2023 PSNC • Site designed and built by <a href="https://makeagency.co.uk/" target="_blank" rel="noopener">Make Agency</a></p>
+</p>
+				</div>
 			</div>
-			<!-- /wrapper -->
-			
-		</footer>
-		<!-- /footer -->
-		
-		<div id="pum-200470" class="pum pum-overlay pum-theme-199867 pum-theme-default-theme popmake-overlay auto_open click_open" data-popmake="{&quot;id&quot;:200470,&quot;slug&quot;:&quot;psnc-newsletters&quot;,&quot;theme_id&quot;:199867,&quot;cookies&quot;:[{&quot;event&quot;:&quot;on_popup_close&quot;,&quot;settings&quot;:{&quot;name&quot;:&quot;pum-200470&quot;,&quot;key&quot;:&quot;&quot;,&quot;time&quot;:&quot;1 month&quot;,&quot;path&quot;:1}}],&quot;triggers&quot;:[{&quot;type&quot;:&quot;auto_open&quot;,&quot;settings&quot;:{&quot;delay&quot;:&quot;1000&quot;,&quot;cookie&quot;:{&quot;name&quot;:[&quot;pum-200470&quot;]}}},{&quot;type&quot;:&quot;click_open&quot;,&quot;settings&quot;:{&quot;extra_selectors&quot;:&quot;&quot;,&quot;cookie&quot;:{&quot;name&quot;:null}}}],&quot;mobile_disabled&quot;:true,&quot;tablet_disabled&quot;:null,&quot;meta&quot;:{&quot;display&quot;:{&quot;size&quot;:&quot;medium&quot;,&quot;responsive_min_width&quot;:&quot;&quot;,&quot;responsive_max_width&quot;:&quot;&quot;,&quot;custom_width&quot;:&quot;640&quot;,&quot;custom_height&quot;:&quot;380&quot;,&quot;animation_type&quot;:&quot;fade&quot;,&quot;animation_speed&quot;:&quot;350&quot;,&quot;animation_origin&quot;:&quot;center top&quot;,&quot;position_bottom&quot;:&quot;0&quot;,&quot;location&quot;:&quot;center top&quot;,&quot;position_right&quot;:&quot;0&quot;,&quot;position_top&quot;:&quot;100&quot;,&quot;position_left&quot;:&quot;0&quot;,&quot;overlay_zindex&quot;:&quot;1999999998&quot;,&quot;zindex&quot;:&quot;1999999999&quot;,&quot;responsive_min_width_unit&quot;:&quot;px&quot;,&quot;responsive_max_width_unit&quot;:&quot;px&quot;,&quot;custom_width_unit&quot;:&quot;px&quot;,&quot;custom_height_unit&quot;:&quot;px&quot;},&quot;close&quot;:{&quot;text&quot;:&quot;&quot;,&quot;button_delay&quot;:&quot;0&quot;},&quot;click_open&quot;:{&quot;extra_selectors&quot;:&quot;&quot;}}}" role="dialog" aria-hidden="true" aria-labelledby="pum_popup_title_200470">
 
-	<div id="popmake-200470" class="pum-container popmake theme-199867 pum-responsive pum-responsive-medium responsive size-medium">
-
-				
-
-				            <div id="pum_popup_title_200470" class="pum-title popmake-title">
-				Do you receive PSNC's email newsletters?			</div>
-		
-
-		
-
-				<div class="pum-content popmake-content">
-			<table class="popup">
-<tbody>
-<tr>
-<td><img class="wp-image-200480 size-full alignnone" src="http://psnc.org.uk/wp-content/uploads/2017/07/Newsletter-promo.png" alt="" width="528" height="260" /></td>
-<td style="vertical-align: top;">
-<p>&nbsp;</p>
-<p>PSNC sends regular emails to help ensure community pharmacy teams don&#8217;t miss any key information, guidance and resources.</p>
-<p>&nbsp;</p>
-<p><strong><a href="http://psnc.org.uk/latest-news/email-sign-up/" target="_blank" rel="noopener noreferrer">Sign up now</a></strong></p></td>
-</tr>
-</tbody>
-</table>
-<p>&nbsp;</p>
 		</div>
+	</div>	
+</footer>
 
-
-				
-
-				            <button type="button" class="pum-close popmake-close" aria-label="Close">
-			X            </button>
 		
+<!--googleoff: all--><div id="cookie-law-info-bar" data-nosnippet="true"><span><div class="cli-bar-container cli-style-v2"><div class="cli-bar-message">We use cookies on our website to give you the most relevant experience by remembering your preferences and repeat visits. By clicking “Accept All”, you consent to the use of ALL the cookies. However, you may visit "Cookie Settings" to provide a controlled consent.</div><div class="cli-bar-btn_container"><a role='button' class="medium cli-plugin-button cli-plugin-main-button cli_settings_button" style="margin:0px 5px 0px 0px">Cookie Settings</a><a id="wt-cli-accept-all-btn" role='button' data-cli_action="accept_all" class="wt-cli-element medium cli-plugin-button wt-cli-accept-all-btn cookie_action_close_header cli_action_button">Accept All</a></div></div></span></div><div id="cookie-law-info-again" data-nosnippet="true"><span id="cookie_hdr_showagain">Manage consent</span></div><div class="cli-modal" data-nosnippet="true" id="cliSettingsPopup" tabindex="-1" role="dialog" aria-labelledby="cliSettingsPopup" aria-hidden="true">
+  <div class="cli-modal-dialog" role="document">
+	<div class="cli-modal-content cli-bar-popup">
+		  <button type="button" class="cli-modal-close" id="cliModalClose">
+			<svg class="" viewBox="0 0 24 24"><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z"></path><path d="M0 0h24v24h-24z" fill="none"></path></svg>
+			<span class="wt-cli-sr-only">Close</span>
+		  </button>
+		  <div class="cli-modal-body">
+			<div class="cli-container-fluid cli-tab-container">
+	<div class="cli-row">
+		<div class="cli-col-12 cli-align-items-stretch cli-px-0">
+			<div class="cli-privacy-overview">
+				<h4>Privacy Overview</h4>				<div class="cli-privacy-content">
+					<div class="cli-privacy-content-text">This website uses cookies to improve your experience while you navigate through the website. Out of these, the cookies that are categorized as necessary are stored on your browser as they are essential for the working of basic functionalities of the website. We also use third-party cookies that help us analyze and understand how you use this website. These cookies will be stored in your browser only with your consent. You also have the option to opt-out of these cookies. But opting out of some of these cookies may affect your browsing experience.</div>
+				</div>
+				<a class="cli-privacy-readmore" aria-label="Show more" role="button" data-readmore-text="Show more" data-readless-text="Show less"></a>			</div>
+		</div>
+		<div class="cli-col-12 cli-align-items-stretch cli-px-0 cli-tab-section-container">
+												<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="necessary" data-toggle="cli-toggle-tab">
+								Necessary							</a>
+															<div class="wt-cli-necessary-checkbox">
+									<input type="checkbox" class="cli-user-preference-checkbox"  id="wt-cli-checkbox-necessary" data-id="checkbox-necessary" checked="checked"  />
+									<label class="form-check-label" for="wt-cli-checkbox-necessary">Necessary</label>
+								</div>
+								<span class="cli-necessary-caption">Always Enabled</span>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="necessary">
+								<div class="wt-cli-cookie-description">
+									Necessary cookies are absolutely essential for the website to function properly. These cookies ensure basic functionalities and security features of the website, anonymously.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-analytics</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Analytics".</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-functional</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">The cookie is set by GDPR cookie consent to record the user consent for the cookies in the category "Functional".</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-necessary</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookies is used to store the user consent for the cookies in the category "Necessary".</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-others</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Other.</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-performance</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Performance".</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">viewed_cookie_policy</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">The cookie is set by the GDPR Cookie Consent plugin and is used to store whether or not user has consented to the use of cookies. It does not store any personal data.</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="functional" data-toggle="cli-toggle-tab">
+								Functional							</a>
+															<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-functional" class="cli-user-preference-checkbox"  data-id="checkbox-functional" />
+									<label for="wt-cli-checkbox-functional" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Functional</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="functional">
+								<div class="wt-cli-cookie-description">
+									Functional cookies help to perform certain functionalities like sharing the content of the website on social media platforms, collect feedbacks, and other third-party features.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-functional</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">The cookie is set by GDPR cookie consent to record the user consent for the cookies in the category "Functional".</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="performance" data-toggle="cli-toggle-tab">
+								Performance							</a>
+															<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-performance" class="cli-user-preference-checkbox"  data-id="checkbox-performance" />
+									<label for="wt-cli-checkbox-performance" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Performance</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="performance">
+								<div class="wt-cli-cookie-description">
+									Performance cookies are used to understand and analyze the key performance indexes of the website which helps in delivering a better user experience for the visitors.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-performance</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Performance".</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="analytics" data-toggle="cli-toggle-tab">
+								Analytics							</a>
+															<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-analytics" class="cli-user-preference-checkbox"  data-id="checkbox-analytics" />
+									<label for="wt-cli-checkbox-analytics" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Analytics</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="analytics">
+								<div class="wt-cli-cookie-description">
+									Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics the number of visitors, bounce rate, traffic source, etc.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-analytics</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Analytics".</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="advertisement" data-toggle="cli-toggle-tab">
+								Advertisement							</a>
+															<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-advertisement" class="cli-user-preference-checkbox"  data-id="checkbox-advertisement" />
+									<label for="wt-cli-checkbox-advertisement" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Advertisement</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="advertisement">
+								<div class="wt-cli-cookie-description">
+									Advertisement cookies are used to provide visitors with relevant ads and marketing campaigns. These cookies track visitors across websites and collect information to provide customized ads.
+								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="others" data-toggle="cli-toggle-tab">
+								Others							</a>
+															<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-others" class="cli-user-preference-checkbox"  data-id="checkbox-others" />
+									<label for="wt-cli-checkbox-others" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Others</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="others">
+								<div class="wt-cli-cookie-description">
+									Other uncategorized cookies are those that are being analyzed and have not been classified into a category as yet.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">cookielawinfo-checkbox-others</td><td class="cookielawinfo-column-3">11 months</td><td class="cookielawinfo-column-4">This cookie is set by GDPR Cookie Consent plugin. The cookie is used to store the user consent for the cookies in the category "Other.</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+										</div>
 	</div>
-
 </div>
-		<script language="javascript" type="text/javascript">
-			var print_data = {"id5989":{"pom_site_css":"http:\/\/psnc.org.uk\/wp-content\/themes\/psnc\/style.css","pom_custom_css":"","pom_html_top":"<img src=\"http:\/\/psnc.org.uk\/wp-content\/themes\/psnc\/img\/print-header.png\" alt=\"Logo\">\r\n<script>\r\nvar value = new Date();\r\nvar month = value.getMonth() + 1;\r\nvar div = document.getElementsByClassName('page-content')[0];\r\ndiv.innerHTML = '<h2>Printed On : ' + value.getDate() + \"\/\" +  month + \"\/\" + value.getFullYear() + '<\/h2>' + div.innerHTML;\r\n<\/script>","pom_html_bottom":"","pom_do_not_print":".news-box","pom_pause_time":"1500","pom_close_after_print":"1"}};
-		</script>
-		<script type="text/javascript">
-/* <![CDATA[ */
-jQuery(document).ready(function () {
-jQuery(".toggle_container").hide();
-jQuery(".trigger").click(function(){jQuery(this).toggleClass("active").next().toggle();
-return false;
-});
-});
-/* ]]> */
-</script>
-<script data-cfasync="false" type="text/javascript">
-var addthis_config = {"data_track_clickback":true,"ui_atversion":300,"ignore_server_config":true};
-var addthis_share = {};
-</script>
-                <!-- AddThis Settings Begin -->
-                <script data-cfasync="false" type="text/javascript">
-                    var addthis_product = "wpp-5.3.6";
-                    var wp_product_version = "wpp-5.3.6";
-                    var wp_blog_version = "4.9.1";
-                    var addthis_plugin_info = {"info_status":"enabled","cms_name":"WordPress","plugin_name":"Share Buttons by AddThis","plugin_version":"5.3.6","anonymous_profile_id":"wp-25948061bcf65a107d5bba98136ece52","plugin_mode":"WordPress","select_prefs":{"addthis_per_post_enabled":true,"addthis_above_enabled":false,"addthis_below_enabled":true,"addthis_sidebar_enabled":false,"addthis_mobile_toolbar_enabled":false,"addthis_above_showon_home":true,"addthis_above_showon_posts":true,"addthis_above_showon_pages":true,"addthis_above_showon_archives":true,"addthis_above_showon_categories":true,"addthis_above_showon_excerpts":true,"addthis_below_showon_home":false,"addthis_below_showon_posts":true,"addthis_below_showon_pages":true,"addthis_below_showon_archives":false,"addthis_below_showon_categories":false,"addthis_below_showon_excerpts":false,"addthis_sidebar_showon_home":true,"addthis_sidebar_showon_posts":true,"addthis_sidebar_showon_pages":true,"addthis_sidebar_showon_archives":true,"addthis_sidebar_showon_categories":true,"addthis_mobile_toolbar_showon_home":true,"addthis_mobile_toolbar_showon_posts":true,"addthis_mobile_toolbar_showon_pages":true,"addthis_mobile_toolbar_showon_archives":true,"addthis_mobile_toolbar_showon_categories":true,"sharing_enabled_on_post_via_metabox":true},"page_info":{"template":false,"post_type":""}};
-                    if (typeof(addthis_config) == "undefined") {
-                        var addthis_config = {"data_track_clickback":true,"ui_atversion":300,"ignore_server_config":true};
-                    }
-                    if (typeof(addthis_share) == "undefined") {
-                        var addthis_share = {};
-                    }
-                    if (typeof(addthis_layers) == "undefined") {
-                        var addthis_layers = {};
-                    }
-                </script>
-                <script
-                    data-cfasync="false"
-                    type="text/javascript"
-                    src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-570e3e0a2d839861 "
-                    async="async"
-                >
-                </script>
-                <script data-cfasync="false" type="text/javascript">
-                    (function() {
-                        var at_interval = setInterval(function () {
-                            if(window.addthis) {
-                                clearInterval(at_interval);
-                                addthis.layers(addthis_layers);
-                            }
-                        },1000)
-                    }());
-                </script>
-                <link rel='stylesheet' id='addthis_output-css'  href='//psnc.org.uk/wp-content/plugins/addthis/css/output.css?ver=4.9.1' media='all' />
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/core.min.js?ver=1.11.4'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.11.4'></script>
-<script type='text/javascript'>
-jQuery(document).ready(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"dd\/mm\/yy","firstDay":1,"isRTL":false});});
-</script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/js/footer-scripts.js?ver=1.0.0'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/suggest.min.js?ver=1.1-20110113'></script>
-<script type='text/javascript'>
-/* <![CDATA[ */
-var FB_WP=FB_WP||{};FB_WP.queue={_methods:[],flushed:false,add:function(fn){FB_WP.queue.flushed?fn():FB_WP.queue._methods.push(fn)},flush:function(){for(var fn;fn=FB_WP.queue._methods.shift();){fn()}FB_WP.queue.flushed=true}};window.fbAsyncInit=function(){FB.init({"xfbml":true});if(FB_WP && FB_WP.queue && FB_WP.queue.flush){FB_WP.queue.flush()}}
-/* ]]> */
-</script>
-<script type="text/javascript">(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(d.getElementById(id)){return}js=d.createElement(s);js.id=id;js.src="http:\/\/connect.facebook.net\/en_GB\/all.js";fjs.parentNode.insertBefore(js,fjs)}(document,"script","facebook-jssdk"));</script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/popup-maker/assets/js/mobile-detect.min.js?ver=1.3.3'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/position.min.js?ver=1.11.4'></script>
-<script type='text/javascript'>
-/* <![CDATA[ */
-var pum_vars = {"ajaxurl":"http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php","restapi":"http:\/\/psnc.org.uk\/wp-json\/pum\/v1","rest_nonce":null,"default_theme":"199867","debug_mode":"","disable_open_tracking":""};
-var pum_debug_vars = {"debug_mode_enabled":"Popup Maker Debug Mode Enabled","debug_started_at":"Debug started at:","debug_more_info":"For more information on how to use this information visit http:\/\/docs.wppopupmaker.com\/?utm_medium=js-debug-info&utm_campaign=ContextualHelp&utm_source=browser-console&utm_content=more-info","global_info":"Global Information","localized_vars":"Localized variables","popups_initializing":"Popups Initializing","popups_initialized":"Popups Initialized","single_popup_label":"Popup: #","theme_id":"Theme ID: ","label_method_call":"Method Call:","label_method_args":"Method Arguments:","label_popup_settings":"Settings","label_triggers":"Triggers","label_cookies":"Cookies","label_delay":"Delay:","label_conditions":"Conditions","label_cookie":"Cookie:","label_settings":"Settings:","label_selector":"Selector:","label_mobile_disabled":"Mobile Disabled:","label_tablet_disabled":"Tablet Disabled:","label_display_settings":"Display Settings:","label_close_settings":"Close Settings:","label_event_before_open":"Event: Before Open","label_event_after_open":"Event: After Open","label_event_open_prevented":"Event: Open Prevented","label_event_setup_close":"Event: Setup Close","label_event_close_prevented":"Event: Close Prevented","label_event_before_close":"Event: Before Close","label_event_after_close":"Event: After Close","label_event_before_reposition":"Event: Before Reposition","label_event_after_reposition":"Event: After Reposition","label_event_checking_condition":"Event: Checking Condition","triggers":{"click_open":{"name":"Click Open","modal_title":"Click Trigger Settings","settings_column":"<strong>Extra Selectors<\/strong>: {{data.extra_selectors}}"},"auto_open":{"name":"Auto Open","modal_title":"Auto Open Settings","settings_column":"<strong>Delay<\/strong>: {{data.delay}}"}},"cookies":{"on_popup_open":{"name":"On Popup Open","modal_title":"On Popup Open Settings"},"on_popup_close":{"name":"On Popup Close","modal_title":"On Popup Close Settings"},"manual":{"name":"Manual JavaScript","modal_title":"Click Trigger Settings"}}};
-var ajaxurl = "http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php";
-var popmake_default_theme = "199867";
-/* ]]> */
-</script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/popup-maker/assets/js/site.min.js?defer&#038;ver=1.6.6' defer='defer'></script>
-<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/wp-embed.min.js?ver=4.9.1'></script>
-<script type='text/javascript'>
-/* <![CDATA[ */
-var frm_js = {"ajax_url":"http:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php","images_url":"http:\/\/psnc.org.uk\/wp-content\/plugins\/formidable\/images","loading":"Loading\u2026","remove":"Remove","offset":"4","nonce":"ef6521c829","id":"ID","no_results":"No results match","file_spam":"That file looks like Spam.","empty_fields":"Please complete the preceding required fields before uploading a file."};
-/* ]]> */
-</script>
-<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/formidable/js/formidable.min.js?ver=2.05.06'></script>
+		  </div>
+		  <div class="cli-modal-footer">
+			<div class="wt-cli-element cli-container-fluid cli-tab-container">
+				<div class="cli-row">
+					<div class="cli-col-12 cli-align-items-stretch cli-px-0">
+						<div class="cli-tab-footer wt-cli-privacy-overview-actions">
+						
+															<a id="wt-cli-privacy-save-btn" role="button" tabindex="0" data-cli-action="accept" class="wt-cli-privacy-btn cli_setting_save_button wt-cli-privacy-accept-btn cli-btn">SAVE &amp; ACCEPT</a>
+													</div>
+												<div class="wt-cli-ckyes-footer-section">
+							<div class="wt-cli-ckyes-brand-logo">Powered by <a href="https://www.cookieyes.com/"><img src="https://psnc.org.uk/wp-content/plugins/cookie-law-info/legacy/public/images/logo-cookieyes.svg" alt="CookieYes Logo"></a></div>
+						</div>
+						
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+  </div>
+</div>
+<div class="cli-modal-backdrop cli-fade cli-settings-overlay"></div>
+<div class="cli-modal-backdrop cli-fade cli-popupbar-overlay"></div>
+<!--googleon: all--><script type="text/javascript">
+    var timer;
+    jQuery('.search-input').on('keyup paste', function() {
+    
+        clearTimeout(timer);
+        timer = setTimeout(function() {
 
-<script type="text/javascript">
+            jQuery.ajax({
+                url: 'https://psnc.org.uk/wp-admin/admin-ajax.php',
+                type: 'post',
+                data: { action: 'data_fetch', keyword: jQuery('#keyword').val() },
+                success: function(data) {
+                    var popular = jQuery('.popular-posts').html();
+                    if(jQuery('.search-input').val() && data){
+                        jQuery('#datafetch').html( data );
+                    } else {
+                        jQuery('#datafetch').html( popular );
+                    }
+                }
+            });
+
+        }, 600);
+
+    });
+</script>
+
+<link rel='stylesheet' id='cookie-law-info-table-css'  href='//psnc.org.uk/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-table.css?ver=3.0.7' media='all' />
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.13.1' id='jquery-ui-datepicker-js'></script>
+<script type='text/javascript' id='jquery-ui-datepicker-js-after'>
+jQuery(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"dS MM yy","firstDay":1,"isRTL":false});});
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/themes/psnc/assets/js/script.js' id='theme-js-js'></script>
+<script type='text/javascript' src='//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js?ver=6.0.3' id='slick-js-js'></script>
+<script type='text/javascript' id='printomatic-js-js-before'>
+const print_data = {"pom_html_top":"<script>\r\nvar value = new Date();\r\nvar month = value.getMonth() + 1;\r\nvar div = document.getElementsByClassName('page-content')[0];\r\ndiv.innerHTML = '<h2>Printed On : ' + value.getDate() + \"\/\" +  month + \"\/\" + value.getFullYear() + '<\/h2>' + div.innerHTML;\r\n<\/script>","pom_html_bottom":"","pom_do_not_print":".news-box","pom_pause_time":"1500"}
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/print-o-matic/js/printomat.js?ver=2.0.11' id='printomatic-js-js'></script>
+<script type='text/javascript' id='printomatic-js-js-after'>
+const print_data_id5320 = []
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/print-o-matic/js/print_elements.js?ver=1.1' id='pe-js-js'></script>
+<script type='text/javascript' src='//psnc.org.uk/wp-includes/js/jquery/suggest.min.js?ver=1.1-20110113' id='suggest-js'></script>
+<script type='text/javascript' id='formidable-js-extra'>
+/* <![CDATA[ */
+var frm_js = {"ajax_url":"https:\/\/psnc.org.uk\/wp-admin\/admin-ajax.php","images_url":"https:\/\/psnc.org.uk\/wp-content\/plugins\/formidable\/images","loading":"Loading\u2026","remove":"Remove","offset":"4","nonce":"5f1608226c","id":"ID","no_results":"No results match","file_spam":"That file looks like Spam.","calc_error":"There is an error in the calculation in the field with key","empty_fields":"Please complete the preceding required fields before uploading a file.","focus_first_error":"1","include_alert_role":"1"};
+var frm_password_checks = {"eight-char":{"label":"Eight characters minimum","regex":"\/^.{8,}$\/","message":"Passwords require at least 8 characters"},"lowercase":{"label":"One lowercase letter","regex":"#[a-z]+#","message":"Passwords must include at least one lowercase letter"},"uppercase":{"label":"One uppercase letter","regex":"#[A-Z]+#","message":"Passwords must include at least one uppercase letter"},"number":{"label":"One number","regex":"#[0-9]+#","message":"Passwords must include at least one number"},"special-char":{"label":"One special character","regex":"\/(?=.*[^a-zA-Z0-9])\/","message":"password is invalid"}};
+/* ]]> */
+</script>
+<script type='text/javascript' src='//psnc.org.uk/wp-content/plugins/formidable-pro/js/frm.min.js?ver=5.5.4.1' id='formidable-js'></script>
+<script type='text/javascript' defer="defer" async="async" src='//www.google.com/recaptcha/api.js?onload=frmRecaptcha&#038;render=explicit&#038;hl=en&#038;ver=3' id='captcha-api-js'></script>
+<script>
 /*<![CDATA[*/
 var frmrules={"155":{"fieldId":"155","fieldKey":"nj9ai2","fieldType":"select","inputType":"select","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":["157","162","158","1715","163","161","161"],"showHide":"show","anyAll":"any","conditions":[]},"157":{"fieldId":"157","fieldKey":"dj4y8h","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"all","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"162":{"fieldId":"162","fieldKey":"5ss0gx","fieldType":"select","inputType":"select","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"158":{"fieldId":"158","fieldKey":"iqdesw","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Community Pharmacy"}],"status":"complete"},"1715":{"fieldId":"1715","fieldKey":"55kyc","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Local Pharmaceutical Committee"}],"status":"complete"},"163":{"fieldId":"163","fieldKey":"7gipyc","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Other"}],"status":"complete"},"161":{"fieldId":"161","fieldKey":"uxyr36","fieldType":"text","inputType":"text","isMultiSelect":false,"formId":"12","inSection":"0","inEmbedForm":"0","isRepeating":false,"dependents":[],"showHide":"show","anyAll":"any","conditions":[{"fieldId":"155","operator":"==","value":"Other"},{"fieldId":"155","operator":"==","value":"Local Pharmaceutical Committee"}],"status":"complete"}};
 if(typeof __FRMRULES == 'undefined'){__FRMRULES=frmrules;}
-else{__FRMRULES=jQuery.extend({},__FRMRULES,frmrules);}var frmHide=["157","162","158","1715","163","161"];if(typeof __frmHideOrShowFields == "undefined"){__frmHideOrShowFields=frmHide;}else{__frmHideOrShowFields=jQuery.extend(__frmHideOrShowFields,frmHide);}/*]]>*/
+else{__FRMRULES=jQuery.extend({},__FRMRULES,frmrules);}var frmHide=["157","162","158","1715","163","161"];if(typeof __frmHideOrShowFields == "undefined"){__frmHideOrShowFields=frmHide;}else{__frmHideOrShowFields=__frmHideOrShowFields.concat(frmHide);}/*]]>*/
 </script>
-<div id="fb-root"></div><!--wp_footer-->		
+		
 	
-	</body>
+</body>
 </html>

--- a/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
@@ -68,8 +68,8 @@ class TestFetchAndImportNCSOConcesions(TestCase):
         for date, drug, pack_size, price_pence, vmpp in [
             ["2017-10-01", "Amiloride 5mg tablets", "28", 925, vmpp1],
             ["2017-10-01", "Anastrozole 1mg tablets", "28", 1445, vmpp2],
-            ["2017-11-01", "Amiloride 5mg tablets", "28", 925, vmpp1],
-            ["2017-11-01", "Amlodipine 5mg tablets", "28", 375, None],
+            ["2023-03-01", "Amiloride 5mg tablets", "28", 925, vmpp1],
+            ["2023-03-01", "Amlodipine 5mg tablets", "28", 375, None],
         ]:
             concession = NCSOConcession.objects.get(date=date, drug=drug)
             self.assertEqual(concession.pack_size, pack_size)


### PR DESCRIPTION
The page that we scrape current NCSO concessions from (https://psnc.org.uk/funding-and-reimbursement/reimbursement/price-concessions/) has been updated, and as of 2023-03-15 the fetch_and_import_ncso_concessions command can no longer parse the date from the expected `<h1>` tag.  This commit updates the date parsing; imports of the actual concession tables are unaffected.

Fixes #3937 