### PR TITLE
Update price concession calculation

### DIFF
--- a/openprescribing/frontend/tests/data_factory.py
+++ b/openprescribing/frontend/tests/data_factory.py
@@ -126,9 +126,6 @@ class DataFactory(object):
     def create_tariff_and_ncso_costings_for_presentations(
         self, presentations, months=None
     ):
-        tariff_category, _ = dmd_models.DtPaymentCategory.objects.get_or_create(
-            cd=1, descr="TariffCategory VIIIA Category A"
-        )
         for presentation in presentations:
             for date in months:
                 price_pence = self.random.randint(10, 100)
@@ -138,7 +135,7 @@ class DataFactory(object):
                     tariff_price = TariffPrice.objects.create(
                         date=date,
                         vmpp=vmpp,
-                        tariff_category=tariff_category,
+                        tariff_category=self.create_tariff_category(),
                         price_pence=price_pence,
                     )
                     if self.random.choice([True, False]):
@@ -151,6 +148,27 @@ class DataFactory(object):
                                 tariff_price.price_pence + self.random.randint(10, 100)
                             ),
                         )
+
+    def create_tariff_category(self):
+        categories = [
+            (1, "Part VIIIA Category A"),
+            (3, "Part VIIIA Category C"),
+            (5, "Part IXa"),
+            (6, "Part IXb"),
+            (7, "Part IXc"),
+            (8, "Part IXr"),
+            (9, "Part X"),
+            (10, "Parts IXb and IXc"),
+            (11, "Part VIIIA Category M"),
+            (12, "Part VIIIB"),
+            (13, "Part VIIIC"),
+            (14, "Part VIIID"),
+        ]
+        cd, descr = self.random.choice(categories)
+        tariff_category, _ = dmd_models.DtPaymentCategory.objects.get_or_create(
+            cd=cd, descr=descr
+        )
+        return tariff_category
 
     def create_prescribing_for_practice(
         self, practice, presentations=None, months=None

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -26,10 +26,13 @@ class TestSpendingViews(TestCase):
     def setUpClass(cls):
         super(TestSpendingViews, cls).setUpClass()
         factory = DataFactory()
-        cls.months = factory.create_months_array(start_date="2018-02-01", num_months=6)
+        cls.months = factory.create_months_array(start_date="2023-03-01", num_months=17)
         # Our NCSO and tariff data extends further than our prescribing data by
         # a couple of months
         cls.prescribing_months = cls.months[:-2]
+        # The test needs to span the dates when the price concession calculation changes
+        assert any(date < "2023-04-01" for date in cls.prescribing_months)
+        assert any(date > "2024-04-01" for date in cls.prescribing_months)
         # Create some high level orgs
         cls.regional_team = factory.create_regional_team()
         cls.stp = factory.create_stp()

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -171,7 +171,7 @@ class TestSpendingViews(TestCase):
 
 def round_floats(value):
     if isinstance(value, float):
-        return round(value, 5)
+        return round(value, 2)
     elif isinstance(value, list):
         return [round_floats(i) for i in value]
     elif isinstance(value, tuple):

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -1,4 +1,5 @@
 import collections
+import datetime
 
 from dateutil.parser import parse as parse_date
 from dateutil.relativedelta import relativedelta
@@ -347,9 +348,11 @@ def calculate_concession_costs(concession):
     tariff_cost_discounted = tariff_cost * (
         1 - (NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE / 100)
     )
-    concession_cost_discounted = concession_cost * (
-        1 - (NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE / 100)
-    )
+    if concession["date"] < datetime.date(2023, 4, 1):
+        concession_discount = NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE
+    else:
+        concession_discount = 0
+    concession_cost_discounted = concession_cost * (1 - (concession_discount / 100))
     return {
         "tariff_cost": tariff_cost_discounted,
         "additional_cost": concession_cost_discounted - tariff_cost_discounted,

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -55,7 +55,6 @@ from frontend.price_per_unit.substitution_sets import (
     get_substitution_sets_by_presentation,
 )
 from frontend.views.spending_utils import (
-    NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE,
     ncso_spending_breakdown_for_entity,
     ncso_spending_for_entity,
 )
@@ -1094,7 +1093,6 @@ def spending_for_one_entity(request, entity_code, entity_type):
         "breakdown_is_estimate": breakdown_metadata["is_estimate"],
         "breakdown_is_incomplete_month": breakdown_metadata["is_incomplete_month"],
         "last_prescribing_date": last_prescribing_date,
-        "national_average_discount_percentage": NATIONAL_AVERAGE_DISCOUNT_PERCENTAGE,
         "form": form,
     }
     return render(request, "spending_for_one_entity.html", context)

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -31,6 +31,7 @@
 <p><a href="#ccgchange">How do you determine ICB membership when GP practices have moved ICBs or ICBs have merged?</a></p>
 <p><a href="#fp34">Do items claimed on FP34 forms show on OpenPrescribing?</a></p>
 <p><a href="#ssps">How do items dispensed under a Serious Shortage Protocol (SSP) appear in OpenPrescribing?</a></p>
+<p><a href="#concessioncosts">How are price concession costs calculated?</a></p>
 
 <h2>Analyse</h2>
 <p><a href="#analysetutorial">How do I use the analyse page?</a></p>
@@ -167,6 +168,25 @@
 
 <h3 id="ssps">How do items dispensed under a Serious Shortage Protocol (SSP) appear in OpenPrescribing?</h3>
 <p>The BSA <a href="https://opendata.nhsbsa.net/dataset/65050ec0-5abd-48ce-989d-defc08ed837e/issues/2">have confirmed</a> that the prescribing dataset we use shows entries for items dispensed under an SSP, but does not include information on the item originally prescribed.</p>
+
+<h3 id="concessioncosts">How are price concession costs calculated?</h3>
+<p>
+  The extra costs for an organisation implied by a price concession are
+  calculated as the difference between the drug tariff price and the concession
+  price <em>after</em> applying the relevant discounts, multiplied by the
+  quantity prescribed by that organisation.
+</p>
+<p>
+  For concessions prior to April 2023 we appply the national average discount
+  of 7.2% to both the tariff price and the concession price. From April 2023
+  onwards we no longer apply any discount to the concession price, as <a
+    href="https://cpe.org.uk/our-news/changes-to-discount-deduction-arrangements-from-april-2023/">specified
+    by CPE</a>. From April 2024, we apply a different discount rate to tariff
+  prices depending on the <a
+    href="https://www.drugtariff.nhsbsa.nhs.uk/#/00857004-DC/DC00856269/Part%20V%20-%20Deduction%20Scale%20(Pharmacy%20Contractors)">category
+    of the product</a>: 20% for generics, 9.85% discount for appliances and 5%
+  discount for everything else.
+</p>
 
 <h2>Analyse</h2>
 <h3 id="analysetutorial">How do I use the analyse page?</h3>

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -20,7 +20,7 @@
   Standard prices are updated monthly from
   <a href="https://www.nhsbsa.nhs.uk/pharmacies-gp-practices-and-appliance-contractors/drug-tariff">NHS BSA</a>,
   concession data is updated daily from
-  <a href="http://psnc.org.uk/dispensing-supply/supply-chain/generic-shortages/ncso-archive/">PSNC</a>.
+  <a href="https://cpe.org.uk/funding-and-reimbursement/reimbursement/price-concessions/archive/">CPE</a>.
 </p>
 <p>
   Over the last 12 months we estimate that price concessions have cost

--- a/openprescribing/templates/spending_for_one_entity.html
+++ b/openprescribing/templates/spending_for_one_entity.html
@@ -76,8 +76,8 @@
     {% endif %}
     <br><br>
   {% endif %}
-  Actual costs are estimated from the Net Ingredient Cost by applying a national average discount of
-  {{ national_average_discount_percentage }}%
+  Actual costs are estimated from the Net Ingredient Cost by applying the
+  <a href="{% url 'faq' %}#concessioncosts">appropriate discounts</a>.
 </div>
 
 <br>


### PR DESCRIPTION
This involves two changes:

1. Applying a zero discount to concession prices from April 2023:
   https://cpe.org.uk/our-news/changes-to-discount-deduction-arrangements-from-april-2023/

2. Applying per-category discounts to drug tariff prices from April 2024:
   https://www.drugtariff.nhsbsa.nhs.uk/#/00857004-DC/DC00856269/Part%20V%20-%20Deduction%20Scale%20(Pharmacy%20Contractors)

Closes #4860 