### PR TITLE
Add a 4m timeout to refresh_news_feed_cache

### DIFF
--- a/deploy/refresh_news_feed_cache.sh
+++ b/deploy/refresh_news_feed_cache.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 . /webapps/openprescribing/.venv/bin/activate
-python /webapps/openprescribing/openprescribing/manage.py refresh_news_feed_cache
+# This was recently observed failing & running for 11 days.
+# Our cronjob currently re-runs it every 5mins, and it's safe to kill it,
+# so let's add `timeout` as an insurance policy.
+timeout 4m python /webapps/openprescribing/openprescribing/manage.py refresh_news_feed_cache


### PR DESCRIPTION
* typically takes only a couple of seconds to run
* recently failed in an unknown way, in which it was using 100% cpu for 11 days