### PR TITLE
Fix logic for selecting practices by SICBL

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -367,9 +367,10 @@ def spending_by_org(request, format=None, org_type=None):
 
 def _get_org_type_and_orgs(org_type, org_ids):
     org_type = utils.translate_org_type(org_type)
+    select_all_orgs = not org_ids
 
     # If no org parameters are supplied then we sum over absolutely everything
-    if org_type is None and not org_ids:
+    if org_type is None and select_all_orgs:
         return "all_practices", [AllEngland()]
 
     # Some special case handling for practices
@@ -397,7 +398,7 @@ def _get_org_type_and_orgs(org_type, org_ids):
         raise ValidationError(detail="Error: unrecognised org_type parameter")
 
     # Filter and sort
-    if org_ids:
+    if not select_all_orgs:
         orgs = orgs.filter(code__in=org_ids)
     orgs = orgs.order_by("code")
 


### PR DESCRIPTION
The API allows you to retrieve practice-level data by supplying a 3-character code for a SICBL/CGG which then selects all the practices belonging to it. However, previously, if you supplied the code of a closed SICBL with no practices it would end up returning five years' worth of data for every practice in England. Not only is this an incorrect respond but it takes a lot of server resources to generate and has the side effect of segfaulting PhantomJS when it tries to render the chart image.

This PR applies the smallest fix to prevent it doing this.