### PR TITLE
Bump gunicorn's limit-request-line setting

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -67,7 +67,8 @@ cmd="gunicorn openprescribing.wsgi:application \
   --timeout $GUNICORN_TIMEOUT \
   --log-level=$GUNICORN_LOG_LEVEL \
   --log-file=$LOGFILE \
-  --access-logfile=$ACCESS_LOGFILE"
+  --access-logfile=$ACCESS_LOGFILE \
+  --limit-request-line=8190"
 
 if [[ ! -z $CHECK_CONFIG ]]; then
     cmd="$cmd --check-config"


### PR DESCRIPTION
This setting controls the maximum size of HTTP request lines.  For some measures (eg silver dressings), the link to the analyse page is long enough to go over the default.  8190 is the maximum we can set it without setting it to be unlimited.

More: https://docs.gunicorn.org/en/stable/settings.html#limit-request-line