### PR TITLE
Bump django-cors-headers from 3.14.0 to 4.3.1

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -175,7 +175,6 @@ MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "corsheaders.middleware.CorsPostCsrfMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile
 #
 asgiref==3.7.2
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 attrs==23.1.0
     # via
     #   outcome
@@ -74,7 +76,7 @@ django==3.2.23
     #   djangorestframework
 django-anymail[mailgun]==10.2
     # via -r requirements.in
-django-cors-headers==3.14.0
+django-cors-headers==4.3.1
     # via -r requirements.in
 django-crispy-forms==2.0
     # via


### PR DESCRIPTION
This involved removing a bit of redundant code which was preventing this upgrade.