### PR TITLE
Actually maybe fix BNF code replacements

### DIFF
--- a/openprescribing/frontend/management/commands/generate_presentation_replacements.py
+++ b/openprescribing/frontend/management/commands/generate_presentation_replacements.py
@@ -106,9 +106,12 @@ def create_code_mapping(filenames):
     bnf_map = []
     for f in filenames:
         for line in open(f, "r"):
-            if not line.strip():
+            line = line.strip()
+            if not line:
                 continue  # skip blank lines
-            if "\t" not in line:
+            elif line.startswith("#"):
+                continue  # skip comments
+            elif "\t" not in line:
                 raise CommandError("Input lines must be tab delimited: %s" % line)
             prev_code, next_code = line.split("\t")
             prev_code = prev_code.strip()

--- a/openprescribing/frontend/management/commands/presentation_replacements/2024_07_09.txt
+++ b/openprescribing/frontend/management/commands/presentation_replacements/2024_07_09.txt
@@ -1,3 +1,6 @@
+# These are presentation replacements which should be removed. See:
+# https://github.com/ebmdatalab/openprescribing/issues/4876#issuecomment-2213952291
+
 0302000W0AAAAAA	REMOVED
 0302000W0BBAAAA	REMOVED
 0407010X0CDACBF	REMOVED


### PR DESCRIPTION
The changes made in #4879 were incorrect because (for reasons that I still don't fully understand) changes are applied in reverse date order. After experimentation I have determined that this does make a non-trivial difference to the set of replacements we end up and so I want to revert to the original behaviour.

To fix the specific problem #4879 was supposed to address I introduce a mechanism for explicitly marking mappings as removed.