### PR TITLE
Update icsdose.json - Fix for high dose corticosteroid inhaler measure

### DIFF
--- a/openprescribing/measures/definitions/icsdose.json
+++ b/openprescribing/measures/definitions/icsdose.json
@@ -67,9 +67,9 @@
   "AND descr IN ('pressurizedinhalation.inhalation','powderinhalation.inhalation')"
   ],
   "authored_by": "christopher.wood@phc.ox.ac.uk",
-  "checked_by": "",
+  "checked_by": "richard.croker@phc.ox.ac.uk",
   "date_reviewed": "2026-02-09",
-  "next_review": "2026-02-09",
+  "next_review": "2027-02-09",
   "measure_complexity": "high",
   "measure_type": "custom",
   "radar_exclude": false,
@@ -90,7 +90,7 @@
       "date": "2026-02-09",
       "description": "Fix to capture products with BNF code changes.",
       "action_by": "christopher.wood@phc.ox.ac.uk",
-      "checked_by": ""
+      "checked_by": "richard.croker@phc.ox.ac.uk"
     }
   ]
 }


### PR DESCRIPTION
Changed from BNF codes to VTM codes for beclometasone combo products (these need to be separate to account for extrafine nature.