### PR TITLE
Ignore comment-only lines in BNF code list

### DIFF
--- a/openprescribing/frontend/management/commands/import_measures.py
+++ b/openprescribing/frontend/management/commands/import_measures.py
@@ -471,7 +471,10 @@ def build_bnf_codes_query_where(filter_):
 
     for element in filter_:
         element = element.split("#")[0].strip()
-        if element[0] == "~":
+        if not element:
+            # Ignore codes which are completely commented out
+            pass
+        elif element[0] == "~":
             excludes.append(build_bnf_codes_query_fragment(element[1:]))
         else:
             includes.append(build_bnf_codes_query_fragment(element))

--- a/openprescribing/frontend/tests/commands/test_import_measures.py
+++ b/openprescribing/frontend/tests/commands/test_import_measures.py
@@ -382,6 +382,7 @@ class BuildMeasureSQLTests(TestCase):
             "010101 # Everything in 1.1.1",
             "~010101000BBABA0 # Langdales_Cinnamon Tab",
             "~0302000N0%AV # Fluticasone Prop_Inh Soln 500mcg/2ml Ud (brands and generic)",
+            "# #GlucoRx Smart Glucose testing strips (GlucoRx Ltd) WAITING FOR BNF CODE",
         ]
 
         expected_sql = """


### PR DESCRIPTION
Sometimes it's useful to leave placeholders in the list. Previously these would blow up with an error.