### PR TITLE
fix(docs): fix typo in api/ API docs

### DIFF
--- a/openprescribing/templates/api.html
+++ b/openprescribing/templates/api.html
@@ -62,7 +62,7 @@
 
 <p>
   You can use the above queries with all the other organisation types supported
-  by OpenPrescribing by changine the <code>org_type</code> parameter:
+  by OpenPrescribing by changing the <code>org_type</code> parameter:
 </p>
 <ul>
   <li><code>?org_type=pcn</code> for PCNs</li>


### PR DESCRIPTION
Hello folks,
Thanks for the API docs: they really helped me get my head around the API.

I noticed what looks like a typo in the API docs at https://openprescribing.net/api/.

I think that a PR like this is the best way to fix it.
I don't belive that fixing this typoe should break any tests. 
But I'm struggling to get the test suite running locally.

If I run the tests as described in [README.md::193](https://github.com/ebmdatalab/openprescribing/blob/2805e8c9ab1404cad698e7d18f01527648f1a686/README.md?plain=1#L193)
I get problems with dependencies that do support the python version in `.python-version` and `Dockerfile` 

```sh
$ python --version
Python 3.12.1
$ python -m pip install -r requirements.dev.txt -r  requirements.txt

ERROR: Ignored the following versions that require a different python version: 0.16.0 Requires-Python >=3.7, <3.11; 0.17.0 Requires-Python >=3.7, <3.11; 0.17.1 Requires-Python >=3.7, <3.11; 0.17.2 Requires-Python >=3.7, <3.11; 0.17.3 Requires-Python >=3.7, <3.11; 0.17.4 Requires-Python >=3.7, <3.11; 0.17.5 Requires-Python >=3.7, <3.11; 0.17.6 Requires-Python >=3.7, <3.11; 0.17.7 Requires-Python >=3.7, <3.11; 0.17.8 Requires-Python >=3.7, <3.11; 0.17.9 Requires-Python >=3.7, <3.11; 0.18.0 Requires-Python >=3.7, <3.11; 1.21.2 Requires-Python >=3.7,<3.11; 1.21.3 Requires-Python >=3.7,<3.11; 1.21.4 Requires-Python >=3.7,<3.11; 1.21.5 Requires-Python >=3.7,<3.11; 1.21.6 Requires-Python >=3.7,<3.11; 2.10.0 Requires-Python >=3.6, <3.10; 2.11.0 Requires-Python >=3.6, <3.10; 2.12.0 Requires-Python >=3.6, <3.10; 2.13.0 Requires-Python >=3.6, <3.10; 2.13.1 Requires-Python >=3.6, <3.10; 2.14.0 Requires-Python >=3.6, <3.10; 2.15.0 Requires-Python >=3.6, <3.10; 2.16.0 Requires-Python >=3.6, <3.10; 2.16.1 Requires-Python >=3.6, <3.10; 2.17.0 Requires-Python >=3.6, <3.10; 2.18.0 Requires-Python >=3.6, <3.10; 2.19.0 Requires-Python >=3.6, <3.10; 2.20.0 Requires-Python >=3.6, <3.10; 2.21.0 Requires-Python >=3.6, <3.10; 2.22.0 Requires-Python >=3.6, <3.10; 2.22.1 Requires-Python >=3.6, <3.10; 2.23.0 Requires-Python >=3.6, <3.10; 2.23.1 Requires-Python >=3.6, <3.10; 2.23.2 Requires-Python >=3.6, <3.10; 2.23.3 Requires-Python >=3.6, <3.10; 2.24.0 Requires-Python >=3.6, <3.10; 2.24.1 Requires-Python >=3.6, <3.10; 2.25.0 Requires-Python >=3.6, <3.10; 2.25.1 Requires-Python >=3.6, <3.10; 2.25.2 Requires-Python >=3.6, <3.10; 2.26.0 Requires-Python >=3.6, <3.10; 2.27.0 Requires-Python >=3.6, <3.10; 2.27.1 Requires-Python >=3.6, <3.10; 2.28.0 Requires-Python >=3.6, <3.10; 2.28.1 Requires-Python >=3.6, <3.10; 2.29.0 Requires-Python >=3.6, <3.10; 2.30.0 Requires-Python >=3.6, <3.11; 2.30.1 Requires-Python >=3.6, <3.11; 2.31.0 Requires-Python >=3.6, <3.11; 2.32.0 Requires-Python >=3.6, <3.11; 2.33.0 Requires-Python >=3.6, <3.11; 2.34.0 Requires-Python >=3.6, <3.11; 2.34.1 Requires-Python >=3.6, <3.11; 2.34.2 Requires-Python >=3.6, <3.11; 2.34.3 Requires-Python >=3.6, <3.11; 2.34.4 Requires-Python >=3.6, <3.11; 2.6.2 Requires-Python >=3.6, <3.9; 2.7.0 Requires-Python >=3.6, <3.10; 2.8.0 Requires-Python >=3.6, <3.10; 2.9.0 Requires-Python >=3.6, <3.10; 3.0.0 Requires-Python >=3.6, <3.11; 3.0.0b1 Requires-Python >=3.6, <3.11; 3.0.1 Requires-Python >=3.6, <3.11; 3.1.0 Requires-Python >=3.6, <3.11; 3.2.0 Requires-Python >=3.6, <3.11; 3.3.0 Requires-Python >=3.7, <3.11; 3.3.1 Requires-Python >=3.7, <3.11; 3.3.2 Requires-Python >=3.7, <3.11; 3.3.3 Requires-Python >=3.7, <3.11; 3.3.5 Requires-Python >=3.7, <3.11; 3.3.6 Requires-Python >=3.7, <3.11
ERROR: Could not find a version that satisfies the requirement pysqlite3-binary (from versions: none)
ERROR: No matching distribution found for pysqlite3-binary
```
so I never get to the stage where `cd openprescribing/openprescribing && make test` can succed.



If I try to run containerized tests in the same way as in CI I get 16 failures

```sh
$ docker-compose run --service-ports test && docker-compose run --service-ports test-production

----------------------------------------------------------------------
Ran 522 tests in 120.574s

FAILED (errors=16)
Destroying test database for alias 'default' ('test_openprescribing-test')...
```

Those errors mostly seem to be to do with creds injected via GHActions 

```sh
google.auth.exceptions.DefaultCredentialsError: File /code/google-credentials.json was not found.
```

or problems driving FireFox for FE tests

```sh
selenium.common.exceptions.WebDriverException: Message: Service /usr/bin/geckodriver unexpectedly exited. Status code was: 1
```
but I'm not confident enough about the code base to say for sure.

Please let me know if there is a better way.
Thanks, 
Laurence

