### PR TITLE
Support filtering prescribing trends pages by organisation

### DIFF
--- a/openprescribing/api/urls.py
+++ b/openprescribing/api/urls.py
@@ -11,7 +11,7 @@ from . import (
 )
 
 urlpatterns = [
-    path(r"spending/", views_spending.total_spending, name="total_spending"),
+    path(r"spending/", views_spending.spending_by_org, name="total_spending"),
     path(r"bubble/", views_spending.bubble, name="bubble"),
     path(r"tariff/", views_spending.tariff, name="tariff_api"),
     path(

--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -428,6 +428,10 @@ def spending_by_org(request, format=None, org_type=None):
 
 
 def _get_org_type_and_orgs(org_type, org_ids):
+    # If no org parameters are supplied then we sum over absolutely everything
+    if org_type is None and not org_ids:
+        return "all_practices", [AllEngland()]
+
     # Accept both cases of CCG (better to fix this specific string rather than
     # make the whole API case-insensitive)
     if org_type == "CCG":
@@ -474,6 +478,16 @@ def _get_org_type_and_orgs(org_type, org_ids):
         orgs = orgs.only("code", "name")
 
     return org_type, orgs
+
+
+class AllEngland:
+    """
+    Implements enough of the API of the ORM org models that we can use it in
+    `_get_prescribing_entries` below
+    """
+
+    pk = None
+    name = "england"
 
 
 def _get_prescribing_entries(bnf_code_prefixes, orgs, org_type, date=None):

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -112,59 +112,55 @@ class TestSpending(ApiTestBase):
     def test_total_spending(self):
         rows = self._get_rows({})
 
-        self.assertEqual(len(rows), 60)
-        self.assertEqual(rows[25]["date"], "2013-04-01")
-        self.assertEqual(rows[25]["actual_cost"], "3.12")
-        self.assertEqual(rows[25]["items"], "2")
-        self.assertEqual(rows[25]["quantity"], "52.0")
-        self.assertEqual(rows[26]["date"], "2013-05-01")
-        self.assertEqual(rows[26]["actual_cost"], "0.0")
-        self.assertEqual(rows[26]["items"], "0")
-        self.assertEqual(rows[26]["quantity"], "0.0")
-        self.assertEqual(rows[44]["date"], "2014-11-01")
-        self.assertEqual(rows[44]["actual_cost"], "230.54")
-        self.assertEqual(rows[44]["items"], "96")
-        self.assertEqual(rows[44]["quantity"], "5143.0")
+        self.assertEqual(len(rows), 7)
+        self.assertEqual(rows[0]["date"], "2013-04-01")
+        self.assertEqual(rows[0]["actual_cost"], "3.12")
+        self.assertEqual(rows[0]["items"], "2")
+        self.assertEqual(rows[0]["quantity"], "52.0")
+        self.assertEqual(rows[5]["date"], "2014-11-01")
+        self.assertEqual(rows[5]["actual_cost"], "230.54")
+        self.assertEqual(rows[5]["items"], "96")
+        self.assertEqual(rows[5]["quantity"], "5143.0")
 
     def test_total_spending_by_bnf_section(self):
         rows = self._get_rows({"code": "2"})
 
-        self.assertEqual(rows[25]["date"], "2013-04-01")
-        self.assertEqual(rows[25]["actual_cost"], "3.12")
-        self.assertEqual(rows[25]["items"], "2")
-        self.assertEqual(rows[25]["quantity"], "52.0")
-        self.assertEqual(rows[44]["date"], "2014-11-01")
-        self.assertEqual(rows[44]["actual_cost"], "230.54")
-        self.assertEqual(rows[44]["items"], "96")
-        self.assertEqual(rows[44]["quantity"], "5143.0")
+        self.assertEqual(rows[0]["date"], "2013-04-01")
+        self.assertEqual(rows[0]["actual_cost"], "3.12")
+        self.assertEqual(rows[0]["items"], "2")
+        self.assertEqual(rows[0]["quantity"], "52.0")
+        self.assertEqual(rows[5]["date"], "2014-11-01")
+        self.assertEqual(rows[5]["actual_cost"], "230.54")
+        self.assertEqual(rows[5]["items"], "96")
+        self.assertEqual(rows[5]["quantity"], "5143.0")
 
     def test_total_spending_by_bnf_section_full_code(self):
         rows = self._get_rows({"code": "02"})
 
-        self.assertEqual(rows[25]["date"], "2013-04-01")
-        self.assertEqual(rows[25]["actual_cost"], "3.12")
-        self.assertEqual(rows[25]["items"], "2")
-        self.assertEqual(rows[25]["quantity"], "52.0")
-        self.assertEqual(rows[44]["date"], "2014-11-01")
-        self.assertEqual(rows[44]["actual_cost"], "230.54")
-        self.assertEqual(rows[44]["items"], "96")
-        self.assertEqual(rows[44]["quantity"], "5143.0")
+        self.assertEqual(rows[0]["date"], "2013-04-01")
+        self.assertEqual(rows[0]["actual_cost"], "3.12")
+        self.assertEqual(rows[0]["items"], "2")
+        self.assertEqual(rows[0]["quantity"], "52.0")
+        self.assertEqual(rows[5]["date"], "2014-11-01")
+        self.assertEqual(rows[5]["actual_cost"], "230.54")
+        self.assertEqual(rows[5]["items"], "96")
+        self.assertEqual(rows[5]["quantity"], "5143.0")
 
     def test_total_spending_by_code(self):
         rows = self._get_rows({"code": "0204000I0"})
 
-        self.assertEqual(rows[44]["date"], "2014-11-01")
-        self.assertEqual(rows[44]["actual_cost"], "176.28")
-        self.assertEqual(rows[44]["items"], "34")
-        self.assertEqual(rows[44]["quantity"], "2355.0")
+        self.assertEqual(rows[0]["date"], "2014-11-01")
+        self.assertEqual(rows[0]["actual_cost"], "176.28")
+        self.assertEqual(rows[0]["items"], "34")
+        self.assertEqual(rows[0]["quantity"], "2355.0")
 
     def test_total_spending_by_codes(self):
         rows = self._get_rows({"code": "0204000I0,0202010B0"})
 
-        self.assertEqual(rows[42]["date"], "2014-09-01")
-        self.assertEqual(rows[42]["actual_cost"], "36.29")
-        self.assertEqual(rows[42]["items"], "40")
-        self.assertEqual(rows[42]["quantity"], "1209.0")
+        self.assertEqual(rows[3]["date"], "2014-09-01")
+        self.assertEqual(rows[3]["actual_cost"], "36.29")
+        self.assertEqual(rows[3]["items"], "40")
+        self.assertEqual(rows[3]["quantity"], "1209.0")
 
 
 class TestSpendingByCCG(ApiTestBase):

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1697,9 +1697,9 @@ def _get_entity(entity_type, entity_code):
         return get_object_or_404(Practice, code=entity_code)
     elif entity_type == "pcn":
         return get_object_or_404(PCN, code=entity_code)
-    elif entity_type == "ccg":
+    elif entity_type == "ccg" or entity_type == "sicbl":
         return get_object_or_404(PCT, code=entity_code)
-    elif entity_type == "stp":
+    elif entity_type == "stp" or entity_type == "icb":
         return get_object_or_404(STP, code=entity_code)
     elif entity_type == "regional_team":
         return get_object_or_404(RegionalTeam, code=entity_code)

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -21,6 +21,7 @@ from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import get_resolver, reverse
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from dmd.models import VMP
 from frontend.forms import (
@@ -93,7 +94,7 @@ def first_or_none(lst):
 ##################################################
 def all_bnf(request):
     sections = Section.objects.filter(is_current=True)
-    context = {"sections": sections}
+    context = {"sections": sections, **get_org_context(request.GET)}
     return render(request, "all_bnf.html", context)
 
 
@@ -124,6 +125,7 @@ def bnf_section(request, section_id):
         "subsections": subsections,
         "chemicals": chemicals,
         "page_id": section_id,
+        **get_org_context(request.GET),
     }
     return render(request, "bnf_section.html", context)
 
@@ -135,7 +137,7 @@ def bnf_section(request, section_id):
 
 def all_chemicals(request):
     chemicals = Chemical.objects.filter(is_current=True).order_by("bnf_code")
-    context = {"chemicals": chemicals}
+    context = {"chemicals": chemicals, **get_org_context(request.GET)}
     return render(request, "all_chemicals.html", context)
 
 
@@ -156,8 +158,27 @@ def chemical(request, bnf_code):
         "bnf_chapter": bnf_chapter,
         "bnf_section": bnf_section,
         "bnf_para": bnf_para,
+        **get_org_context(request.GET),
     }
     return render(request, "chemical.html", context)
+
+
+def get_org_context(params):
+    org_type = params.get("org_type", "")
+    org_code = params.get("org", "")
+    if not org_type or not org_code:
+        return {
+            "org": None,
+            "extra_url_params": "",
+            "extra_api_params": "",
+        }
+
+    org = _get_entity(org_type, org_code)
+    return {
+        "org": org,
+        "extra_url_params": format_html("?org_type={}&org={}", org_type, org.code),
+        "extra_api_params": format_html("&org_type={}&org={}", org_type, org.code),
+    }
 
 
 ##################################################

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -1413,6 +1413,9 @@ def _home_page_context_for_entity(request, entity):
         "entity": entity,
         "entity_type": entity_type,
         "entity_type_human": _entity_type_human(entity_type),
+        "public_entity_type": {"ccg": "sicbl", "stp": "icb"}.get(
+            entity_type, entity_type
+        ),
         "has_prescribing": org_has_prescribing(entity_type, entity.code),
     }
     if not context["has_prescribing"]:

--- a/openprescribing/media/js/src/bar-charts.js
+++ b/openprescribing/media/js/src/bar-charts.js
@@ -30,7 +30,9 @@ var barChart = {
     getChartTitle: function(graphType) {
         var title = 'Total ';
         title += (graphType === 'actual_cost') ? 'spending' : 'items';
-        if ((pageType !== 'ccg') && (pageType !== 'practice')) {
+        if (window.orgName) {
+          title += " across " + orgName;
+        } else if ((pageType !== 'ccg') && (pageType !== 'practice')) {
             title += ' across all practices in England';
         }
         return title;

--- a/openprescribing/templates/all_bnf.html
+++ b/openprescribing/templates/all_bnf.html
@@ -19,7 +19,7 @@
 <li>
 {% if s.bnf_section %}&nbsp;&nbsp;{% endif %}
 {% if s.bnf_para %}&nbsp;&nbsp;{% endif %}
-<a href="{% url 'bnf_section' s.bnf_id %}">{{ s.number_str }}: {{ s.name }}</a>
+<a href="{% url 'bnf_section' s.bnf_id %}{{ extra_url_params }}">{{ s.number_str }}: {{ s.name }}</a>
 </li>
 {% endfor %}
 </ul>
@@ -35,7 +35,7 @@ var inputSearch = '#search',
 var section = {
     name: '{{ s.name }}',
     code: '{{ s.number_str }}',
-    url: "{% url 'bnf_section' s.bnf_id %}"
+    url: "{% url 'bnf_section' s.bnf_id %}{{ extra_url_params  }}"
 };
 allItems.push(section);
 {% endfor %}
@@ -43,8 +43,9 @@ allItems.push(section);
 {% conditional_js 'list-filter' %}
 {% conditional_js 'config' %}
 <script>
-var filename = config.apiHost + "{% url 'total_spending' %}?format=json";
+var filename = config.apiHost + "{% url 'spending_by_org' %}?format=json{{ extra_api_params }}";
 var pageType = 'bnf-section';
+var orgName = {% if org %}"{{ org.cased_name }}"{% else %}null{% endif %};
 </script>
 {% conditional_js 'bar-charts' %}
 {% endblock %}

--- a/openprescribing/templates/all_chemicals.html
+++ b/openprescribing/templates/all_chemicals.html
@@ -13,7 +13,7 @@
 
 <ul class="list-unstyled" id="all-results">
 {% for c in chemicals %}
-<li><a href="{% url 'chemical' c.bnf_code %}">{{ c.chem_name }}</a> ({{ c.bnf_code }})</li>
+<li><a href="{% url 'chemical' c.bnf_code %}{{ extra_url_params }}">{{ c.chem_name }}</a> ({{ c.bnf_code }})</li>
 {% endfor %}
 </ul>
 
@@ -28,7 +28,7 @@ var inputSearch = '#search',
 var chemical = {
     name: '{{ c.chem_name }}',
     code: '{{ c.bnf_code }}',
-    url: "{% url 'chemical' c.bnf_code %}"
+    url: "{% url 'chemical' c.bnf_code %}{{ extra_url_params }}"
 };
 allItems.push(chemical);
 {% endfor %}

--- a/openprescribing/templates/bnf_section.html
+++ b/openprescribing/templates/bnf_section.html
@@ -10,14 +10,14 @@
 {% if section %}
 <h1>{{ section.number_str}}: {{ section.name }}</h1>
 {% if bnf_chapter %}
-<p class="lead">Part of chapter <a href="{% url 'bnf_section' bnf_chapter.bnf_id %}">{{ bnf_chapter.number_str }} {{ bnf_chapter.name }}</a>{% if bnf_section %}, section <a href="{% url 'bnf_section' bnf_section.bnf_id %}">{{ bnf_section.number_str }} {{ bnf_section.name }}</a>{% endif %}
+<p class="lead">Part of chapter <a href="{% url 'bnf_section' bnf_chapter.bnf_id %}{{ extra_url_params }}">{{ bnf_chapter.number_str }} {{ bnf_chapter.name }}</a>{% if bnf_section %}, section <a href="{% url 'bnf_section' bnf_section.bnf_id %}{{ extra_url_params }}">{{ bnf_section.number_str }} {{ bnf_section.name }}</a>{% endif %}
 </p>
 {% endif %}
 {% endif %}
 
 <hr/>
 
-<p>High-level prescribing trends for {{ section.name }} (BNF section {{ section.number_str }}) across all GP practices in NHS England for the last five years. You can <a href="{% url 'analyse' %}#numIds={{ section.number_str }}">explore prescribing trends for this section by Sub-ICB Location</a>, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
+<p>High-level prescribing trends for {{ section.name }} (BNF section {{ section.number_str }}) across {% if org %}{{ org.cased_name }}{% else %}all GP practices in NHS England{% endif %} for the last five years. You can <a href="{% url 'analyse' %}#numIds={{ section.number_str }}">explore prescribing trends for this section by Sub-ICB Location</a>, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
 
 <p><a href="{% url 'dmd_search' %}?q={{ page_id }}">View all matching dm+d items.</a></p>
 
@@ -28,21 +28,21 @@
 {% if subsections %}
 <h3>Subsections</h3>
 {% for subsection in subsections %}
-<a class="subsection" href="{% url 'bnf_section' subsection.bnf_id %}">{{ subsection.number_str }}: {{ subsection.name }}</a><br/>
+<a class="subsection" href="{% url 'bnf_section' subsection.bnf_id %}{{ extra_url_params }}">{{ subsection.number_str }}: {{ subsection.name }}</a><br/>
 {% endfor %}
 {% endif %}
 
 {% if chemicals %}
 <h3>Chemicals</h3>
 {% for chemical in chemicals %}
-<a href="{% url 'chemical' chemical.bnf_code %}">{{ chemical.chem_name }} ({{ chemical.bnf_code }})</a><br/>
+<a href="{% url 'chemical' chemical.bnf_code %}{{ extra_url_params }}">{{ chemical.chem_name }} ({{ chemical.bnf_code }})</a><br/>
 {% endfor %}
 {% endif %}
 
 <div id="download-data">
 <h3>Download raw data</h3>
 <p>Download CSVs:
-<a href="{% url 'total_spending' %}?code={{ page_id }}&format=csv">all data on {{ section.name }}</a> or
+<a href="{% url 'spending_by_org' %}?code={{ page_id }}&format=csv{{ extra_api_params }}">all data on {{ section.name }}</a> or
 <a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ section.name }} by Sub-ICB Location</a>.
 </p>
 </div>
@@ -52,8 +52,9 @@
 {% block extra_js %}
 {% conditional_js 'config' %}
 <script>
-var filename = config.apiHost + "{% url 'total_spending' %}?format=json&code={{ page_id }}";
+var filename = config.apiHost + "{% url 'spending_by_org' %}?format=json&code={{ page_id }}{{ extra_api_params }}";
 var pageType = 'bnf-section';
+var orgName = {% if org %}"{{ org.cased_name }}"{% else %}null{% endif %};
 </script>
 {% conditional_js 'bar-charts' %}
 {% endblock %}

--- a/openprescribing/templates/chemical.html
+++ b/openprescribing/templates/chemical.html
@@ -10,14 +10,14 @@
 <h1>{{ chemical.chem_name }} ({{ chemical.bnf_code }})</h1>
 
 <p class="lead">Part of chapter
-<a href="{% url 'bnf_section' bnf_chapter.bnf_id %}">{{ bnf_chapter.number_str }} {{ bnf_chapter.name }}</a>, section <a href="{% url 'bnf_section' bnf_section.bnf_id %}">{{ bnf_section.number_str }} {{ bnf_section.name }}</a>{% if bnf_para %}, paragraph
-<a href="{% url 'bnf_section' bnf_para.bnf_id %}">{{ bnf_para.number_str }} {{ bnf_para.name }}</a>
+<a href="{% url 'bnf_section' bnf_chapter.bnf_id %}{{ extra_url_params }}">{{ bnf_chapter.number_str }} {{ bnf_chapter.name }}</a>, section <a href="{% url 'bnf_section' bnf_section.bnf_id %}{{ extra_url_params }}">{{ bnf_section.number_str }} {{ bnf_section.name }}</a>{% if bnf_para %}, paragraph
+<a href="{% url 'bnf_section' bnf_para.bnf_id %}{{ extra_url_params }}">{{ bnf_para.number_str }} {{ bnf_para.name }}</a>
 {% endif %}
 </p>
 
 <hr/>
 
-<p>High-level prescribing trends for {{ chemical.chem_name }} (BNF code {{ chemical.bnf_code }}) across all GP practices in NHS England for the last five years. You can see <a href="{% url 'analyse' %}#numIds={{ chemical.bnf_code }}&denomIds={% if bnf_para %}{{ bnf_para.number_str }}{% else %}{{ bnf_section.number_str }}{% endif %}">which Sub-ICB Locations prescribe most of this chemical</a> relative to its class, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
+<p>High-level prescribing trends for {{ chemical.chem_name }} (BNF code {{ chemical.bnf_code }}) across {% if org %}{{ org.cased_name }}{% else %}all GP practices in NHS England{% endif %} for the last five years. You can see <a href="{% url 'analyse' %}#numIds={{ chemical.bnf_code }}&denomIds={% if bnf_para %}{{ bnf_para.number_str }}{% else %}{{ bnf_section.number_str }}{% endif %}">which Sub-ICB Locations prescribe most of this chemical</a> relative to its class, or learn more <a href="{% url 'about' %}#sources">about this site</a>.</p>
 
 <p><a href="{% url 'dmd_search' %}?q={{ chemical.bnf_code }}">View all matching dm+d items.</a></p>
 
@@ -29,7 +29,7 @@
 <h3>Download raw data</h3>
 <p>
 Download CSV:
-<a href="{% url 'total_spending' %}?code={{ page_id }}&format=csv">all data on {{ chemical.chem_name }}</a> or
+<a href="{% url 'spending_by_org' %}?code={{ page_id }}&format=csv{{ extra_api_params }}">all data on {{ chemical.chem_name }}</a> or
 <a href="{% url 'spending_by_ccg' %}?code={{ page_id }}&format=csv">data on {{ chemical.chem_name }} by Sub-ICB Location</a>.
 </p>
 </div>
@@ -39,8 +39,9 @@ Download CSV:
 {% block extra_js %}
 {% conditional_js 'config' %}
 <script>
-var filename = config.apiHost + "{% url 'total_spending' %}?format=json&code={{ page_id }}";
+var filename = config.apiHost + "{% url 'spending_by_org' %}?format=json&code={{ page_id }}{{ extra_api_params }}";
 var pageType = 'chemical';
+var orgName = {% if org %}"{{ org.cased_name }}"{% else %}null{% endif %};
 </script>
 {% conditional_js 'bar-charts' %}
 {% endblock %}

--- a/openprescribing/templates/entity_home_page.html
+++ b/openprescribing/templates/entity_home_page.html
@@ -181,7 +181,8 @@
       <h3>Looking for more data?</h3>
       <p>
         Try our <a href="{% url 'analyse' %}">Analyse form</a> which allows you
-        run custom analyses on prescribing data for this {{ entity_type_human }}.
+        run custom analyses on prescribing data for this {{ entity_type_human }}, or view
+        <a href="{% url 'all_bnf' %}?org_type={{ public_entity_type }}&org={{ entity.code }}">high-level prescribing trends</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
As currently implemented, this is something of a hidden feature. It's accessible via a link on each organisation's homepage:
![image](https://github.com/ebmdatalab/openprescribing/assets/19630/78c7a1bf-b7fa-425d-8a12-a2a8d9d61560)

Clicking this link takes you to a version of the BNF trends page where the charts are filtered to just that organisation's prescribing:
![image](https://github.com/ebmdatalab/openprescribing/assets/19630/37bf5f15-f611-4a1d-8320-7e5abb24e1ad)

If this turns out to be a useful feature which we'd like to highlight more then we can work on making the interface a bit more accessible.