### PR TITLE
Use `prefetch_related()` for MeasureValue queries

### DIFF
--- a/openprescribing/api/views_measures.py
+++ b/openprescribing/api/views_measures.py
@@ -29,7 +29,7 @@ class InvalidMultiParameter(APIException):
 def measure_global(request, format=None):
     measures = utils.param_to_list(request.query_params.get("measure", None))
     tags = utils.param_to_list(request.query_params.get("tags", None))
-    qs = MeasureGlobal.objects.select_related("measure")
+    qs = MeasureGlobal.objects.prefetch_related("measure")
     if measures:
         qs = qs.filter(measure_id__in=measures)
     if tags:

--- a/openprescribing/frontend/managers.py
+++ b/openprescribing/frontend/managers.py
@@ -47,10 +47,10 @@ class MeasureValueQuerySet(models.QuerySet):
             raise ValueError("Unknown org_type: {}".format(org_type))
 
     def for_orgs(self, org_type, org_ids):
-        qs = self.select_related("measure")
+        qs = self.prefetch_related("measure")
 
         if org_ids:
-            qs = qs.select_related(org_type)
+            qs = qs.prefetch_related(org_type)
 
             org_type_key = org_type + "_id"
             org_Q = Q()


### PR DESCRIPTION
Previously we used `select_related()` this meant that we fetched the related measure and organisation from the database repeatedly for each MeasureValue. Using `prefetch_related()` means an extra roundtrip to the database, but it means we only load the related object once which is a huge performance win.