### PR TITLE
Handle price strings with previous prices

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -164,7 +164,21 @@ def parse_price(price_str):
     if price_str == "11..35":
         price_str = "£11.35"
     # We need to accept a variety of formats here: £1.50, 1.50, 1.5, 11
-    match = re.fullmatch(r"£?(\d+)(\.(\d)(\d)?)?", price_str)
+    match = re.fullmatch(
+        r"""
+        # Optional leading currency symbol
+        £ ?
+        # Pounds digits
+        ( \d+ )
+        # Optional pence digits (.N or .NN)
+        ( \. (\d) (\d)? ) ?
+        # Optional previous price in parentheses
+        \s*
+        ( \( previously \s+ [£\d\.]+ \) ) ?
+        """,
+        price_str,
+        re.VERBOSE,
+    )
     assert match, price_str
     return (
         int(match[1]) * 100

--- a/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
@@ -274,6 +274,7 @@ class TestFetchAndImportNCSOConcesions(TestCase):
             ("12.03", 1203),
             ("12", 1200),
             ("£12", 1200),
+            ("£7.02 (previously £6.17)", 702),
             # Correct weird one-off typo
             ("11..35", 1135),
         ]


### PR DESCRIPTION
This fixes the NCSO importer to handle price strings like:

    £7.02 (previously £6.17)