### PR TITLE
Fix Ghost-Branded Generic exclusions list

### DIFF
--- a/openprescribing/frontend/ghost_branded_generics.py
+++ b/openprescribing/frontend/ghost_branded_generics.py
@@ -34,7 +34,7 @@ class SetWithCacheKey(set):
 
     cache_key = None
 
-    def __new__(cls, *items):
+    def __new__(cls, items):
         instance = set.__new__(cls, items)
         hashobj = hashlib.md5(str(sorted(items)).encode("utf8"))
         instance.cache_key = hashobj.digest()
@@ -42,14 +42,16 @@ class SetWithCacheKey(set):
 
 
 PRESENTATIONS_TO_IGNORE = SetWithCacheKey(
-    # These can be prescribed fractionally, but BSA round quantity down,
-    # making quantity unreliable. See #1764
-    "1106000L0AAAAAA"  # latanoprost
-    "1308010Z0AAABAB"  # Ingenol Mebutate_Gel
-    # These are sometimes recorded by dose, and sometimes by pack (of 8) see #937
-    "0407020A0AABPBP"  # Fentanyl 400micrograms/dose nasal spray
-    # These are sometimes recorded as bottles, sometimes in litres
-    "0902021S0AAAXAX"  # Sodium chloride 0.9% infusion 1litre polyethylene bottles
+    [
+        # These can be prescribed fractionally, but BSA round quantity down,
+        # making quantity unreliable. See #1764
+        "1106000L0AAAAAA",  # latanoprost
+        "1308010Z0AAABAB",  # Ingenol Mebutate_Gel
+        # These are sometimes recorded by dose, and sometimes by pack (of 8) see #937
+        "0407020A0AABPBP",  # Fentanyl 400micrograms/dose nasal spray
+        # These are sometimes recorded as bottles, sometimes in litres
+        "0902021S0AAAXAX",  # Sodium chloride 0.9% infusion 1litre polyethylene bottles
+    ]
 )
 
 

--- a/openprescribing/frontend/tests/test_ghost_branded_generics.py
+++ b/openprescribing/frontend/tests/test_ghost_branded_generics.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from frontend import ghost_branded_generics as gbg
+
+
+class TestPresentationsToIgnore(TestCase):
+    print(gbg.PRESENTATIONS_TO_IGNORE)
+
+    def test_missing_commas(self):
+        for presentation in gbg.PRESENTATIONS_TO_IGNORE:
+            self.assertGreater(
+                len(presentation),
+                1,
+                f"'{presentation}' does not look like a BNF code, "
+                f"are you missing square brackets around the list?",
+            )
+            self.assertLessEqual(
+                len(presentation),
+                15,
+                f"'{presentation}' does not look like a BNF code, "
+                f"are you missing commas?",
+            )


### PR DESCRIPTION
A combination of bugs (missing list contructor and missing commas) made this run without throwing an error but not behave as intended. This fixes the issue and adds a test to guard against future issues.