### PR TITLE
Add command to cleanup EmailMessage/MailLog

### DIFF
--- a/deploy/crontab-openprescribing
+++ b/deploy/crontab-openprescribing
@@ -6,3 +6,4 @@
 00 04 * * * hello /webapps/openprescribing/deploy/clean_up_bq_test_data.sh
 00 05 * * * hello /webapps/openprescribing/deploy/diskcache_garbage_collect.sh
 30 05 * * * hello /webapps/openprescribing/deploy/clearsessions.sh
+12 06 * * 1 hello /webapps/openprescribing/deploy/maillog_garbage_collect.sh

--- a/deploy/maillog_garbage_collect.sh
+++ b/deploy/maillog_garbage_collect.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. /webapps/openprescribing/.venv/bin/activate
+python /webapps/openprescribing/openprescribing/manage.py maillog_garbage_collect

--- a/openprescribing/frontend/management/commands/maillog_garbage_collect.py
+++ b/openprescribing/frontend/management/commands/maillog_garbage_collect.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+from frontend.models import EmailMessage, MailLog
+
+
+class Command(BaseCommand):
+    help = "Deletes old EmailMessage instances and their associated MailLog instances."
+
+    def handle(self, *args, **options):
+        latest = EmailMessage.objects.aggregate(Max("created_at"))["created_at__max"]
+        if latest is None:
+            return
+        threshold = latest - timedelta(days=2 * 31)
+        MailLog.objects.filter(message__created_at__lt=threshold).delete()
+        MailLog.objects.filter(message__isnull=True, timestamp__lt=threshold).delete()
+        EmailMessage.objects.filter(created_at__lt=threshold).delete()

--- a/openprescribing/frontend/tests/commands/test_maillog_garbage_collect.py
+++ b/openprescribing/frontend/tests/commands/test_maillog_garbage_collect.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
+from django.core.management import call_command
+from django.test import TestCase
+from frontend.models import EmailMessage, EventType, MailLog
+
+
+class MailLogGarbageCollectTest(TestCase):
+    def test_maillog_garbage_collect(self):
+        # Make some EmailMessages and MailLog entries of the appropriate age
+        for days_ago in [0, 40, 80, 120]:
+            timestamp = datetime.fromisoformat("2023-12-20T00:00:00Z") - timedelta(
+                days=days_ago
+            )
+            recipient = f"{days_ago}_days_ago@example.com"
+            message = EmailMessage.objects.create(
+                message_id=f"{days_ago}_days_ago",
+                to=[recipient],
+            )
+            # Can't set this in `create()` becaause the field is configured with `auto_now_add`
+            message.created_at = timestamp
+            message.save()
+            MailLog.objects.create(
+                timestamp=timestamp,
+                recipient=recipient,
+                message=message,
+                event_type=EventType.SENT,
+            )
+            MailLog.objects.create(
+                timestamp=timestamp,
+                recipient=recipient,
+                message=message,
+                event_type=EventType.DELIVERED,
+            )
+            # Create a MailLog entry which isn't associated with an EmailMessage
+            MailLog.objects.create(
+                timestamp=timestamp,
+                recipient=recipient,
+                event_type=EventType.BOUNCED,
+            )
+
+        call_command("maillog_garbage_collect")
+
+        remaining_messages = EmailMessage.objects.values_list("message_id", flat=True)
+        remaining_recipients = MailLog.objects.values_list("recipient", flat=True)
+        self.assertEqual(
+            set(remaining_messages),
+            {"0_days_ago", "40_days_ago"},
+        )
+        self.assertEqual(
+            set(remaining_recipients),
+            {"0_days_ago@example.com", "40_days_ago@example.com"},
+        )
+
+    def test_maillog_garbage_collect_handles_empty_database(self):
+        self.assertEqual(EmailMessage.objects.count(), 0)
+        call_command("maillog_garbage_collect")


### PR DESCRIPTION
This had grown to 35G in production, which we obviously don't need. Keeping the latest two months' worth seems plenty.

We configure a cronjob to do this on a weekly basis.