### PR TITLE
Add custom styles for labs pages

### DIFF
--- a/openprescribing/templates/labs/custom.css
+++ b/openprescribing/templates/labs/custom.css
@@ -1,3 +1,15 @@
+:root {
+  --oxford-50: #f1f7ff;
+  --oxford-600: #0058be;
+  --oxford-900: #001936;
+
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+
+  --sun-300: #ffedb0;
+  --sun-500: #ffd13a;
+}
+
 html {
   font-size: 16px;
 }
@@ -6,25 +18,125 @@ html {
   font-size: 1rem;
   line-height: 1.5;
   padding-top: 0.1rem !important;
+}
 
-  #notebook-container {
-    box-shadow: none;
-    font-size: 1rem;
-    line-height: 1.5;
-    max-width: 60rem;
+#notebook-container {
+  box-shadow: none;
+  font-size: 1rem;
+  line-height: 1.5;
+  max-width: 60rem;
+  padding: 0 0 4rem;
+}
+
+div.cell {
+  border-width: 0;
+  padding: 0;
+
+  &:before {
+    display: none;
+  }
+}
+
+.cell:has(h1) {
+  font-size: 1.1em;
+
+  .output_area {
+    display: block;
+
+    img {
+      box-shadow:
+        0 10px 15px -3px rgb(0 0 0 / 0.1),
+        0 4px 6px -4px rgb(0 0 0 / 0.1);
+      margin: 1rem 1rem 2rem;
+    }
+  }
+
+  .output_subarea {
+    display: block;
+    max-width: 100%;
     padding: 0;
+  }
+
+  .rendered_html {
+    background-color: var(--oxford-50);
+    margin-block: -0.75em 2em;
+    overflow-x: visible;
+    padding: 3em 0;
+    position: relative;
+
+    &::before,
+    &::after {
+      background-color: var(--oxford-50);
+      content: "";
+      height: 100%;
+      position: absolute;
+      top: 0;
+      width: 100vw;
+      z-index: 10;
+    }
+
+    &::before {
+      left: -100vw;
+    }
+
+    &::after {
+      right: -100vw;
+    }
   }
 
   h1 {
-    margin-top: 0;
+    margin-block-start: 0 !important;
   }
+}
 
-  div.cell {
-    border-width: 0;
-    padding: 0;
+.output_area:has(h2:first-child > a) {
+  h2 {
+    border-top: 1px solid var(--gray-300);
+    margin-block: 3rem 0 !important;
+    padding-block: 3rem 0 !important;
+  }
+}
 
-    &:before {
-      display: none;
+.output_area:has(h4:first-child > a) {
+  h4 {
+    border-top: 1px dashed var(--gray-200);
+    font-size: 1.25em;
+    margin-block: 2rem 0 !important;
+    padding-block: 2rem 0 !important;
+  }
+}
+
+.output_area:has(h2:first-child > a),
+.output_area:has(h4:first-child > a) {
+
+  h2 a,
+  h4 a {
+    color: var(--oxford-600);
+    line-height: 1.2;
+    text-decoration: none !important;
+
+    &:not([href^="#"])::after {
+      content: "\21F2";
+      display: inline-block;
+      transform: rotate(-90deg);
+      margin-inline-start: 0.25em;
+    }
+
+    &:hover {
+      color: var(--oxford-900);
+      text-decoration: underline !important;
+    }
+
+    &:hover {
+      color: var(--oxford-900);
+      text-decoration: underline !important;
+    }
+
+    &:focus-visible {
+      background-color: var(--sun-300);
+      color: var(--oxford-900);
+      outline: 2px solid var(--sun-500);
+      outline-offset: 0.25rem;
     }
   }
 }


### PR DESCRIPTION
Whilst this can be tested by running OpenPrescribing locally, the fastest way is to use DevTools.

## Steps to test

1. Go to https://openprescribing.net/labs/sicbl-improvement-radar/ in Chrome (or Chrome based browser)
2. Open Chrome DevTools
3. Go to the "**Sources**" tab
4. Right-mouse click on the "**custom.css**" file and select "**Override content**"
5. A toolbar will pop up above the DevTools, click on "**Select folder**" and select somewhere on your drive you can access
6. You may now need to "**Allow**" Chrome access to this location (a toolbar will appear at the top of the window)
7. Go to the folder in your code editor of choice, and replace the contents of the "**custom.css**" file with the file in this PR
8. The page should update in your browser when you save the file in your editor

## Screenshots

### Before

![Page header before styling changes](https://github.com/ebmdatalab/openprescribing/assets/24863179/75c221ff-e67c-4169-81ff-658f32e72e3f)

---

![Example page content before styling changes](https://github.com/ebmdatalab/openprescribing/assets/24863179/3d9a7000-0037-48ee-83b1-0dee041aebd0)

### After

![Page header after styling changes](https://github.com/ebmdatalab/openprescribing/assets/24863179/1d2f8706-247e-457f-aeb8-c562eb524462)

---

![Example page content after styling changes](https://github.com/ebmdatalab/openprescribing/assets/24863179/472b38ac-5ea3-4388-92b2-bdfaa9959e5f)