### PR TITLE
Handle absence of Google Analytics `ga()` function

### DIFF
--- a/openprescribing/templates/base.html
+++ b/openprescribing/templates/base.html
@@ -47,6 +47,11 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
       {% endif %}
       ga('send', 'pageview', location.pathname + location.search + location.hash);
     </script>
+    {% else %}
+    <script>
+      // Define no-op `ga()` function so code which assumes it doesn't error
+      function ga() {}
+    </script>
     {% endif %}
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Well, not so much handle its absence as ensure its presence as that is by far the easier "fix" here.

Without this, the chart images needed for "search bookmark" (aka Analyse) alerts don't render.

I'm not exactly sure when or why this stopped working. Possibly it was as a consequence of #4343, or possibly it was already broken and that point and that PR just failed to fix it.

I've confirmed this works locally, but it's hard to be 100% sure until we try it in prod.