### PR TITLE
Fix link to cost saving measures

### DIFF
--- a/openprescribing/templates/bookmarks/email_for_measures.html
+++ b/openprescribing/templates/bookmarks/email_for_measures.html
@@ -79,7 +79,7 @@
   {% if stats.top_savings.possible_top_savings_total > 5000 %}
     <h3>Best-case possible savings</h3>
       <p>We compared this {{ bookmark.org_type }}'s spending with the best-performing 10% on all the areas we track.  If it prescribed as well as those {{ bookmark.org_type }}s, it could save around <b>£{{stats.top_savings.possible_top_savings_total|roundpound}}</b>.
-      <a href="{{ dashboard_uri }}&sortBySavings=1">Here's a list of measures, sorted by potential cost savings</a>.
+      <a href="{{ dashboard_uri }}&tags=cost&sortBySavings=1">Here's a list of measures, sorted by potential cost savings</a>.
     </p>
   {% endif %}
 


### PR DESCRIPTION
Previously the link to you to a page showing "core" measures which didn't always include the relevant measures.

Closes #5082