### PR TITLE
Update manually_added_concessions.csv

### DIFF
--- a/openprescribing/pipeline/management/commands/supplementary_files/fetch_and_import_ncso_concessions/manually_added_concessions.csv
+++ b/openprescribing/pipeline/management/commands/supplementary_files/fetch_and_import_ncso_concessions/manually_added_concessions.csv
@@ -15,3 +15,4 @@ Date,Name,Pack Size,Price Pence,Notes,URL (if applicable)
 2026-02-01,Trimethoprim 100mg tablets,28,407,,https://cpe.org.uk/our-news/february-2026-price-concessions-final-update/
 2026-05-01,Indometacin 25mg capsules,28,1120,,https://cpe.org.uk/our-news/improved-prices-for-indometacin-25mg-capsules-sumatriptan-50mg-tablets-for-may-2026/
 2026-05-01,Sumatriptan 50mg tablets,28,626,,https://cpe.org.uk/our-news/improved-prices-for-indometacin-25mg-capsules-sumatriptan-50mg-tablets-for-may-2026/
+2026-06-01,Ezetimibe 10mg tablets,28,900,,https://cpe.org.uk/our-news/improved-prices-for-ezetimibe-10mg-tablets-for-june-2026/


### PR DESCRIPTION
Added June 26 price concession update for ezetimibe
https://cpe.org.uk/our-news/improved-prices-for-ezetimibe-10mg-tablets-for-june-2026/