### PR TITLE
New measure  opioidper1000over120

### DIFF
--- a/openprescribing/common/measure_tags.json
+++ b/openprescribing/common/measure_tags.json
@@ -97,6 +97,10 @@
     "name": "Respiratory",
     "description": "These measures are for treatments commonly used for treating respiratory conditions such as asthma and COPD."
   },
+  "retired": {
+    "name": "Retired measures",
+    "description": "These measures are no longer current, and have been retired from OpenPrescribing."
+  },
   "safety": {
     "name": "Safety",
     "description": "Improving safety is about reducing risk and minimising mistakes. The World Health Organisation has launched its third patient safety challenge Medication Without Harm. Changes in the following measures may result in reduction of the risk of harm to patients and contribute to WHOs ambition in reducting medication related harm by 50% within 5 years."

--- a/openprescribing/measures/definitions/opioidper1000_120plus.json
+++ b/openprescribing/measures/definitions/opioidper1000_120plus.json
@@ -24,7 +24,7 @@
     "NHS England National Medicines Optimisation Opportunities for 2024/25</a> identify reducing opioid use in chronic non-cancer pain as an area for improvement.</p>"
   ],
   "tags": [
-
+    "retired"
   ],
   "url": null,
   "is_percentage": false,


### PR DESCRIPTION
Temporarily reinstate opioidsper1000 in 120mg + format to support ongoing work in some ICBs.
Measure to be removed end of May 2026.