### PR TITLE
Update channel for data import error slack notifications

### DIFF
--- a/environment-sample
+++ b/environment-sample
@@ -39,7 +39,7 @@ GUNICORN_NUM_WORKERS=6
 GUNICORN_LOG_LEVEL=warn
 
 SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
-SLACK_DATATEAM_POST_KEY=slack_datateam_post_key
+SLACK_TEAM_POST_KEY=slack_team_post_key
 CF_API_KEY=cf_api_key
 
 # The path to a file containing your credentials for accessing Google Cloud

--- a/openprescribing/openprescribing/slack.py
+++ b/openprescribing/openprescribing/slack.py
@@ -11,13 +11,13 @@ def notify_slack(message, is_error=False):
         return
 
     webhook_url = settings.SLACK_TECHNOISE_POST_KEY
-    datateam_webhook_url = settings.SLACK_DATATEAM_POST_KEY
+    team_webhook_url = settings.SLACK_TEAM_POST_KEY
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)
     if is_error:
-        # Also post error messages to #team-data
-        response = requests.post(datateam_webhook_url, json=slack_data)
+        # Also post error messages to relevant team channel
+        response = requests.post(team_webhook_url, json=slack_data)
 
     if response.status_code != 200:
         raise ValueError(


### PR DESCRIPTION
The actual webhook is an environment variable (already updated); I've changed the name of the variable so it doesn't reference the specific team, so that in the event that we change teams/team names again, we just need to update the env var content.  

See https://github.com/ebmdatalab/sysadmin/issues/313