### PR TITLE
Don't upload full EPD CSV file

### DIFF
--- a/openprescribing/pipeline/runner.py
+++ b/openprescribing/pipeline/runner.py
@@ -353,6 +353,8 @@ def upload_task_input_files(task):
     bucket = storage_client.get_bucket()
 
     for path in task.input_paths():
+        if re.match("epd_\d{6}_full.csv", path):
+            continue
         assert path[0] == "/"
         assert settings.PIPELINE_DATA_BASEDIR[-1] == "/"
         name = "hscic" + path.replace(settings.PIPELINE_DATA_BASEDIR, "/")


### PR DESCRIPTION
It has an extra column, which means that we cannot build raw_prescribing_v2, since this is backed by all CSV files in the prescribing_v2 directory.