### PR TITLE
Fix chart image rendering in PhantomJS

### DIFF
--- a/openprescribing/frontend/context_processors.py
+++ b/openprescribing/frontend/context_processors.py
@@ -30,7 +30,13 @@ def debug(request):
 
 def google_tracking_id(request):
     tracking_id = None
-    if hasattr(settings, "GOOGLE_TRACKING_ID"):
+    container_id = None
+    if "PhantomJS" in request.META.get("HTTP_USER_AGENT", ""):
+        # Google's JavaScript breaks the ancient JS engine in PhantomJS which we use for
+        # taking screenshots of charts (plus I'm not sure we want analytics to be
+        # running in this case anyway)
+        pass
+    elif hasattr(settings, "GOOGLE_TRACKING_ID"):
         tracking_id = settings.GOOGLE_TRACKING_ID
         container_id = getattr(settings, "GOOGLE_OPTIMIZE_CONTAINER_ID", "")
     else:


### PR DESCRIPTION
Google's JS is now using ES6 flavoured code which PhantomJS's ancient JS engine can't handle. This means that attempting to render chart images dies with:

    ReferenceError: Can't find variable: Map

      https://www.googletagmanager.com/gtag/js?id=G-9DPND0VYSC&cx=c&_slc=1:141

This was the quickest way I could think of the make the problem go away.