### PR TITLE
Remove Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
   schedule:
     interval: daily
   rebase-strategy: "disabled"
-  open-pull-requests-limit: 15
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
Now we no longer have a huge backlog we don't need to worry about being overwhelmed here. And on the occasions when we do let a backlog of more than 15 updates build up it's annoying to think you've cleared them all and then discover the next day that there were more pending.