### PR TITLE
Fix measure SQL

### DIFF
--- a/openprescribing/measures/views/vw__inhaler_quantity_adjustment.sql
+++ b/openprescribing/measures/views/vw__inhaler_quantity_adjustment.sql
@@ -11,11 +11,11 @@ END
 FROM
   hscic.normalised_prescribing AS rx
 INNER JOIN
-  dmd.vmpp_full AS vmpp
+  {project}.dmd.vmpp_full AS vmpp
 ON
   CONCAT( SUBSTR(rx.bnf_code, 0, 9), 'AA', SUBSTR(rx.bnf_code,-2, 2) ) = CONCAT( SUBSTR(vmpp.bnf_code, 0, 11), SUBSTR(vmpp.bnf_code,-2, 2) )
 INNER JOIN
-  measures.vw__dmd_objs_with_form_route AS form
+  {project}.measures.vw__dmd_objs_with_form_route AS form
 ON
   form.vpid = vmpp.vmp
 WHERE

--- a/openprescribing/measures/views/vw__presentation_ingredient_count.sql
+++ b/openprescribing/measures/views/vw__presentation_ingredient_count.sql
@@ -4,13 +4,13 @@ SELECT
   presentation_code as bnf_code,
   COUNT(ing) AS ing_count
 FROM
-  dmd.vpi AS vpi
+  {project}.dmd.vpi AS vpi
 INNER JOIN
-  dmd.vmp AS v
+  {project}.dmd.vmp AS v
 ON
   v.id = vpi.vmp
 INNER JOIN
-  hscic.bnf AS bnf
+  {project}.hscic.bnf AS bnf
 ON
   CONCAT(SUBSTR(bnf.presentation_code, 0, 9),'AA',SUBSTR(bnf.presentation_code,-2, 2)) = CONCAT(SUBSTR(v.bnf_code, 0, 11),SUBSTR(v.bnf_code,-2, 2))
 GROUP BY


### PR DESCRIPTION
For measure views, the SQL needs to identify the Google Cloud Platform project.  The import pipeline replaces `{project}` with the correct value.