### PR TITLE
Fix links to measure in email alerts

### DIFF
--- a/openprescribing/frontend/templatetags/template_extras.py
+++ b/openprescribing/frontend/templatetags/template_extras.py
@@ -4,6 +4,7 @@ from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 register = template.Library()
@@ -98,3 +99,12 @@ def fancy_join(lst, sep=", ", final_sep=" and "):
 @register.filter
 def username_from_email(email):
     return email.split("@")[0]
+
+
+@register.simple_tag(takes_context=True)
+def dashboard_measure_uri(context, measure):
+    return format_html(
+        "{}#{}",
+        context["dashboard_uri"],
+        measure.id,
+    )

--- a/openprescribing/frontend/templatetags/template_extras.py
+++ b/openprescribing/frontend/templatetags/template_extras.py
@@ -104,7 +104,10 @@ def username_from_email(email):
 @register.simple_tag(takes_context=True)
 def dashboard_measure_uri(context, measure):
     return format_html(
-        "{}#{}",
+        "{}&tags={}#{}",
         context["dashboard_uri"],
+        # It doesn't matter which tag we chose, it just needs to be one that the target
+        # measure has so we know it will appear on the linked dashboard
+        measure.tags[0],
         measure.id,
     )

--- a/openprescribing/templates/bookmarks/email_for_measures.html
+++ b/openprescribing/templates/bookmarks/email_for_measures.html
@@ -17,16 +17,16 @@
       {% for measure in stats.worst %}
         {% if forloop.first %}
           <p>Over the last three months, we found that this {{ bookmark.org_type }} was in the worst 10% on
-          <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>:<br>
-          <a href="{{ dashboard_uri }}#{{measure.id}}"><img src="cid:{{ still_bad_image }}"></a><br>
+          <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>:<br>
+          <a href="{% dashboard_measure_uri measure %}"><img src="cid:{{ still_bad_image }}"></a><br>
         {% elif stats.worst|length == 2 %}
-          It was also in the worst 10% on <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>.
+          It was also in the worst 10% on <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>.
         {% else %}
           {% if forloop.counter == 2 %}
             It was also in the worst 10% on:
             <ul>
           {% endif %}
-              <li><a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a></li>
+              <li><a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a></li>
           {% if forloop.last %}
             </ul>
           {% endif %}
@@ -39,16 +39,16 @@
     <p>
       {% for d in stats.most_changing.declines %}
         {% if forloop.counter == 1 %}
-          In comparison with other {{ bookmark.org_type }}s, we found that this {{ bookmark.org_type }} slipped {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>:<br>
-        <a href="{{ dashboard_uri }}#{{d.measure.id}}"><img src="cid:{{ getting_worse_image }}"></a><br>
+          In comparison with other {{ bookmark.org_type }}s, we found that this {{ bookmark.org_type }} slipped {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>:<br>
+        <a href="{% dashboard_measure_uri d.measure %}"><img src="cid:{{ getting_worse_image }}"></a><br>
         {% elif stats.most_changing.declines|length == 2 %}
-          It also slipped {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>.
+          It also slipped {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>.
         {% else %}
           {% if forloop.counter == 2 %}
            It also slipped:
            <ul>
           {% endif %}
-            <li>{{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a></li>
+            <li>{{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a></li>
           {% if forloop.last %}
            </ul>
           {% endif %}
@@ -63,14 +63,14 @@
     <p>We looked at all the measures where this organisation could have saved at least £1,000 in the last six months.
 
     {% if stats.top_savings.possible_savings|length_is:1 %}
-      We found that if it had prescribed in line with the average {{ bookmark.org_type }}, it could have saved about <b>£{{ stats.top_savings.possible_savings.0.1|roundpound }}</b> on <a href="{{ dashboard_uri }}#{{stats.top_savings.possible_savings.0.0.id}}">{{stats.top_savings.possible_savings.0.0.name}}</a>.</p>
+      We found that if it had prescribed in line with the average {{ bookmark.org_type }}, it could have saved about <b>£{{ stats.top_savings.possible_savings.0.1|roundpound }}</b> on <a href="{% dashboard_measure_uri stats.top_savings.possible_savings.0.0 %}">{{stats.top_savings.possible_savings.0.0.name}}</a>.</p>
     {% else %}
       </p>
       <p>These add up to around <b>£{{total_possible_savings|roundpound}}</b> of potential savings. If it had prescribed in line with the average {{ bookmark.org_type }}, it could have saved about:</p>
 
       <ul>
         {% for measure, saving in stats.top_savings.possible_savings %}
-        <li><b>£{{saving|roundpound}}</b> on <a href="{{ dashboard_uri }}#{{measure.id}}">{{measure.name}}</a></li>
+        <li><b>£{{saving|roundpound}}</b> on <a href="{% dashboard_measure_uri measure %}">{{measure.name}}</a></li>
         {% endfor %}
       </ul>
     {% endif %}
@@ -88,15 +88,15 @@
     {% for measure in stats.best %}
       {% if forloop.first %}
         <p>Over the last three months, we found that this {{ bookmark.org_type }} was in the best 10% on
-        <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>.
+        <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>.
       {% elif stats.best|length == 2 %}
-        It was also in the best 10% on <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>.</p>
+        It was also in the best 10% on <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>.</p>
       {% else %}
         {% if forloop.counter == 2 %}</p>
           It was also in the best 10% on:
           <ul>
         {% endif %}
-            <li><a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a></li>
+            <li><a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a></li>
         {% if forloop.last %}
           </ul>
         {% endif %}
@@ -108,16 +108,16 @@
     <h3 class="better">Prescribing measures which are getting better</h3>
       {% for d in stats.most_changing.improvements %}
         {% if forloop.counter == 1 %}
-          <p>In comparison with other {{ bookmark.org_type }}s, we found that this {{ bookmark.org_type }} improved {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>.
+          <p>In comparison with other {{ bookmark.org_type }}s, we found that this {{ bookmark.org_type }} improved {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>.
         {% elif stats.most_changing.improvements|length == 2 %}
-          It also improved {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>.</p>
+          It also improved {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>.</p>
         {% else %}
           {% if forloop.counter == 2 %}
            </p>
            It also improved:
            <ul>
           {% endif %}
-            <li>{{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a></li>
+            <li>{{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a></li>
           {% if forloop.last %}
            </ul>
           {% endif %}
@@ -133,16 +133,16 @@
       {% for measure in stats.interesting %}
         {% if forloop.first %}
           <p>Over the last three months, we found that this {{ bookmark.org_type }} deviated a long way from the median {{ bookmark.org_type }} on
-          <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>:<br>
-          <a href="{{ dashboard_uri }}#{{measure.id}}"><img src="cid:{{ interesting_image }}"></a><br>
+          <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>:<br>
+          <a href="{% dashboard_measure_uri measure %}"><img src="cid:{{ interesting_image }}"></a><br>
         {% elif stats.interesting|length == 2 %}
-          It was also an outlier on <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>.
+          It was also an outlier on <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>.
         {% else %}
           {% if forloop.counter == 2 %}
             It was also an outlier on:
             <ul>
           {% endif %}
-              <li><a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a></li>
+              <li><a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a></li>
           {% if forloop.last %}
             </ul>
           {% endif %}
@@ -153,16 +153,16 @@
   {% if stats.most_changing_interesting %}
       {% for d in stats.most_changing_interesting %}
         {% if forloop.counter == 1 %}
-          <p>We found that over the last {{ d.period }} months this {{ bookmark.org_type }} moved {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>.
+          <p>We found that over the last {{ d.period }} months this {{ bookmark.org_type }} moved {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>.
         {% elif stats.most_changing.improvements|length == 2 %}
-          It also changed {{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a>.</p>
+          It also changed {{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a>.</p>
         {% else %}
           {% if forloop.counter == 2 %}
            </p>
            It also changed:
            <ul>
           {% endif %}
-            <li>{{d.from|deltawords:d.to}} on <a href="{{ dashboard_uri }}#{{d.measure.id}}">{{ d.measure.name }}</a></li>
+            <li>{{d.from|deltawords:d.to}} on <a href="{% dashboard_measure_uri d.measure %}">{{ d.measure.name }}</a></li>
           {% if forloop.last %}
            </ul>
           {% endif %}
@@ -173,12 +173,12 @@
   {% if stats.top_savings.achieved_savings %}
    <h3 class="better">Achieved savings</h3>
    {% if stats.top_savings.achieved_savings|length == 1 %}
-    <p>By prescribing <a href="{{ dashboard_uri }}#{{stats.top_savings.achieved_savings.0.0.id}}">{{ stats.top_savings.achieved_savings.0.0.name }}</a> better than the median, this {{bookmark.org_type }} saved around <b>£{{stats.top_savings.achieved_savings.0.1|roundpound}}</b> over the past 6 months. </p>
+    <p>By prescribing <a href="{% dashboard_measure_uri stats.top_savings.achieved_savings.0.0 %}">{{ stats.top_savings.achieved_savings.0.0.name }}</a> better than the median, this {{bookmark.org_type }} saved around <b>£{{stats.top_savings.achieved_savings.0.1|roundpound}}</b> over the past 6 months. </p>
     {% else %}
     Over the past 6 months, by prescribing better than the median, this {{bookmark.org_type }} saved around:
      <ul>
      {% for measure, saving in stats.top_savings.achieved_savings %}
-       <li><b>£{{saving|roundpound}}</b> on <a href="{{ dashboard_uri }}#{{measure.id}}">{{ measure.name }}</a>
+       <li><b>£{{saving|roundpound}}</b> on <a href="{% dashboard_measure_uri measure %}">{{ measure.name }}</a>
         </li>
      {% endfor %}
      </ul>

--- a/openprescribing/templates/bookmarks/email_for_measures.html
+++ b/openprescribing/templates/bookmarks/email_for_measures.html
@@ -173,7 +173,7 @@
   {% if stats.top_savings.achieved_savings %}
    <h3 class="better">Achieved savings</h3>
    {% if stats.top_savings.achieved_savings|length == 1 %}
-    <p>By prescribing <a href="{{ dashboard_uri }}#{{measure.id}}">{{ stats.top_savings.achieved_savings.0.0.name }}</a> better than the median, this {{bookmark.org_type }} saved around <b>£{{stats.top_savings.achieved_savings.0.1|roundpound}}</b> over the past 6 months. </p>
+    <p>By prescribing <a href="{{ dashboard_uri }}#{{stats.top_savings.achieved_savings.0.0.id}}">{{ stats.top_savings.achieved_savings.0.0.name }}</a> better than the median, this {{bookmark.org_type }} saved around <b>£{{stats.top_savings.achieved_savings.0.1|roundpound}}</b> over the past 6 months. </p>
     {% else %}
     Over the past 6 months, by prescribing better than the median, this {{bookmark.org_type }} saved around:
      <ul>


### PR DESCRIPTION
We link to measures by linking to the appropriate organisation dashboard and including a fragment identifier which causes the JS to jump to and highlight the target measure. However this only works if the measure is actually on the page. By default the dashboard only displays measures tagged `core`. And so all links to non-core measures were effectively broken.

We don't include many non-core measures in the alerts which is why this issue wasn't more obvious. But we certainly do include the Low Priority Prescribing measures, and possibly others, so this needed fixing.

Closes #4588