### PR TITLE
Expunge Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ database configuration, you'll need to blow away the volume with:
     docker-compose rm -f all
 
 Any time you change the npm or pip dependencies, you should rebuild
-the docker image used by the tests to improve runtime performance of
-travis.
+the docker image used by the tests.
 
     # Base docker image, for production
     docker build -t ebmdatalab/openprescribing-py3-base .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,8 @@ services:
     env_file: environment-docker
     environment:
       - DJANGO_SETTINGS_MODULE=openprescribing.settings.test
-      - TRAVIS=${TRAVIS}
       - BROWSER=${BROWSER}
       - TEST_SUITE=${TEST_SUITE}
-      - TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
-      - TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
-      - TRAVIS_BRANCH=${TRAVIS_BRANCH}
-      - TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
-      - TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
       - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN}
       - COVERALLS_PARALLEL=true
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
@@ -50,14 +44,8 @@ services:
     command: /bin/bash -c './scripts/docker_setup.sh production && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
     env_file: environment-docker
     environment:
-      - TRAVIS=${TRAVIS}
       - TEST_SUITE=${TEST_SUITE}
       - BROWSER=${BROWSER}
-      - TRAVIS_JOB_NUMBER=${TRAVIS_JOB_NUMBER}
-      - TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
-      - TRAVIS_BRANCH=${TRAVIS_BRANCH}
-      - TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
-      - TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
       - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN}
       - COVERALLS_PARALLEL=true
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json

--- a/openprescribing/frontend/tests/commands/test_geocode_practices.py
+++ b/openprescribing/frontend/tests/commands/test_geocode_practices.py
@@ -1,6 +1,3 @@
-import os
-import unittest
-
 from django.core.management import call_command
 from django.test import TestCase
 from frontend.models import Practice
@@ -32,10 +29,6 @@ def tearDownModule():
 
 
 class CommandsTestCase(TestCase):
-    @unittest.skipIf(
-        "TRAVIS" in os.environ and os.environ["TRAVIS"],
-        "Skipping this test on Travis CI.",
-    )
     def test_import_practice_geocoding(self):
         args = []
         opts = {"filename": "frontend/tests/fixtures/commands/gridall.csv"}

--- a/openprescribing/frontend/tests/test_api_org_location.py
+++ b/openprescribing/frontend/tests/test_api_org_location.py
@@ -1,7 +1,5 @@
 import datetime
 import json
-import os
-import unittest
 
 from django.test import TestCase
 from frontend.models import PCT
@@ -41,10 +39,6 @@ class TestAPIOrgLocationViews(TestCase):
         self.assertAlmostEqual(coord[0], -117.00000000000003)
         self.assertAlmostEqual(coord[1], 33.97943076318428)
 
-    @unittest.skipIf(
-        "TRAVIS" in os.environ and os.environ["TRAVIS"],
-        "Skipping this test on Travis CI.",
-    )
     def test_api_view_org_location_practice_by_code(self):
         url = "%s/org_location?org_type=practice&q=03Q&format=json" % self.api_prefix
         response = self.client.get(url, follow=True)


### PR DESCRIPTION
We no longer use Travis, so it's just a little bit confusing and just a little bit untidy to have Travis-related environment variables and logic in the codebase. More importantly, because the Travis-related environment variables are referenced by docker-compose.yml, a call to `docker compose` for any service will emit a warning for each missing environment variable. These warnings can obscure more important information and can lead to warning fatigue.