### PR TITLE
Remove STAR-PUs

### DIFF
--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -68,7 +68,6 @@
                 <option value="nothing" selected>nothing</option>
                 <option value="chemical">drugs or BNF sections</option>
                 <option value="total_list_size" selected>total list size</option>
-                <option value="star_pu.oral_antibacterials_item">STAR-PUs for antibiotics</option>
             </select>
         </div>
         <div class="col right">

--- a/openprescribing/templates/faq.html
+++ b/openprescribing/templates/faq.html
@@ -197,11 +197,9 @@
 
 <p>You can use "list size" which tells you how many patients a practice covers, but this can be problematic, because different practices will have different kinds of patients, some with lots of older people, and so on.</p>
 
-<p>To account for this the NHS uses imperfect but useful "adjusted" denominators called STAR-PUs, which try to account for the age and sex structure of the practice's population. These STAR-PUs are specific to specific disease areas, because they try to account for different rates of usage -- in different age bands of the population - for specific treatment. So for the STAR-PU for cardiovascular disease prevention prescribing, for example, gives you extra points for every man aged 40-50, even more for men aged 50-60, and so on; but less for women in the same bands, and very little for younger people.</p>
-
-<p>Generating these STAR-PUs for each practice, each disease area, and each month, takes coder time, so we currently only have the STAR-PU for antibiotics.</p>
-
 <p>When using the data ourselves we tend to use more thoughtful approaches to try to "bake in" population prevalence or need for a particular condition, or to explore different prescribing patterns. For example, we often use whole classes of drug as the denominator in our analyses, as in the video walkthroughs; or we compare the use of one drug against the use of another. When looking at whether a practice is using a lot of Nexium (an expensive "proton pump inhibitor" pill for treating ulcers) we might look at "Nexium prescribing" versus "all proton pump inhibitor prescribing" (<a href="{% url 'analyse' %}#org=Sub-ICB Location&numIds=0103050E0BB&denomIds=1.3.5">example</a>).</p>
+
+<p>We have removed STAR-PUs as a denominator option on our analysis page and from several of our pre-built antibiotic measures. This decision was made following user consultation, due to concerns about the appropriateness of the STAR-PU weightings, which have not been reviewed since 2013. You can read more about this in our <a href="https://www.bennett.ox.ac.uk/blog/2024/02/star-pus-should-we-still-be-using-them/">blog</a>.</p>
 
 <p>Play around and <a href="mailto:{{ FEEDBACK_MAILTO }}">let us know</a> if you find anything interesting, or develop any interesting methods.</p>
 


### PR DESCRIPTION
Update FAQ to explain why we don't have STAR-PUs as a denominator any longer.
Remove STAR-PU from analyse dropdown options - **should get tech team review/opinion on this**.

With this STAR-PU won't be selectable - but is still being calculated - so could be added to analyse URL/used in a measure if unexpectedly needed again in future (I presume isn't using much resource to calculate).