### PR TITLE
Fix typo

### DIFF
--- a/openprescribing/frontend/management/commands/send_ncso_concessions_alerts.py
+++ b/openprescribing/frontend/management/commands/send_ncso_concessions_alerts.py
@@ -32,7 +32,7 @@ def send_alerts(date):
     success_count = 0
     error_count = 0
     for bookmark in bookmarks:
-        description = f"to {bookmark.user.email} about {bookmark.entity.cased_name}"
+        description = f"to {bookmark.user.email} about {bookmark.entity_cased_name}"
         try:
             send_alert(bookmark, date)
             success_count += 1


### PR DESCRIPTION
This worked by accident when `entity` wasn't `None`.