### PR TITLE
Update geckodriver, and add recipes for building and pushing images

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
 FROM ghcr.io/bennettoxford/openprescribing-py312-base:latest
 
-RUN wget -qO- https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz | tar xvz -C /usr/bin
+RUN wget -qO- https://github.com/mozilla/geckodriver/releases/download/v0.37.1/geckodriver-v0.37.1-linux64.tar.gz | tar xvz -C /usr/bin
 RUN apt-get update && apt-get install -y firefox-esr xvfb

--- a/justfile
+++ b/justfile
@@ -118,3 +118,36 @@ db-clean:
 
 db-shell: db
     docker compose exec {{ db_service }} psql --username user openprescribing-test
+
+# Build the base and test images
+[confirm("This will remove the existing base and test images. Do you wish to continue? (y/n)")]
+build-images:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
+    base_image=ghcr.io/bennettoxford/openprescribing-py312-base:latest
+    test_image=ghcr.io/bennettoxford/openprescribing-py312-test:latest
+
+    # First, remove the existing images, if they exist. We want to be sure that we're
+    # building the new test image on the new base image, and not on the old base image.
+    for image in "$base_image" "$test_image"; do
+        if docker image inspect "$image" >/dev/null 2>&1; then
+            docker image rm "$image"
+        fi
+    done
+
+    # Now, build the images. We use `buildx build` rather than `compose build`, because
+    # the services are missing build configurations. The dot sets the build context to
+    # the current directory.
+
+    # Build the new base image. This corresponds to the test-production service.
+    docker buildx build --file Dockerfile --tag "$base_image" .
+
+    # Build the new test image. This corresponds to the test service.
+    docker buildx build --file Dockerfile-test --tag "$test_image" .
+
+# Push the base and test images to GHCR
+[confirm("This will push the base and test images to GHCR. Do you wish to continue? (y/n)")]
+push-images:
+    docker image push ghcr.io/bennettoxford/openprescribing-py312-base:latest
+    docker image push ghcr.io/bennettoxford/openprescribing-py312-test:latest


### PR DESCRIPTION
The older version of geckodriver isn't compatible with the version of Firefox on the base and test images, which causes the functional tests to fail when run on a container without BrowserStack.