### PR TITLE
Add TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,74 @@
+# Testing
+
+There are two types of test: functional and non-functional.
+
+## Functional tests
+
+The functional tests use Selenium to make requests to a [Django live server][].
+They can be run locally (the host system) or in a container (the guest system),
+with or without BrowserStackLocal (see below).
+Let's consider the four cases.
+Functional tests can be run:
+
+* locally with BrowserStackLocal: `BROWSER='...' just test-browserstack-functional`
+* in a container with BrowserStackLocal: `BROWSER='...' just test-docker-browserstack-functional`
+* locally without BrowserStackLocal: `just test-functional`
+* in a container without BrowserStackLocal: `just test-docker-functional`
+
+Where `BROWSER` is of the form `<browser name>:<browser version>:<OS name>:<OS version>`.
+For example:
+
+* `'Edge:latest:Windows:10'`
+* `'Firefox:latest:OS X:Catalina'`
+
+See the "[Select browsers and devices][]" page in the BrowserStack documentation for values.
+See `.github/workflows/main.yml` of values used in CI.
+
+Of these, the "in a container with BrowserStackLocal" case is how functional tests are run in CI.
+
+### BrowserStackLocal
+
+[BrowserStackLocal][] is BrowserStack's local agent.
+It sits between a Django live server and BrowserStackCloud.
+
+### Django live server and `0.0.0.0`
+
+The functional tests use `SeleniumTestCase`, which inherits from `LiveServerTestCase`.
+`LiveServerTestCase` starts a [Django live server][] on setup and stops it on teardown.
+`LiveServerTestCase.host` is used as a server bind address *and* as a client destination address.
+By default, `LiveServerTestCase.host` is `localhost`.
+However, `SeleniumTestCase.host` is `0.0.0.0`.
+
+When used as a server bind address, `0.0.0.0` means "all local interfaces".
+When used as a client destination address, `0.0.0.0` is invalid.
+However, it's important to know that:
+
+* on some systems, requests to connect to `0.0.0.0` are treated as requests to connect to `localhost`,
+  if a server is bound on the system.
+* BrowserStackLocal seems to do the same.
+* a server should bind to `0.0.0.0` in a container,
+  such that it can be easily reached from the host system.
+
+Let's consider the four cases again.
+Functional tests can be run:
+
+* locally with BrowserStackLocal.
+  Either the system or BrowserStackLocal maps `0.0.0.0` to `localhost`.
+  A connection is established.
+* in a container with BrowserStackLocal.
+  As above.
+  A connection is established.
+* locally without BrowserStackLocal.
+  The system may or may not map `0.0.0.0` to `localhost`.
+  A connection may or may not be established.
+* in a container without BrowserStackLocal.
+  As above, remembering that "local" means "local to the container",
+  rather than "local to the host system".
+  A connection may or may not be established.
+
+Relying on either the system or BrowserStackLocal to map `0.0.0.0` to `localhost` is unwise,
+but not doing so means modifying the functional tests.
+
+[BrowserStackLocal]: https://www.browserstack.com/docs/automate/selenium/local-testing-introduction?fw-lang=python
+[Django live server]: https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.LiveServerTestCase
+[Select browsers and devices]: https://www.browserstack.com/docs/automate/selenium/select-browsers-and-devices

--- a/justfile
+++ b/justfile
@@ -54,6 +54,12 @@ _BROWSER:
 test-browserstack-functional *args: _BROWSER
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional "$@"
 
+test-docker-browserstack-functional: _BROWSER
+    # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
+    # used to determine whether the functional tests are run with the BrowserStack local
+    # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).
+    GITHUB_ACTIONS=1 {{ just_executable() }} test-docker-functional
+
 test-docker:
     #!/usr/bin/env bash
     set -euxo pipefail

--- a/justfile
+++ b/justfile
@@ -31,6 +31,17 @@ test *args: db
     SKIP_NPM_BUILD=1 uv run coverage run manage.py test "$@"
 
 test-functional *args:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
+    check_status() {
+        if [[ $? -ne 0 ]]; then
+            echo 'See TESTING.md for information about why this recipe might have failed.'
+        fi
+    }
+    # Run check_status, even though we set -e (if a command fails, then exit Bash).
+    trap 'check_status' EXIT INT TERM
+
     TEST_SUITE=functional {{ just_executable() }} test "$@"
 
 test-nonfunctional *args:

--- a/justfile
+++ b/justfile
@@ -65,10 +65,10 @@ _BROWSER:
         exit 1
     fi
 
-test-browserstack-functional *args: _BROWSER
+test-browserstack-functional *args: _BROWSER start-browserstacklocal && stop-browserstacklocal
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional "$@"
 
-test-docker-browserstack-functional: _BROWSER
+test-docker-browserstack-functional: _BROWSER start-browserstacklocal && stop-browserstacklocal
     # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
     # used to determine whether the functional tests are run with the BrowserStack local
     # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).

--- a/justfile
+++ b/justfile
@@ -50,6 +50,9 @@ test-nonfunctional *args:
 start-browserstacklocal:
     BrowserStackLocal --daemon start --key "$BROWSERSTACK_ACCESS_KEY" --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
+stop-browserstacklocal:
+    BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
+
 _BROWSER:
     #!/usr/bin/env bash
     set -euxo pipefail

--- a/justfile
+++ b/justfile
@@ -48,7 +48,10 @@ test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
 
 start-browserstacklocal:
-    BrowserStackLocal --daemon start --key "$BROWSERSTACK_ACCESS_KEY" --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
+    BrowserStackLocal \
+    --daemon start \
+    --key "$BROWSERSTACK_ACCESS_KEY" \
+    --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
 stop-browserstacklocal:
     BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"

--- a/justfile
+++ b/justfile
@@ -48,8 +48,12 @@ test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
 
 start-browserstacklocal:
+    # The force flag kills other instances of the BrowserStackLocal daemon with the same
+    # local-identifier. At most, one instance should exist if a previous BrowserStack
+    # recipe failed.
     BrowserStackLocal \
     --daemon start \
+    --force
     --key "$BROWSERSTACK_ACCESS_KEY" \
     --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
 
 start-browserstacklocal:
-    BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY" --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
+    BrowserStackLocal --daemon start --key "$BROWSERSTACK_ACCESS_KEY" --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
 _BROWSER:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ test-nonfunctional *args:
 start-browserstacklocal:
     BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY" --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
-test-browserstack-functional *args:
+_BROWSER:
     #!/usr/bin/env bash
     set -euxo pipefail
 
@@ -51,6 +51,7 @@ test-browserstack-functional *args:
         exit 1
     fi
 
+test-browserstack-functional *args: _BROWSER
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional "$@"
 
 test-docker:


### PR DESCRIPTION
This adds TESTING.md that gives an up-to-date description of how to run the functional tests. It also updates justfile, tidying away the mechanism for starting and stopping BrowserStackLocal as well as adding a warning message when we expect the functional tests to error.

This isn't everything there is to say about testing, and it deliberately doesn't modify README or DEVELOPERS. Think of TESTING.md as a companion to justfile.