### PR TITLE
Replace dependabot with update-dependencies-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,10 @@
 version: 2
+
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-  rebase-strategy: "disabled"
-  open-pull-requests-limit: 99
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-  groups:
-    dependencies:
-      applies-to: version-updates
-      dependency-type: "production"
-  ignore:
-  # Newer versions break on our email contents (see #5017)
-  - dependency-name: html2text
-    versions:
-    - "> 2020.1.16"
-  # We're just not interested in messing around with updates to this module
-  # (changes to its capitalisation rules break our tests)
-  - dependency-name: titlecase
-    versions:
-    - "> 0.12.0"
-  # Version 4.2 is the latest Django LTS version, we want patch updates to that
-  # but no major version updates until we manually upgrade to the next LTS
-  - dependency-name: django
-    versions:
-    - ">= 4.3"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore: "

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,31 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "5 3 * * MON"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
+      with:
+        app-id: ${{ secrets.CREATE_PR_APP_ID }}
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: opensafely-core/update-dependencies-action@v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+        automerge: false
+        pr_title: "Update python dependencies"
+        update_command: |
+          pip install pip-tools && \
+          pip-compile -U requirements.dev.in && \
+          pip-compile -U requirements.in


### PR DESCRIPTION
Replace dependabot for python dependencies. 

Update dependabot to check for github actions updates only.