### PR TITLE
Fix typos in Drug Tariff filename

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_drug_tariff.py
@@ -57,6 +57,11 @@ class Command(BaseCommand):
                 # reported to us via Slack, so if we pull out some nonsense here we
                 # *should* notice.
                 year = re.match(r"\d+", year).group()
+
+                # Fix typo
+                if year == "20251":
+                    year = "2025"
+
                 if len(year) == 2:
                     year = "20" + year
 
@@ -69,6 +74,13 @@ class Command(BaseCommand):
                 continue
 
             csv_url = urljoin(url, a.attrs["href"])
+
+            # Fix broken link
+            csv_url = csv_url.replace(
+                "Part%20VIIIA%20December%2020251.xls_0.csv",
+                "Part%20VIIIA%20December%2020251.xls.csv",
+            )
+
             csv_data = requests.get(csv_url).text
             rows = csv.reader(StringIO(csv_data))
 


### PR DESCRIPTION
The December 2025 file is named:

    Part VIIIA December 20251.xls_0.csv

This has a stray "1" on the end of the year which breaks our date parser. Additionally the link itself is broken: the correct suffix should be ".xls.csv".