### PR TITLE
Update reference to Slack API key

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -343,7 +343,7 @@ GRAB_HOST = "https://openprescribing.net"
 # Webhook URLs for posting to different channels can be configured at
 # https://api.slack.com/apps/A6B85C8KC/incoming-webhooks
 SLACK_TECHNOISE_POST_KEY = utils.get_env_setting("SLACK_TECHNOISE_POST_KEY", default="")
-SLACK_DATATEAM_POST_KEY = utils.get_env_setting("SLACK_DATATEAM_POST_KEY", default="")
+SLACK_TEAM_POST_KEY = utils.get_env_setting("SLACK_TEAM_POST_KEY", default="")
 SLACK_SENDING_ACTIVE = True
 
 


### PR DESCRIPTION
The name of this changed in #4541 but we missed this reference.