### PR TITLE
Fix uses of deprecated APIs

### DIFF
--- a/openprescribing/common/generate_measure_sql.py
+++ b/openprescribing/common/generate_measure_sql.py
@@ -1,6 +1,6 @@
 import csv
 
-reader = csv.DictReader(open("statins.csv", "rU"))
+reader = csv.DictReader(open("statins.csv"))
 high_cost_codes = []
 all_codes = []
 for row in reader:

--- a/openprescribing/frontend/management/commands/geocode_practices.py
+++ b/openprescribing/frontend/management/commands/geocode_practices.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
             if options["verbosity"] > 1:
                 self.IS_VERBOSE = True
 
-            gridall = csv.reader(open(options["filename"], "rU"))
+            gridall = csv.reader(open(options["filename"]))
             postcodes = {}
             for row in gridall:
                 postcode = row[1].replace(" ", "").strip()

--- a/openprescribing/frontend/management/commands/import_bnf_codes.py
+++ b/openprescribing/frontend/management/commands/import_bnf_codes.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         if "filename" not in options:
             raise CommandError("Please supply a filename")
 
-        reader = csv.DictReader(open(options["filename"], "rU"))
+        reader = csv.DictReader(open(options["filename"]))
 
         sections = {}
         with transaction.atomic():

--- a/openprescribing/frontend/management/commands/import_ccgs.py
+++ b/openprescribing/frontend/management/commands/import_ccgs.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
         parser.add_argument("--ccg")
 
     def handle(self, **options):
-        for row in csv.reader(open(options["ccg"], "rU")):
+        for row in csv.reader(open(options["ccg"])):
             row = [r.strip() for r in row]
             if row[2] == "Y99" or row[3] == "Q99":
                 # This indicates a National Commissioning Hub which does not

--- a/openprescribing/frontend/management/commands/import_hscic_chemicals.py
+++ b/openprescribing/frontend/management/commands/import_hscic_chemicals.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         if self.IS_VERBOSE:
             print("Importing Chemicals from %s" % filename)
         lines = count = 0
-        chemicals = csv.DictReader(open(filename, "rU"))
+        chemicals = csv.DictReader(open(filename))
         for row in chemicals:
             row = self._strip_dict(row)
             bnf_code = row["CHEM SUB"]

--- a/openprescribing/frontend/management/commands/import_practices.py
+++ b/openprescribing/frontend/management/commands/import_practices.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         return row
 
     def import_practices_from_epraccur(self, filename):
-        entries = csv.reader(open(filename, "rU"))
+        entries = csv.reader(open(filename))
         count = 0
         for row in entries:
             row = [r.strip() for r in row]
@@ -98,7 +98,7 @@ class Command(BaseCommand):
         if self.IS_VERBOSE:
             print("Importing practices from %s" % filename)
         count = 0
-        practices = csv.reader(open(filename, "rU"))
+        practices = csv.reader(open(filename))
         for row in practices:
             row = [i.strip() for i in row]
             p, created = Practice.objects.get_or_create(code=row[1])

--- a/openprescribing/frontend/management/commands/import_qof_prevalence.py
+++ b/openprescribing/frontend/management/commands/import_qof_prevalence.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         ccg_file = options["by_ccg"]
         practice_file = options["by_practice"]
 
-        ccg_prevalence = csv.DictReader(open(ccg_file, "rU"))
+        ccg_prevalence = csv.DictReader(open(ccg_file))
         for row in ccg_prevalence:
             ccg_code = row["ccgcode"]
             ccg = PCT.objects.get(code=ccg_code)
@@ -41,7 +41,7 @@ class Command(BaseCommand):
                 disease_register_size=row["disease_register_size"],
             )
 
-        practice_prevalence = csv.DictReader(open(practice_file, "rU"))
+        practice_prevalence = csv.DictReader(open(practice_file))
         for row in practice_prevalence:
             practicecode = row["practicecode"]
             practice = Practice.objects.get(code=practicecode)

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-import html.parser
 import logging
 import os
 import re
 import subprocess
 import urllib.parse
 from datetime import date
+from html import unescape
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -876,9 +876,8 @@ def unescape_href(text):
     do about it](https://github.com/peterbe/premailer/issues/72).
     Unencode them again."""
     hrefs = re.findall(r'href=["\']([^"\']+)["\']', text)
-    html_parser = html.parser.HTMLParser()
     for href in hrefs:
-        text = text.replace(href, html_parser.unescape(href))
+        text = text.replace(href, unescape(href))
     return text
 
 


### PR DESCRIPTION
These are deprecated in Python 3.8 and removed entirely in Python 3.11.