### PR TITLE
Test against Postgres 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db-test:
-    image: mdillon/postgis:latest
+    image: postgis/postgis:16-3.4
     env_file: environment-docker
   test:
     image: ghcr.io/ebmdatalab/openprescribing-py311-test:latest
@@ -61,7 +61,7 @@ services:
       - db-test
 
   db-dev:
-    image: mdillon/postgis:latest
+    image: postgis/postgis:16-3.4
     env_file: environment-docker
   dev:
     image: ghcr.io/ebmdatalab/openprescribing-py311-test:latest

--- a/openprescribing/frontend/tests/commands/test_import_list_sizes.py
+++ b/openprescribing/frontend/tests/commands/test_import_list_sizes.py
@@ -31,8 +31,8 @@ class CommandsTestCase(TestCase):
             practice_id="N84014", date=last_list_size_date
         )
         self.assertEqual(p.total_list_size, 40)
-        self.assertEqual(p.astro_pu_cost, 199.419458446917)
-        self.assertEqual(p.astro_pu_items, 780.191218783541)
+        self.assertAlmostEqual(p.astro_pu_cost, 199.419458446917)
+        self.assertAlmostEqual(p.astro_pu_items, 780.191218783541)
         self.assertEqual("%.3f" % p.star_pu["oral_antibacterials_item"], "27.135")
         self.assertEqual("%.3f" % p.star_pu["cox-2_inhibitors_cost"], "13.050")
         self.assertEqual("%.3f" % p.star_pu["antidepressants_adq"], "887.100")


### PR DESCRIPTION
Django 3.2 (the previous LTS release) is shortly going out of support and Django 4.2 (the new LTS release) won't run against Postgres 11 (it needs at least version 12). Given that we're going to have to upgrade Postgres we may as well do it to version 16 (current latest) and buy ourselves as much time as possible.

The production deployment has already been updated. This PR updates the tests to match.