### PR TITLE
Fix test_header_and_query_string_json_negotiation

### DIFF
--- a/openprescribing/frontend/tests/test_api_bnf_codes.py
+++ b/openprescribing/frontend/tests/test_api_bnf_codes.py
@@ -30,11 +30,11 @@ class TestAPIBNFCodeViews(ApiTestBase):
 
         url = "%s/bnf_code?q=lor" % self.api_prefix
         response = self.client.get(url, follow=True)
-        self.assertNotJson(response.content)
+        self.assertJson(response.content)
 
         url = "%s/bnf_code?q=lor" % self.api_prefix
         response = self.client.get(url, {}, follow=True, HTTP_ACCEPT="application/json")
-        self.assertNotJson(response.content)
+        self.assertJson(response.content)
 
     def test_api_view_bnf_chemical(self):
         url = "%s/bnf_code?q=lor&format=json" % self.api_prefix


### PR DESCRIPTION
We removed BrowsableAPIRenderer in 3cfa442 and 5cbd88 (it had been around since 2aab031b, the initial commit). We didn't, however, update this test.

When we had a browsable API, we expected these responses to be HTML (i.e. not JSON). Now we don't have a browsable API, we expect these responses to be JSON.