### PR TITLE
Replace PyArrow serialization with `pickle`

### DIFF
--- a/openprescribing/matrixstore/serializer.py
+++ b/openprescribing/matrixstore/serializer.py
@@ -1,3 +1,4 @@
+import pickle
 import struct
 import warnings
 
@@ -24,6 +25,12 @@ warnings.filterwarnings(
 # The magic intial bytes which tell us that a given binary chunk is LZ4
 # compressed data
 LZ4_MAGIC_NUMBER = struct.pack("<I", 0x184D2204)
+
+# PyArrow serialized matrices always start with this value and our custom serialization
+# format will never do (the initial bytes are a count which is guaranteed non-zero) so
+# we can use this as format marker
+FOUR_ZERO_BYTES = struct.pack("<I", 0)
+
 
 context = pyarrow.SerializationContext()
 
@@ -65,27 +72,112 @@ context.register_type(
 
 def serialize(obj):
     """
-    Serialize an arbitrary Python object using our custom PyArrow context
+    Serialize an arbitrary Python object while exploiting the zero-copy features of
+    Pickle Protocol 5 (https://peps.python.org/pep-0574/)
+
+    Pickle does almost all the hard work here but we still need to handle the buffer
+    objects. The protocol is designed on the assumption that there exists some
+    out-of-band mechanism for passing the buffers around and we want to do this by
+    bundling them up into the bytestream. Of course, this means we lose the zero-copy
+    property while serializing but we can still do zero-copy deserialization and that's
+    the operation which is performance critical for us.
+
+    Benchmarking this on SciPy sparse arrays of the size we deal with gives the
+    following (all times in microseconds):
+
+                          deserialize  serialize
+        zero-copy pickle  11           806
+                 pyarrow  58           8063
+            naive pickle  807          4217
     """
-    return context.serialize(obj).to_buffer()
+    buffers = []
+    pickled = pickle.dumps(
+        obj,
+        protocol=5,
+        buffer_callback=lambda buffer: buffers.append(buffer.raw()),
+    )
+    buffers.append(pickled)
+    return serialize_buffers(buffers)
+
+
+def deserialize_uncompressed(data):
+    """
+    Inverse of `serialize`
+
+    Note that the resulting object may contain zero-copy views on to the original data.
+    """
+    buffers = deserialize_buffers(data)
+    return pickle.loads(buffers[-1], buffers=buffers)
 
 
 def serialize_compressed(obj):
     """
-    Serialize an arbitrary Python object using our custom PyArrow context and
-    compress the result using LZ4
+    Serialize an arbitrary Python object and compress the result using LZ4
     """
-    data = context.serialize(obj).to_buffer()
+    data = serialize(obj)
     # See commit comments for details of how this compression level was chosen
     return lz4.frame.compress(data, compression_level=10, return_bytearray=True)
 
 
 def deserialize(data):
     """
-    Deserialize binary data using our custom PyArrow context, automatically
-    detecting compressed data and decompressing if necessary
+    Deserialize binary data, whether compressed or uncompressed and whether serialized
+    using PyArrow or our own custom format
     """
-    magic_number = memoryview(data)[:4]
-    if magic_number == LZ4_MAGIC_NUMBER:
+    if memoryview(data)[:4] == LZ4_MAGIC_NUMBER:
         data = lz4.frame.decompress(data, return_bytearray=True)
-    return context.deserialize(data)
+    if memoryview(data)[:4] == FOUR_ZERO_BYTES:
+        return context.deserialize(data)
+    else:
+        return deserialize_uncompressed(data)
+
+
+def serialize_buffers(buffers):
+    """
+    Serialize a list of binary data objects to bytes
+
+    Data objects can be of any type that has a length and can be joined
+    with bytes (buffer, bytes, bytearray etc).
+
+    Each data object must be less than 2**32 bytes in length and there must be fewer
+    than 2**32 of them.
+    """
+    sizes = [len(buffer) for buffer in buffers]
+    header = serialize_ints(sizes)
+    return b"".join([header, *buffers])
+
+
+def deserialize_buffers(data):
+    """
+    Inverse of `serialize_buffers`
+
+    Returned buffers are zero-copy views on to the original data.
+    """
+    data = memoryview(data)
+    sizes, offset = deserialize_ints(data)
+    output = []
+    for size in sizes:
+        next_offset = offset + size
+        output.append(data[offset:next_offset])
+        offset = next_offset
+    return output
+
+
+def serialize_ints(ints):
+    """
+    Serialize a list of positive integers to bytes
+
+    Each int must be less than 2**32 and there must be fewer than 2**32 of them
+    (`struct` will enforce this).
+    """
+    count = len(ints)
+    return struct.pack(f"<{count + 1}I", count, *ints)
+
+
+def deserialize_ints(data):
+    """
+    Inverse of `serialize_ints`
+    """
+    count = struct.unpack("<I", data[:4])[0]
+    end = 4 + (count * 4)
+    return struct.unpack(f"<{count}I", data[4:end]), end


### PR DESCRIPTION
PyArrow serialization has long been deprecated and was removed in version 12 meaning that we have been unable to upgrade:
https://arrow.apache.org/blog/2023/05/02/12.0.0-release/#python-notes

But in fact, we don't need PyArrow at all now because the venerable `pickle` library has learned to do zero-copy serialization and deserialization. It isn't quite as simple as switching to `pickle.dumps()` because Pickle's zero-copy mechanism is lower-level than PyArrow's was, so we have to design our own tiny framing format for it. But this doesn't involve too much code.

The new code is about 5x as fast as PyArrow for both serializing and deserializing. I don't necessarily expect that to translate into a noticeable overall performance improvement, but the key thing is that it isn't worse that it was before.

For now we retain the capacity to read data serialized in the old format to facilitate easy deployment. And later PR will remove this, allowing us to drop the PyArrow dependency and associated code entirely.