### PR TITLE
Surface failures in sending emails

### DIFF
--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import logging
+import sys
 
 from common.alert_utils import EmailErrorDeferrer
 from django.core.management.base import BaseCommand, CommandError

--- a/openprescribing/frontend/management/commands/send_monthly_alerts.py
+++ b/openprescribing/frontend/management/commands/send_monthly_alerts.py
@@ -132,7 +132,7 @@ class Command(BaseCommand):
                     stp_id=options["stp"],
                 )
             ]
-            logger.info("Created a single test org bookmark")
+            self.log_info("Created a single test org bookmark")
         elif options["recipient_email"] or options["recipient_email_file"]:
             recipients = []
             if options["recipient_email_file"]:
@@ -142,14 +142,14 @@ class Command(BaseCommand):
                 recipients = [options["recipient_email"]]
             query = query & Q(user__email__in=recipients)
             bookmarks = OrgBookmark.objects.filter(query)
-            logger.info("Found %s matching org bookmarks" % bookmarks.count())
+            self.log_info("Found %s matching org bookmarks" % bookmarks.count())
         else:
             bookmarks = OrgBookmark.objects.filter(query)
             if options["skip_email_file"]:
                 with open(options["skip_email_file"], "r") as f:
                     skip = [x.strip() for x in f]
                 bookmarks = bookmarks.exclude(user__email__in=skip)
-            logger.info("Found %s matching org bookmarks" % bookmarks.count())
+            self.log_info("Found %s matching org bookmarks" % bookmarks.count())
         return bookmarks
 
     def get_search_bookmarks(self, now_month, **options):
@@ -164,14 +164,14 @@ class Command(BaseCommand):
                     user=dummy_user, url=options["url"], name=options["search_name"]
                 )
             ]
-            logger.info("Created a single test search bookmark")
+            self.log_info("Created a single test search bookmark")
         elif not options["recipient_email"]:
             bookmarks = SearchBookmark.objects.filter(query)
-            logger.info("Found %s matching search bookmarks" % bookmarks.count())
+            self.log_info("Found %s matching search bookmarks" % bookmarks.count())
         else:
             query = query & Q(user__email=options["recipient_email"])
             bookmarks = SearchBookmark.objects.filter(query)
-            logger.info("Found %s matching search bookmarks" % bookmarks.count())
+            self.log_info("Found %s matching search bookmarks" % bookmarks.count())
         return bookmarks
 
     def validate_options(self, **options):
@@ -199,7 +199,7 @@ class Command(BaseCommand):
         else:
             assert False
         if getattr(org, "close_date", None):
-            logger.info("Skipping sending alert for closed org %s", org.pk)
+            self.log_info("Skipping sending alert for closed org %s", org.pk)
             return
         stats = bookmark_utils.InterestingMeasureFinder(org).context_for_org_email()
 
@@ -207,11 +207,11 @@ class Command(BaseCommand):
             msg = bookmark_utils.make_org_email(org_bookmark, stats, tag=now_month)
             msg = EmailMessage.objects.create_from_message(msg)
             msg.send()
-            logger.info(
+            self.log_info(
                 "Sent org bookmark alert to %s about %s" % (msg.to, org_bookmark.id)
             )
         except bookmark_utils.BadAlertImageError as e:
-            logger.exception(e)
+            self.log_exception(e)
 
     def send_search_bookmark_email(self, search_bookmark, now_month):
         try:
@@ -219,12 +219,12 @@ class Command(BaseCommand):
             msg = bookmark_utils.make_search_email(search_bookmark, tag=now_month)
             msg = EmailMessage.objects.create_from_message(msg)
             msg.send()
-            logger.info(
+            self.log_info(
                 "Sent search bookmark alert to %s about %s"
                 % (recipient_id, search_bookmark.id)
             )
         except bookmark_utils.BadAlertImageError as e:
-            logger.exception(e)
+            self.log_exception(e)
 
     def send_all_england_alerts(self, options):
         # The `send_all_england_alerts` command doesn't respect the same set of
@@ -246,18 +246,14 @@ class Command(BaseCommand):
         # We do understand this one, so keep a record of its value
         recipient_email = set_options.pop("recipient_email", None)
         if not set_options:
-            message = "Sending All England alerts"
-            logger.info(message)
-            print(message)
+            self.log_info("Sending All England alerts")
             send_all_england_alerts(recipient_email)
         else:
-            message = (
+            self.log_info(
                 "Not sending All England alerts as found unhandled option: {}".format(
                     ", ".join(set_options.keys())
                 )
             )
-            logger.info(message)
-            print(message)
 
     def handle(self, *args, **options):
         self.validate_options(**options)
@@ -277,3 +273,11 @@ class Command(BaseCommand):
                 error_deferrer.try_email(
                     self.send_search_bookmark_email, search_bookmark, now_month
                 )
+
+    def log_info(self, msg):
+        logger.info(msg)
+        self.stdout.write(msg)
+
+    def log_exception(self, exc):
+        logger.exception(exc)
+        self.stderr.write(str(exc))

--- a/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
+++ b/openprescribing/frontend/tests/commands/test_send_monthly_alerts.py
@@ -138,12 +138,16 @@ class FailingEmailTestCase(TestCase):
         self.assertEqual(EmailMessage.objects.count(), 3)
         self.assertEqual(len(mail.outbox), 2)
 
-    def test_bad_alert_image_error_not_sent_and_not_raised(self, attach_image, finder):
+    def test_bad_alert_image_error_not_sent_and_exits_with_error(
+        self, attach_image, finder
+    ):
         attach_image.side_effect = BadAlertImageError
         measure = MagicMock()
         measure.id = "measureid"
         test_context = _makeContext(worst=[measure])
-        call_mocked_command(test_context, finder, max_errors="0")
+        with self.assertRaises(SystemExit) as exc:
+            call_mocked_command(test_context, finder, max_errors="0")
+        self.assertNotEqual(exc.exception.code, 0)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_max_errors(self, attach_image, finder):

--- a/openprescribing/frontend/views/bookmark_utils.py
+++ b/openprescribing/frontend/views/bookmark_utils.py
@@ -299,7 +299,7 @@ class InterestingMeasureFinder(object):
                 measure_df, measure.is_percentage
             )
             if len(non_jagged) == period:
-                comparator = non_jagged[-1]
+                comparator = non_jagged.iloc[-1]
                 if invert_percentile_for_comparison:
                     comparator = 100 - comparator
                 worst.append((measure, comparator))


### PR DESCRIPTION
Previously, errors were logged only to the `django.log` file and not surfaced in the console to the user running the command. Additionally, `BadAlertImageError` exceptions weren't treated as errors so the command as a whole would appear to have run successfully even where these were encountered.

As these seem to occur quite regularly for transient reasons, this meant that every month a random selection of subscribers would never receive their emails.