### PR TITLE
Remove `django-import-export` plugin

### DIFF
--- a/openprescribing/frontend/admin.py
+++ b/openprescribing/frontend/admin.py
@@ -6,8 +6,6 @@ from django.db import connection
 from django.db.models import Count
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from import_export import resources
-from import_export.admin import ImportExportModelAdmin
 
 from .models import (
     EmailMessage,
@@ -53,27 +51,16 @@ class UserVerifiedFilter(admin.SimpleListFilter):
             return queryset.filter(emailaddress__verified=False)
 
 
-class SearchBookmarkResource(resources.ModelResource):
-    class Meta:
-        model = SearchBookmark
-
-
 @admin.register(SearchBookmark)
-class SearchBookmarkAdmin(ImportExportModelAdmin):
+class SearchBookmarkAdmin(admin.ModelAdmin):
     date_hierarchy = "created_at"
     list_display = ("name", "user", "created_at")
     list_filter = ("created_at",)
     readonly_fields = ("dashboard_link",)
     search_fields = ("user__email",)
-    resource_class = SearchBookmarkResource
 
     def dashboard_link(self, obj):
         return format_html('<a href="{}">view in site</a>', obj.dashboard_url())
-
-
-class OrgBookmarkResource(resources.ModelResource):
-    class Meta:
-        model = OrgBookmark
 
 
 # See Django documentation for SimpleListFilter:
@@ -104,13 +91,12 @@ class OrgBookmarkTypeFilter(admin.SimpleListFilter):
 
 
 @admin.register(OrgBookmark)
-class OrgBookmarkAdmin(ImportExportModelAdmin):
+class OrgBookmarkAdmin(admin.ModelAdmin):
     date_hierarchy = "created_at"
     list_display = ("name", "user", "created_at")
     list_filter = ("created_at", OrgBookmarkTypeFilter)
     readonly_fields = ("dashboard_link",)
     search_fields = ("user__email",)
-    resource_class = OrgBookmarkResource
 
     def dashboard_link(self, obj):
         return format_html('<a href="{}">view in site</a>', obj.dashboard_url())

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -214,7 +214,6 @@ CONTRIB_APPS = (
     "crispy_forms",
     "crispy_bootstrap3",
     "raven.contrib.django.raven_compat",
-    "import_export",
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,6 @@ django-anymail[mailgun]
 django-cors-headers
 django-crispy-forms
 django-dotenv
-django-import-export
 # Django 4.2 is the current LTS release. If you update this remember to update
 # the constraints in .github/dependabot.yml
 django>=4.2,<4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,10 +56,6 @@ cycler==0.12.1
     # via matplotlib
 db-dtypes==1.2.0
     # via pandas-gbq
-defusedxml==0.7.1
-    # via odfpy
-diff-match-patch==20230430
-    # via django-import-export
 diskcache==5.6.3
     # via -r requirements.in
 django==4.2.8
@@ -72,7 +68,6 @@ django==4.2.8
     #   django-debug-toolbar
     #   django-debug-toolbar-template-timings
     #   django-extensions
-    #   django-import-export
     #   djangorestframework
 django-anymail[mailgun]==10.2
     # via -r requirements.in
@@ -91,8 +86,6 @@ django-debug-toolbar-template-timings==0.9
 django-dotenv==1.4.2
     # via -r requirements.in
 django-extensions==3.2.3
-    # via -r requirements.in
-django-import-export==3.3.5
     # via -r requirements.in
 djangorestframework==3.14.0
     # via
@@ -193,8 +186,6 @@ lxml==4.9.4
     #   pyquery
 lz4==4.3.2
     # via -r requirements.in
-markuppy==1.14
-    # via tablib
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.8.2
@@ -220,12 +211,8 @@ numpy==1.26.2
     #   seaborn
 oauthlib==3.2.2
     # via requests-oauthlib
-odfpy==1.4.1
-    # via tablib
 openpyxl==3.1.2
-    # via
-    #   -r requirements.in
-    #   tablib
+    # via -r requirements.in
 outcome==1.3.0.post0
     # via trio
 packaging==23.2
@@ -308,8 +295,6 @@ pytz==2023.3.post1
     #   pandas
 pyvirtualdisplay==3.0
     # via -r requirements.in
-pyyaml==6.0.1
-    # via tablib
 raven==6.10.0
     # via -r requirements.in
 requests[security]==2.31.0
@@ -349,10 +334,6 @@ sqlparse==0.4.4
     # via
     #   django
     #   django-debug-toolbar
-tablib[html,ods,xls,xlsx,yaml]==3.5.0
-    # via
-    #   django-import-export
-    #   tablib
 titlecase==0.12.0
     # via -r requirements.in
 trio==0.23.2
@@ -379,11 +360,7 @@ when-changed==0.3.0
 wsproto==1.2.0
     # via trio-websocket
 xlrd==2.0.1
-    # via
-    #   -r requirements.in
-    #   tablib
-xlwt==1.3.0
-    # via tablib
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
We've already removed this once:
https://github.com/ebmdatalab/openprescribing/pull/1881

And then re-added here:
https://github.com/ebmdatalab/openprescribing/pull/2906

Following discussion in the below thread we've decided that carrying such a heavyweight dependency (given its transitive dependencies) isn't worth it for such a simple feature. If we need a bulk export to CSV feature we can build one ourselves.
https://bennettoxford.slack.com/archives/C051A4P27GE/p1703159367127889