### PR TITLE
Raise an explicit error for TRUD login failure

### DIFF
--- a/openprescribing/dmd/management/commands/fetch_dmd.py
+++ b/openprescribing/dmd/management/commands/fetch_dmd.py
@@ -32,6 +32,10 @@ class Command(BaseCommand):
             "commit": "LOG+IN",
         }
         rsp = session.post(login_url, params)
+        if "The email address or password is invalid" in rsp.text:
+            raise RuntimeError(
+                f"TRUD login failure for username: {settings.TRUD_USERNAME!r}"
+            )
 
         index_url = (
             base_url


### PR DESCRIPTION
This should make it easier to identify the issue in future.