### PR TITLE
Tweak the format of NCSO importer Slack report

### DIFF
--- a/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
@@ -234,7 +234,7 @@ class TestFetchAndImportNCSOConcesions(TestCase):
 
             self.assertEqual(NCSOConcession, Client().upload_model.call_args[0][0])
             self.assertIn(
-                "Fetched 3 concessions. Imported 2 new concessions",
+                "Fetched 3 concessions. Imported 2 new concessions.",
                 notify_slack.call_args[0][0],
             )
 
@@ -251,42 +251,9 @@ class TestFetchAndImportNCSOConcesions(TestCase):
             )
 
     def test_format_message_when_nothing_to_do(self):
-        msg = fetch_ncso.format_message([], 0)
+        msg = fetch_ncso.format_message([])
         self.assertEqual(
-            msg, "Fetched 0 concessions. Found no new concessions to import"
-        )
-
-    def test_most_recent_examples(self):
-        examples = [
-            {
-                "drug": "Amiloride 5mg tablets",
-                "pack_size": "28",
-                "supplied_vmpp_id": 1191111000001100,
-                "publish_date": datetime.date(2023, 1, 20),
-            },
-            {
-                "drug": "Amiloride 5mg tablets",
-                "pack_size": "28",
-                "supplied_vmpp_id": 1191111000001100,
-                "publish_date": datetime.date(2021, 8, 10),
-            },
-            {
-                "drug": "Amiloride 5mg tablets",
-                "pack_size": "28",
-                "supplied_vmpp_id": 1191111000001100,
-                "publish_date": datetime.date(2023, 3, 1),
-            },
-        ]
-        self.assertEqual(
-            list(fetch_ncso.most_recent_examples(examples)),
-            [
-                {
-                    "drug": "Amiloride 5mg tablets",
-                    "pack_size": "28",
-                    "supplied_vmpp_id": 1191111000001100,
-                    "publish_date": datetime.date(2023, 3, 1),
-                }
-            ],
+            msg, "Fetched 0 concessions. Found no new concessions to import."
         )
 
 


### PR DESCRIPTION
Having seen this in the wild I now realise that (a) it's not fixed-width formatted and (b) the kind of report that's helpful when doing on big re-import of everything using a new system is not the same as what's helpful when doing frequent incremental imports. In particular, constantly being told about mismatched VMPPs from historical publications is just noise.