### PR TITLE
Make day of week optional in date regex

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -53,8 +53,10 @@ MONTH_DATE_RE = re.compile(
 PUBLISH_DATE_RE = re.compile(
     r"""
     concessions \s+ announcement \s+
-    ( monday | tuesday | wednesday | thursday | friday | saturday | sunday )
-    \s+
+    (
+      ( monday | tuesday | wednesday | thursday | friday | saturday | sunday )
+      \s+
+    ) ?
     (?P<day> \d+) \s* ( st | nd | rd | th )
     \s+
     (?P<month>


### PR DESCRIPTION
The latest newsletter has:

    Price Concessions Announcement 1st June 2023

Where previously we would have expected:

    Price Concessions Announcement Friday 1st June 2023