### PR TITLE
Disable Gunicorn control socket

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -68,7 +68,8 @@ cmd="gunicorn openprescribing.wsgi:application \
   --log-level=$GUNICORN_LOG_LEVEL \
   --log-file=$LOGFILE \
   --access-logfile=$ACCESS_LOGFILE \
-  --limit-request-line=8190"
+  --limit-request-line=8190 \
+  --no-control-socket"
 
 if [[ ! -z $CHECK_CONFIG ]]; then
     cmd="$cmd --check-config"


### PR DESCRIPTION
* this does not have correct file permissions in deployment
* it therefore does not work, and is therefore not used
* but it does put lots of error messages in the logs