### PR TITLE
Update faq.html

### DIFF
--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -10,7 +10,7 @@
 
 <h1>FAQs</h1>
 
-<p>We strongly recommend reading NHS Digital's <a href="https://digital.nhs.uk/practice-level-prescribing-summary">introduction to prescribing data</a>, including their excellent <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a> (PDF) and <a href="http://content.digital.nhs.uk/media/10686/Download-glossary-of-terms-for-GP-prescribing---presentation-level/pdf/PLP_Presentation_Level_Glossary_April_2015.pdf">glossary of terms</a> (PDF).</p>
+<p>We strongly recommend reading NHS Digital's <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary">Practice Level Prescribing in England: a summary</a>, including their excellent <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-data-more-information">Practice level prescribing data: More information section which describes which practices and professionals are included in the data and how prescription data are collected</a> and <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms"> Practice level prescribing - glossary of terms</a>.</p>
 
 <p>Is your question not listed below? Send us a message <a href="mailto:{{ FEEDBACK_MAILTO }}">here</a> and we'll get back to you</p>
 

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -88,9 +88,8 @@
   weeks’ worth of treatment while others will be much smaller.
 </p>
 <p>
-  For more detail see the NHS Digital
-  <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a>
-  (PDF)
+  For more detail see the NHS Digital Practice level prescribing 
+  <a https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms#items">glossary of terms</a>
 </p>
 
 <h3 id="prescquantity">What does quantity mean?</h3>
@@ -123,9 +122,8 @@
   strengths and formulations.
 </p>
 <p>
-  For more detail see the NHS Digital
-  <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a>
-  (PDF)
+  For more detail see the NHS Digital Practice level prescribing 
+  <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms#quantity">glossary of terms</a>
 </p>
 
 <h3 id="actualcost">What is actual cost?</h3>
@@ -140,9 +138,8 @@
   container allowance.
 </p>
 <p>
-  For more detail see the NHS Digital
-  <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a>
-  (PDF)
+  For more detail see the NHS Digital Practice level prescribing 
+  <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms#actual-cost">glossary of terms</a>
 </p>
 
 <h3 id="bnfchange">How do you deal with BNF code changes?</h3>
@@ -187,7 +184,7 @@
 <h2>Dashboards</h2>
 
 <h3 id="measureinterpret">How should I interpret the measures?</h3>
-<p>We recommend reading NHS Digitals's <a href="https://digital.nhs.uk/practice-level-prescribing-summary">introduction to prescribing data</a>, including their <a href="http://content.digital.nhs.uk/media/10048/FAQs-Practice-Level-Prescribingpdf/pdf/PLP_FAQs_April_2015.pdf">FAQ</a> (PDF) and <a href="http://content.digital.nhs.uk/media/10686/Download-glossary-of-terms-for-GP-prescribing---presentation-level/pdf/PLP_Presentation_Level_Glossary_April_2015.pdf">glossary of terms</a> (PDF).</p>
+<p>We recommend reading NHS Digitals's <a href="https://digital.nhs.uk/practice-level-prescribing-summary">Practice Level Prescribing in England: a summary</a>, including the <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-data-more-information">more information section</a> and <a href="https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms">glossary of terms</a>.</p>
 
 <p>Just because a practice or NHS organisation is an outlier for high or low use of a particular treatment, that doesn't necessarily mean they are good or bad prescribers. These are <em>measures</em> rather than <em>indicators</em>, and they need to be interpreted judiciously.</p>
 


### PR DESCRIPTION
Update links for NHS digital Practice Level prescribing pages (Inc main page, more information and glossary)

[Practice level prescribing in England: a summary](https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary)

[More Information section](https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-data-more-information)

[Glossary](https://digital.nhs.uk/data-and-information/areas-of-interest/prescribing/practice-level-prescribing-in-england-a-summary/practice-level-prescribing-glossary-of-terms)