### PR TITLE
Notify data team for import failures

### DIFF
--- a/environment-sample
+++ b/environment-sample
@@ -39,6 +39,7 @@ GUNICORN_NUM_WORKERS=6
 GUNICORN_LOG_LEVEL=warn
 
 SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
+SLACK_DATATEAM_POST_KEY=slack_datateam_post_key
 CF_API_KEY=cf_api_key
 CF_API_EMAIL=cf_api_email
 

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -345,9 +345,7 @@ GRAB_HOST = "https://openprescribing.net"
 # Webhook URLs for posting to different channels can be configured at
 # https://api.slack.com/apps/A6B85C8KC/incoming-webhooks
 SLACK_TECHNOISE_POST_KEY = utils.get_env_setting("SLACK_TECHNOISE_POST_KEY", default="")
-SLACK_TECHSUPPORT_POST_KEY = utils.get_env_setting(
-    "SLACK_TECHSUPPORT_POST_KEY", default=""
-)
+SLACK_DATATEAM_POST_KEY = utils.get_env_setting("SLACK_DATATEAM_POST_KEY", default="")
 SLACK_SENDING_ACTIVE = True
 
 

--- a/openprescribing/openprescribing/slack.py
+++ b/openprescribing/openprescribing/slack.py
@@ -11,13 +11,13 @@ def notify_slack(message, is_error=False):
         return
 
     webhook_url = settings.SLACK_TECHNOISE_POST_KEY
-    techsupport_webhook_url = settings.SLACK_TECHSUPPORT_POST_KEY
+    datateam_webhook_url = settings.SLACK_DATATEAM_POST_KEY
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)
     if is_error:
-        # Also post error messages to tech-support
-        response = requests.post(techsupport_webhook_url, json=slack_data)
+        # Also post error messages to #team-data
+        response = requests.post(datateam_webhook_url, json=slack_data)
 
     if response.status_code != 200:
         raise ValueError(


### PR DESCRIPTION
Change slack notification to post directly to #team-data instead of tech support.