### PR TITLE
Pin version of `html2text`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,8 @@ google-cloud-bigquery
 google-cloud-storage
 google-cloud-bigquery-storage  # this speeds up access to BQ
 gunicorn
-html2text
+# Newer versions break on our email contents (see #5017)
+html2text==2020.1.16
 html5lib
 lxml
 lz4


### PR DESCRIPTION
Newer versions choke when trying to reformat our email content and it doesn't seem worthwhile spending time to work out what the issue is.

This test demonstrates the issue:

    SKIP_NPM_BUILD=True ./manage.py test --keepdb \
      frontend.tests.commands.test_send_all_england_alerts.CommandTestCase.test_send_alerts

The failure looks like this:

    Traceback (most recent call last):
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/tests/commands/test_send_all_england_alerts.py", line 23, in test_send_alerts
        call_command("send_all_england_alerts")
      File "/home/dave/.virtualenvs/ebm-openprescribing/lib/python3.12/site-packages/django/core/management/__init__.py", line 194, in call_command
        return command.execute(*args, **defaults)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/.virtualenvs/ebm-openprescribing/lib/python3.12/site-packages/django/core/management/base.py", line 458, in execute
        output = self.handle(*args, **options)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/management/commands/send_all_england_alerts.py", line 24, in handle
        send_alerts(recipient_email=recipient_email)
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/management/commands/send_all_england_alerts.py", line 43, in send_alerts
        error_deferrer.try_email(send_alert, bookmark, date)
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/common/alert_utils.py", line 39, in try_email
        return  callback(*args)
                ^^^^^^^^^^^^^^^
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/management/commands/send_all_england_alerts.py", line 73, in send_alert
        message = bookmark_utils.make_all_england_email(bookmark, tag=date)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/views/bookmark_utils.py", line 917, in make_all_england_email
        finalise_email(
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/frontend/views/bookmark_utils.py", line 689, in finalise_email
        text = email_as_text(html)
               ^^^^^^^^^^^^^^^^^^^
      File "/home/dave/projects/ebmdatalab/openprescribing/openprescribing/common/utils.py", line 65, in email_as_text
        text = text_maker.handle(html)
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/.virtualenvs/ebm-openprescribing/lib/python3.12/site-packages/html2text/__init__.py", line 149, in handle
        return pad_tables_in_text(markdown)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/.virtualenvs/ebm-openprescribing/lib/python3.12/site-packages/html2text/utils.py", line 280, in pad_tables_in_text
        table = reformat_table(table_buffer, right_margin)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/dave/.virtualenvs/ebm-openprescribing/lib/python3.12/site-packages/html2text/utils.py", line 229, in reformat_table
        max_width = [len(x.rstrip()) + right_margin for x in lines[0].split("|")]
                                                             ~~~~~^^^
    IndexError: list index out of range

Here's the original Dependabot PR with links to the changelog:
 * https://github.com/ebmdatalab/openprescribing/pull/4677