### PR TITLE
Tech support for failed imports

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -345,6 +345,9 @@ GRAB_HOST = "https://openprescribing.net"
 # Webhook URLs for posting to different channels can be configured at
 # https://api.slack.com/apps/A6B85C8KC/incoming-webhooks
 SLACK_TECHNOISE_POST_KEY = utils.get_env_setting("SLACK_TECHNOISE_POST_KEY", default="")
+SLACK_TECHSUPPORT_POST_KEY = utils.get_env_setting(
+    "SLACK_TECHSUPPORT_POST_KEY", default=""
+)
 SLACK_SENDING_ACTIVE = True
 
 

--- a/openprescribing/openprescribing/slack.py
+++ b/openprescribing/openprescribing/slack.py
@@ -2,7 +2,7 @@ import requests
 from django.conf import settings
 
 
-def notify_slack(message):
+def notify_slack(message, is_error=False):
     """Posts the message to #technoise
 
     See https://my.slack.com/services/new/incoming-webhook/
@@ -11,9 +11,14 @@ def notify_slack(message):
         return
 
     webhook_url = settings.SLACK_TECHNOISE_POST_KEY
+    techsupport_webhook_url = settings.SLACK_TECHSUPPORT_POST_KEY
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)
+    if is_error:
+        # Also post error messages to tech-support
+        response = requests.post(techsupport_webhook_url, json=slack_data)
+
     if response.status_code != 200:
         raise ValueError(
             "Request to slack returned an error %s, the response is:\n%s"

--- a/openprescribing/pipeline/runner.py
+++ b/openprescribing/pipeline/runner.py
@@ -394,7 +394,7 @@ def run_task(task, year, month, **kwargs):
         import traceback
 
         task_log.mark_failed(formatted_tb=traceback.format_exc())
-        msg = "Importing data for {}_{} has failed when running {}.".format(
+        msg = "Importing data for {}_{} has failed when running {}. Calling tech-support.".format(
             year, month, task.name
         )
         notify_slack(msg)

--- a/openprescribing/pipeline/runner.py
+++ b/openprescribing/pipeline/runner.py
@@ -394,10 +394,10 @@ def run_task(task, year, month, **kwargs):
         import traceback
 
         task_log.mark_failed(formatted_tb=traceback.format_exc())
-        msg = "Importing data for {}_{} has failed when running {}. Calling tech-support.".format(
+        msg = "Importing data for {}_{} has failed when running {}.".format(
             year, month, task.name
         )
-        notify_slack(msg)
+        notify_slack(msg, is_error=True)
         raise
 
 


### PR DESCRIPTION
The slack bot can't listen to itself, so we need to explicitly repost failed messages to the tech-support channel