### PR TITLE
Tweak BNF trends charts

### DIFF
--- a/openprescribing/media/js/src/bar-charts.js
+++ b/openprescribing/media/js/src/bar-charts.js
@@ -93,7 +93,7 @@ var barChart = {
 
     setUp: function() {
         var _this = this;
-        _this.graphType = 'items';
+        _this.graphType = 'actual_cost';
         $.ajax({
           type: 'GET',
           url: filename,

--- a/openprescribing/templates/_chart.html
+++ b/openprescribing/templates/_chart.html
@@ -8,8 +8,8 @@
 <h3>Trends</h3>
 
 <div class="btn-group btn-toggle" id="graphtype" aria-label="Show spending or items on graph">
-<button class="btn btn-info" data-type="items">Items</button>
-<button class="btn btn-default" data-type="actual_cost">Spending</button>
+<button class="btn btn-info" data-type="actual_cost">Spending</button>
+<button class="btn btn-default" data-type="items">Items</button>
 </div>
 
 <div id="chart" class="chart">

--- a/openprescribing/templates/all_bnf.html
+++ b/openprescribing/templates/all_bnf.html
@@ -8,6 +8,8 @@
 
 <h1>All BNF sections</h1>
 
+{% include '_chart.html' %}
+
 <p>Search for a BNF section by name or code, and get trends for total prescribing.</p>
 
 <input class="form-control" id="search" placeholder="Search by name or code, e.g. diabetes" />
@@ -39,4 +41,10 @@ allItems.push(section);
 {% endfor %}
 </script>
 {% conditional_js 'list-filter' %}
+{% conditional_js 'config' %}
+<script>
+var filename = config.apiHost + "{% url 'total_spending' %}?format=json";
+var pageType = 'bnf-section';
+</script>
+{% conditional_js 'bar-charts' %}
 {% endblock %}


### PR DESCRIPTION
This adds a bar chart to the root of the BNF trends page showing prescribing over the entire BNF. It also switches the default view from items to spending.

This is the easy part of the changes requested by @brianmackenna to aid spending analysis.
