### PR TITLE
Set default ordering of PCNs

### DIFF
--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -129,6 +129,9 @@ class PCN(models.Model):
 
     HUMAN_NAME = "PCN"
 
+    class Meta:
+        ordering = ['name']
+
     def __str__(self):
         return self.name
 

--- a/openprescribing/frontend/models.py
+++ b/openprescribing/frontend/models.py
@@ -130,7 +130,7 @@ class PCN(models.Model):
     HUMAN_NAME = "PCN"
 
     class Meta:
-        ordering = ['name']
+        ordering = ["name"]
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
This is so that on a page such as https://openprescribing.net/sicbl/15E/  the PCN list is shown in alphabetical order.