### PR TITLE
Display latest news from blog on homepage

### DIFF
--- a/deploy/crontab-openprescribing
+++ b/deploy/crontab-openprescribing
@@ -7,3 +7,4 @@
 00 05 * * * hello /webapps/openprescribing/deploy/diskcache_garbage_collect.sh
 30 05 * * * hello /webapps/openprescribing/deploy/clearsessions.sh
 12 06 * * 1 hello /webapps/openprescribing/deploy/maillog_garbage_collect.sh
+*/5 * * * * hello /webapps/openprescribing/deploy/refresh_news_feed_cache.sh

--- a/deploy/refresh_news_feed_cache.sh
+++ b/deploy/refresh_news_feed_cache.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. /webapps/openprescribing/.venv/bin/activate
+python /webapps/openprescribing/openprescribing/manage.py refresh_news_feed_cache

--- a/openprescribing/frontend/management/commands/refresh_news_feed_cache.py
+++ b/openprescribing/frontend/management/commands/refresh_news_feed_cache.py
@@ -1,0 +1,39 @@
+import datetime
+
+import requests
+
+from django.core.cache import cache
+from django.core.management.base import BaseCommand
+
+
+FEED_URL = "https://www.bennett.ox.ac.uk/blog/index.json"
+
+
+class Command(BaseCommand):
+    help = f"Fetch and cache news items from:\n{FEED_URL}"
+
+    def handle(self, *args, **options):
+        response = requests.get(FEED_URL)
+        response.raise_for_status()
+        feed_data = response.json()
+        items = [
+            format_news_item(**item)
+            for item in feed_data["posts"]
+            if is_openprescribing_news_item(**item)
+        ]
+        cache.set("news_feed", items, timeout=60 * 60 * 24 * 365)
+
+
+def is_openprescribing_news_item(*, categories, tags, **kwargs):
+    if not categories or "OpenPrescribing" not in categories:
+        return False
+    if not tags or "news" not in tags:
+        return False
+    return True
+
+
+def format_news_item(*, date, **kwargs):
+    return {
+        "date": datetime.datetime.fromisoformat(date),
+        **kwargs,
+    }

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -88,9 +88,15 @@ def first_or_none(lst):
         return None
 
 
+def home(request):
+    return render(request, "index.html", {})
+
+
 ##################################################
 # BNF sections
 ##################################################
+
+
 def all_bnf(request):
     sections = Section.objects.filter(is_current=True)
     context = {"sections": sections, **get_org_context(request.GET)}

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -89,7 +89,13 @@ def first_or_none(lst):
 
 
 def home(request):
-    return render(request, "index.html", {})
+    return render(
+        request,
+        "index.html",
+        {
+            "news_feed": cache.get("news_feed", [])[:3],
+        },
+    )
 
 
 ##################################################

--- a/openprescribing/media/css/homepage.less
+++ b/openprescribing/media/css/homepage.less
@@ -16,3 +16,12 @@
   left: 45px;
   color: #ccc;
 }
+
+.latest-news-item {
+  margin-bottom: 20px;
+  img {
+    display: block;
+    width: 200px;
+    border-radius: 6px;
+  }
+}

--- a/openprescribing/openprescribing/urls.py
+++ b/openprescribing/openprescribing/urls.py
@@ -48,8 +48,8 @@ def all_england_redirects(request, *args, **kwargs):
 
 
 urlpatterns = [
+    path(r"", views.home, name="home"),
     # Static pages.
-    path(r"", TemplateView.as_view(template_name="index.html"), name="home"),
     path(r"api/", TemplateView.as_view(template_name="api.html"), name="api"),
     path(r"about/", TemplateView.as_view(template_name="about.html"), name="about"),
     path(r"faq/", TemplateView.as_view(template_name="faq.html"), name="faq"),

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 {% load template_extras %}
+{% load static %}
 
 {% block title %}Home{% endblock %}
 {% block active_class %}home{% endblock %}
 
 {% block content %}
 
-<h1>Explore England's prescribing data</h1>
 
 <div class="row">
 
   <div class="col-md-9">
+
+    <h1>Explore England's prescribing data</h1>
 
     <p>Every month, the NHS in England publishes <a href="https://digital.nhs.uk/practice-level-prescribing-summary">anonymised data</a> about the drugs prescribed by GPs. But the raw data files are large and unwieldy, with more than 700 million rows. We're making it easier for GPs, managers and everyone to explore - supporting safer, more efficient prescribing.</p>
 
@@ -54,7 +56,18 @@
   </div>
 
   <div class="col-md-3">
-    {% include '_mailchimp_signup.html' %}
+    <h3>Latest News</h3>
+
+    <div class="latest-news-item">
+      <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
+        <img src="{% static 'img/footer-bennett.svg' %}">
+      </a>
+      <p style="margin-top: 5px">
+        <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
+          Read the latest news from OpenPrescribing on the Bennett Institute blog
+        </a>
+      </p>
+    </div>
   </div>
 
 </div>

--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -58,16 +58,33 @@
   <div class="col-md-3">
     <h3>Latest News</h3>
 
-    <div class="latest-news-item">
-      <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
-        <img src="{% static 'img/footer-bennett.svg' %}">
-      </a>
-      <p style="margin-top: 5px">
-        <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
-          Read the latest news from OpenPrescribing on the Bennett Institute blog
-        </a>
-      </p>
-    </div>
+    {% if news_feed %}
+
+      {% for item in news_feed %}
+
+        <div class="latest-news-item">
+          <a href="{{ item.link }}"><img src="{{ item.image }}"></a>
+          <small class="text-muted">{{ item.date | date:"j M Y" }}</small>
+          <p><a href="{{ item.link }}">{{ item.title }}</a></p>
+        </div>
+
+      {% endfor %}
+
+    {% else %}
+
+        <div class="latest-news-item">
+          <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
+            <img src="{% static 'img/footer-bennett.svg' %}">
+          </a>
+          <p style="margin-top: 5px">
+            <a href="https://www.bennett.ox.ac.uk/openprescribing/blog/">
+              Read the latest news from OpenPrescribing on the Bennett Institute blog
+            </a>
+          </p>
+        </div>
+
+    {% endif %}
+
   </div>
 
 </div>


### PR DESCRIPTION
This replaces the sign-up form on the homepage with the latest three OpenPrescribing news posts from the Bennett blog. (Note that only two appear at the moment because there are only two matching posts.)

![Screenshot from 2024-09-12 09-15-48](https://github.com/user-attachments/assets/089a65bb-b43a-4ea6-8f14-c00dc58fd1c9)

If, for whatever reason, the latest posts aren't available we fall back to a generic Bennett logo and a link to the blog.

![Screenshot from 2024-09-12 09-16-22](https://github.com/user-attachments/assets/256a0fc9-2f8b-48b2-b4f1-9a919539d494)


No tests! Because this is a simple non-critical feature and I have other things to be doing. 

Closes #4864