### PR TITLE
Change GBG download link

### DIFF
--- a/openprescribing/templates/_ghost_generics_data_table.html
+++ b/openprescribing/templates/_ghost_generics_data_table.html
@@ -30,5 +30,5 @@
 
 </table>
 
-<a class="btn btn-primary" href="{% url 'ghost_generics_api' %}?entity_code={{ entity.code }}&entity_type={{ entity_type }}&date={{ date|date:'Y-m-d' }}&group_by=practice&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download raw data</a>
+<a class="btn btn-primary" href="{% url 'ghost_generics_api' %}?entity_code={{ entity.code }}&entity_type={{ entity_type }}&date={{ date|date:'Y-m-d' }}&group_by=presentation&format=csv"><span class="glyphicon glyphicon-download-alt"></span> Download data</a>
 <hr>


### PR DESCRIPTION
This changes the download link to download link to retrive exactly the data shown in the table, rather than additionally breaking the down by practice. Breaking down by practice for large CCGs/SICBLs was too slow to be practical and led to timeouts.

As a consequence, we change the button text to "Download data" rather than "Download raw data".

Closes #4600