### PR TITLE
Rename ebmbot fabric user to bennettbot

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -10,7 +10,7 @@ from fabric.contrib.files import exists
 env.hosts = ["web2.openprescribing.net"]
 env.forward_agent = True
 env.colorize_errors = True
-env.user = "ebmbot"
+env.user = "bennettbot"
 
 environments = {"production": "openprescribing", "staging": "openprescribing_staging"}
 

--- a/openprescribing/frontend/management/commands/delete_measure.py
+++ b/openprescribing/frontend/management/commands/delete_measure.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
     def handle(self, measure_id, **options):
         if not options["delete_live_measure"]:
             if not measure_id.startswith(settings.MEASURE_PREVIEW_PREFIX):
-                # We want these errors to be visble to users who run via ebmbot but the
+                # We want these errors to be visble to users who run via bennettbot but the
                 # only way to achieve that is to write them to stderr and exit 0 :(
                 self.stdout.write(
                     f"Not deleting '{measure_id}' because it doesn't look like a "

--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             upload_supplementary_tables()
             measure_id = import_preview_measure(github_url)
         except BadRequest as e:
-            # We want these errors to be visble to users who run via ebmbot but the only
+            # We want these errors to be visble to users who run via bennettbot but the only
             # way to achieve that is to write them to stderr and exit 0 :(
             self.stdout.write(
                 f"Importing measure preview failed for {github_url}\n\n{e.message}"


### PR DESCRIPTION
The ebmbot user on all servers is being renamed to bennettbot; update the fabric user to match.

Also fixes a couple of ebmbot references in comments (these refer to the bot itself rather than the user on the server).

See https://github.com/ebmdatalab/bennettbot/issues/551