### PR TITLE
Post monthly update notifications to #openprescribing

### DIFF
--- a/environment-sample
+++ b/environment-sample
@@ -40,6 +40,7 @@ GUNICORN_LOG_LEVEL=warn
 
 SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
 SLACK_TEAM_POST_KEY=slack_team_post_key
+SLACK_OP_POST_KEY=slack_op_post_key
 CF_API_KEY=cf_api_key
 
 # The path to a file containing your credentials for accessing Google Cloud

--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -342,9 +342,10 @@ GRAB_HOST = "https://openprescribing.net"
 
 # For sending messages to Slack
 # Webhook URLs for posting to different channels can be configured at
-# https://api.slack.com/apps/A6B85C8KC/incoming-webhooks
+# https://api.slack.com/apps/A03UM1N45JN/incoming-webhooks
 SLACK_TECHNOISE_POST_KEY = utils.get_env_setting("SLACK_TECHNOISE_POST_KEY", default="")
 SLACK_TEAM_POST_KEY = utils.get_env_setting("SLACK_TEAM_POST_KEY", default="")
+SLACK_OP_POST_KEY = utils.get_env_setting("SLACK_OP_POST_KEY", default="")
 SLACK_SENDING_ACTIVE = True
 
 

--- a/openprescribing/openprescribing/slack.py
+++ b/openprescribing/openprescribing/slack.py
@@ -2,22 +2,26 @@ import requests
 from django.conf import settings
 
 
-def notify_slack(message, is_error=False):
-    """Posts the message to #technoise
+def notify_slack(message, is_error=False, channel="default"):
+    """Posts the message to #technoise by default
 
     See https://my.slack.com/services/new/incoming-webhook/
     """
     if not settings.SLACK_SENDING_ACTIVE:
         return
 
-    webhook_url = settings.SLACK_TECHNOISE_POST_KEY
-    team_webhook_url = settings.SLACK_TEAM_POST_KEY
+    webhooks = {
+        "default": settings.SLACK_TECHNOISE_POST_KEY,
+        "op": settings.SLACK_OP_POST_KEY,
+        "dev_team": settings.SLACK_TEAM_POST_KEY,
+    }
+    webhook_url = webhooks.get(channel, webhooks["default"])
     slack_data = {"text": message}
 
     response = requests.post(webhook_url, json=slack_data)
     if is_error:
         # Also post error messages to relevant team channel
-        response = requests.post(team_webhook_url, json=slack_data)
+        response = requests.post(webhooks["dev_team"], json=slack_data)
 
     if response.status_code != 200:
         raise ValueError(

--- a/openprescribing/pipeline/runner.py
+++ b/openprescribing/pipeline/runner.py
@@ -453,7 +453,8 @@ def run_all(year, month, under_test=False):
     )
 
     if not under_test:
-        notify_slack(msg)
+        # Notify the openprescribing slack channel
+        notify_slack(msg, channel="op")
 
 
 def in_progress():


### PR DESCRIPTION
Adds a SLACK_OP_POST_KEY setting for posting messages to the #openprescribing channel directly. This means they don't have to be manually picked up and reposted from #tech-noise.

The new webhook URL is already created and set in the environment file.