### PR TITLE
Fix nginx config to work with newer versions

### DIFF
--- a/contrib/nginx/openprescribing.conf
+++ b/contrib/nginx/openprescribing.conf
@@ -15,10 +15,9 @@ upstream hello_app_server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name deploy.openprescribing.net;
 
-    ssl on;
     ssl_certificate     /etc/nginx/certificates/cloudflare.pem;
     ssl_certificate_key /etc/nginx/certificates/cloudflare.key;
 


### PR DESCRIPTION
The `ssl` directive has been removed and replaced with an `ssl` argument to the `listen` directive.