### PR TITLE
Exclude closed ICBs

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -303,7 +303,7 @@ def ccg_home_page(request, ccg_code):
 
 
 def all_stps(request):
-    stps = STP.objects.order_by("name")
+    stps = STP.objects.exclude(pct=None).order_by("name")
     context = {"stps": stps}
     return render(request, "all_stps.html", context)
 


### PR DESCRIPTION
We don't capture whether an ICB is open or not when we ingest the ODS data (although we could), so we exclude ICBs that have no linked SICBLs.

(ICBs were called STPs; SICBLs were called CCGs which were called PCTs.)