### PR TITLE
Bump selenium from 4.9.1 to 4.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -339,7 +339,7 @@ scipy==1.11.4
     # via -r requirements.in
 seaborn==0.13.0
     # via -r requirements.in
-selenium==4.9.1
+selenium==4.16.0
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
This involved replacing the long-deprecated arguments we used to construct WebDriver instances.