### PR TITLE
Yet more fixes for NCSO importer

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -372,9 +372,10 @@ def format_message(inserted):
     new_mismatched = [
         i
         for i in inserted
-        if i["vmpp_id"] != i["supplied_vmpp_id"]
-        and i["created"]
+        if i["vmpp_id"] is not None
         and i["supplied_vmpp_id"] is not None
+        and i["vmpp_id"] != i["supplied_vmpp_id"]
+        and i["created"]
     ]
 
     msg = f"Fetched {len(inserted)} concessions. "

--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -270,6 +270,10 @@ def regularise_name(name):
     name = name.replace("gastro- resistant", "gastro-resistant")
     name = name.replace("/ml", "/1ml")
 
+    # Strip leading asterisks which are sometimes used to indicate the presence of
+    # additional notes
+    name = re.sub(r"^\s*\*\s*", "", name)
+
     # Lowercase
     name = name.lower()
 

--- a/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
@@ -306,6 +306,11 @@ class TestFetchAndImportNCSOConcesions(TestCase):
             NCSOConcession.objects.filter(vmpp_id=1240211000001107).exists()
         )
 
+    def test_regularise_name(self):
+        self.assertEqual(
+            fetch_ncso.regularise_name(" * Some Drug Name 500 mg"), "some drug name 500"
+        )
+
 
 class ContextStack(contextlib.ExitStack):
     """


### PR DESCRIPTION
We now handle leading asterisks on drug names, and we also correctly report when we have failed to match a drug name.