### PR TITLE
Switch to new Cloudflare auth mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ PostGIS extensions, and create a superuser for the database.
 
 Copy `environment-sample` to `environment`, and set the `DB_*` environment variables.
 
-Set the `CF_API_EMAIL` and `CF_API_KEY` for Cloudflare (this is only required for automated deploys, see below).
+Set the `CF_API_KEY` for Cloudflare (this is only required for automated deploys, see below).
 
 You will want `MAILGUN_WEBHOOK_USER` and `MAILGUN_WEBHOOK_PASS` if you want to process Mailgun webhook callbacks (see [`TRACKING.md`](./TRACKING.md)) to match the username/password configured in Mailgun. For example, if the webhook is
 

--- a/deploy/clear_cache.py
+++ b/deploy/clear_cache.py
@@ -13,8 +13,7 @@ def list_cloudflare_zones():
     url = "https://api.cloudflare.com/client/v4/zones"
     headers = {
         "Content-Type": "application/json",
-        "X-Auth-Key": os.environ["CF_API_KEY"],
-        "X-Auth-Email": os.environ["CF_API_EMAIL"],
+        "Authorization": f"Bearer {os.environ['CF_API_KEY']}",
     }
     result = json.loads(requests.get(url, headers=headers).text)
     zones = [{"name": x["name"], "id": x["id"]} for x in result["result"]]
@@ -25,8 +24,7 @@ def clear_cloudflare():
     url = "https://api.cloudflare.com/client/v4/zones/%s"
     headers = {
         "Content-Type": "application/json",
-        "X-Auth-Key": os.environ["CF_API_KEY"],
-        "X-Auth-Email": os.environ["CF_API_EMAIL"],
+        "Authorization": f"Bearer {os.environ['CF_API_KEY']}",
     }
     data = {"purge_everything": True}
     result = json.loads(

--- a/environment-sample
+++ b/environment-sample
@@ -41,7 +41,6 @@ GUNICORN_LOG_LEVEL=warn
 SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
 SLACK_DATATEAM_POST_KEY=slack_datateam_post_key
 CF_API_KEY=cf_api_key
-CF_API_EMAIL=cf_api_email
 
 # The path to a file containing your credentials for accessing Google Cloud
 # Platform services (eg BigQuery, Cloud Storage).


### PR DESCRIPTION
The old shared account has been removed and the new token is a bearer token (stored in BitWarden) with restricted privileges.

![Screenshot from 2023-10-09 11-44-44](https://github.com/ebmdatalab/openprescribing/assets/19630/a1068b62-1eaa-423c-a620-aebe37c1f267)
