### PR TITLE
Add link to v2 from Analyse page

### DIFF
--- a/openprescribing/templates/analyse.html
+++ b/openprescribing/templates/analyse.html
@@ -16,6 +16,11 @@
 
 <h1>Search GP prescribing data</h1>
 
+<div class="alert alert-warning">
+  We're working on a beta version of a new OpenPrescribing.
+  Visit <a href="https://beta.openprescribing.net/">https://beta.openprescribing.net/</a> to find out more.
+</div>
+
 <p>Search 700 million rows of prescribing data, and get prescribing information by practice, PCN, Sub-ICB Location, ICB or regional team. You can search for any numerator over any denominator.</p>
 
 <p>Unsure how to create your own searches? <a target="_blank" href="{% url 'analyse' %}#numIds=0212000AA&denomIds=2.12">Try an example</a>, <a target="_blank" href="http://openprescribing.net/docs/analyse">read more</a> about how to use this tool, check our <a target="_blank" href="{% url 'faq' %}">FAQs</a> and read our <a href='https://www.bennett.ox.ac.uk/blog/2017/04/prescribing-data-bnf-codes/'> what is a BNF code blog</a>.</p>


### PR DESCRIPTION
The new v2 functionality replicates much of what the v1 Analyse page does, and we'd like to get people looking at it as soon as possible.

<img width="991" height="237" alt="image" src="https://github.com/user-attachments/assets/3598f48e-e910-476b-b9b4-98e5615913c6" />

Addresses #5428.  Copy agreed [here](https://bennettoxford.slack.com/archives/C0A7P1N0B41/p1772194264120629).